### PR TITLE
Minor changes

### DIFF
--- a/glance_api_global_check.py
+++ b/glance_api_global_check.py
@@ -33,7 +33,7 @@ def check(auth_ref):
             if i.status == "killed":
                 killed += 1
     except Exception as e:
-        status_err(e)
+        status_err(str(e))
 
     status_ok()
     metric('glance_active_images', 'uint32', active)

--- a/maas_common.py
+++ b/maas_common.py
@@ -58,7 +58,7 @@ else:
                                        password=auth_details['OS_PASSWORD'],
                                        tenant_name=tenant_name,
                                        auth_url=auth_details['OS_AUTH_URL'])
-        except (k_exc.Unauthorized, k_exc.AuthorizationFailure) as e:
+        except Exception as e:
             status_err(str(e))
 
         try:
@@ -80,7 +80,9 @@ else:
             keystone = k_client.Client(auth_ref=auth_ref, endpoint=endpoint)
 
         try:
-            keystone.authenticate()
+            # This should be a rather light-weight call that validates we're
+            # actually connected/authenticated.
+            keystone.services.list()
         except (k_exc.AuthorizationFailure, k_exc.Unauthorized):
             # Force an update of auth_ref
             auth_details = get_auth_details()
@@ -88,6 +90,8 @@ else:
             keystone = get_keystone_client(auth_ref,
                                            previous_tries + 1,
                                            endpoint)
+        except Exception as e:
+            status_err(str(e))
 
         return keystone
 


### PR DESCRIPTION
- send str(e) in glance_api_global_check.py
- change keystone.authenticate() call to keystone.services.list() as
  the former appeared to speak to auth_url rather than endpoint_url
- trap all keystoneclient exceptions in keystone_auth() rather than just
  the auth ones
- trap all unhandled exceptions in get_keystone_client() to handle
  situations where attempting to connect to a endpoint_url that's down,
  etc.
