### PR TITLE
Fix proc_check

### DIFF
--- a/proc_check.py
+++ b/proc_check.py
@@ -5,26 +5,25 @@ import os
 import psutil
 import sys
 
+from maas_common import metric, status_err, status_ok
 
-def err(reason):
-    print 'status err', reason
-    sys.exit(1)
 
 procnames = sys.argv[1:]
 if not procnames:
-    err('script takes between 1 and 10 arguments, each being '
-        ' a process name to check for')
-    sys.exit(1)
+    status_err('script takes between 1 and 10 arguments, each being'
+               ' a process name to check for')
 # single monitor can only report up to 10 metrics
 if len(procnames) > 10:
-    err('script takes at most 10 process names to check for')
+    status_err('script takes at most 10 process names to check for')
 
 results = collections.Counter(**{proc: 0 for proc in procnames})
 for to_match in procnames:
     for proc in psutil.process_iter():
-        if to_match in str(proc.cmdline) and proc.pid != os.getpid():
+        if not proc.cmdline():
+            continue
+        if to_match in proc.cmdline()[0] and proc.pid != os.getpid():
             results.update((to_match, ))
 
-print 'status OK'
+status_ok()
 for proc, count in results.viewitems():
-    print 'metric num_running_processes_%s uint32 %d' % (proc, count)
+    metric('num_running_processes_%s' % proc, 'uint32', count)


### PR DESCRIPTION
proc.cmdline is function so must be called.

Added in helper functions for status and metric
