### PR TITLE
[WIP] Make a direct call to glance-api using requests

### DIFF
--- a/glance_api_local_check.py
+++ b/glance_api_local_check.py
@@ -1,20 +1,27 @@
 #!/usr/bin/env python
 
 from maas_common import (status_ok, status_err, metric, metric_bool,
-                         get_auth_ref)
+                         get_keystone_client, get_auth_ref)
 from requests import Session
 from requests import exceptions as exc
 
 
 def check(auth_ref):
+    # We call get_keystone_client here as there is some logic within to get a
+    # new token if previous one is bad.
+    keystone = get_keystone_client(auth_ref)
+    tenant_id = keystone.tenant_id
+    auth_token = keystone.auth_token
     api_endpoint = 'http://127.0.0.1:9292/v2'
+
     api_status = 1
     milliseconds = 0
+
     s = Session()
 
     s.headers.update(
         {'Content-type': 'application/json',
-         'x-auth-token': auth_ref['token']['id']})
+         'x-auth-token': auth_token})
 
     try:
         # Hit something that isn't querying the glance-registry, since we


### PR DESCRIPTION
This change makes this check no longer use the glanceclient tool so
we can craft a request that doesn't hit the glance-registry.  The
reason for this is that the glance-registry itself is tested in a
different check and therefore we just need to ensure the glance-api
itself is responding.
