### PR TITLE
Minor changes to memcached_status.py

### DIFF
--- a/memcached_status.py
+++ b/memcached_status.py
@@ -7,6 +7,7 @@ import telnetlib
 
 
 ITEM_COUNT = re.compile('STAT items:\d+:number (\d+)')
+MEMCACHED_CONF = '/etc/memcached.conf'
 
 
 def item_stats(host, port):
@@ -43,17 +44,17 @@ def main():
     bind_ip = '127.0.0.1'
     port = 11211
 
-    if os.path.exists('/etc/memcached.conf'):
-      conf = open('/etc/memcached.conf')
-      for line in conf:
-        line_arr = line.split()
+    if os.path.exists(MEMCACHED_CONF):
+        conf = open(MEMCACHED_CONF)
+        for line in conf:
+            line_arr = line.split()
 
-        if len(line_arr) > 1:
-          if line_arr[0] == "-l":
-            bind_ip = line_arr[1]
-          elif line_arr[0] == "-p":
-            port = line_arr[1]
-      conf.close()
+            if len(line_arr) > 1:
+                if line_arr[0] == "-l":
+                    bind_ip = line_arr[1]
+                elif line_arr[0] == "-p":
+                    port = line_arr[1]
+        conf.close()
 
     results = item_stats(bind_ip, port)
 


### PR DESCRIPTION
Our memcached containers bind to a non-localhost IP.  This change
checks /etc/memcached.conf to find bind IP and port and connects to
those instead.  We also check for existence of memcached binary
rather than init script as this service may move to upstart/systemd
instead.
