### PR TITLE
Helper function for boolean metrics so success is always 1.

### DIFF
--- a/maas_common.py
+++ b/maas_common.py
@@ -239,3 +239,8 @@ def metric(name, metric_type, value, unit=None):
     if unit is not None:
         metric_line = ' '.join((metric_line, unit))
     print metric_line
+
+
+def metric_bool(name, success):
+    value = success and 1 or 0
+    metric(name, 'uint32', value)


### PR DESCRIPTION
There is no boolean metric type listed in the docs. This helper function is to enforce consistency when reporting a boolean. Not sure if this is actually useful though - discuss.
