### PR TITLE
Prevent creation of legacy_state metrics

### DIFF
--- a/maas_common.py
+++ b/maas_common.py
@@ -358,7 +358,7 @@ def force_reauth():
 
 def status(status, message):
     if status in ('ok', 'warn', 'err'):
-        raise Exception('The status "%s" is not allowed because it creates a '
+        raise ValueError('The status "%s" is not allowed because it creates a '
                         'metric called legacy_state' % status)
     status_line = 'status %s' % status
     if message is not None:


### PR DESCRIPTION
These legacy_state metrics are for compatibility with cloud kick and
should not be used - "https://github.com/virgo-agent-toolkit/rackspace-m
onitoring-agent/blob/master/check/base.lua#L336-343"

The status helper functions have been modified to guard against this
behaviour.
