### PR TITLE
API status metric helper function

### DIFF
--- a/maas_common.py
+++ b/maas_common.py
@@ -374,3 +374,9 @@ def metric(name, metric_type, value, unit=None):
 def metric_bool(name, success):
     value = success and 1 or 0
     metric(name, 'uint32', value)
+
+
+def metric_api_status(name, status):
+    metric_bool(name, status)
+    if not status:
+        sys.exit(0)


### PR DESCRIPTION
Pro's - helps ensure no other metrics returned if api is down.
Con's - assumes script is specific to api and no other metrics will need to be returned when down.

Not sure if this is a helper function too far - thoughts?
