### PR TITLE
vgs doesn't like additional file descriptors

### DIFF
--- a/cinder_lvm_check.py
+++ b/cinder_lvm_check.py
@@ -12,7 +12,8 @@ def get_volume_group_info(vg_name):
                                        '--nosuffix', '--units', 'g', '-o',
                                        'size,free,lv_count', '--separator', ':',
                                        vg_name],
-                                      stderr=subprocess.STDOUT)
+                                      stderr=subprocess.STDOUT,
+                                      close_fds=True)
     except subprocess.CalledProcessError:
         return None
 
@@ -23,6 +24,8 @@ def get_volume_group_info(vg_name):
             vg_info = {'size': float(fields[0]),
                        'free': float(fields[1]),
                        'count': int(fields[2])}
+        else:
+            status_err(out)
 
     return vg_info
 

--- a/maas_common.py
+++ b/maas_common.py
@@ -363,6 +363,7 @@ def status(status, message):
     status_line = 'status %s' % status
     if message is not None:
         status_line = ' '.join((status_line, str(message)))
+    status_line = status_line.replace('\n', '\\n')
     print status_line
 
 


### PR DESCRIPTION
maas gets the following error if fds >2 are open with vgs.
File descriptor 9 (/var/log/rackspace-monitoring-agent.log) leaked on
vgs invocation. Parent PID 18103: python\n 20.00:19.00:1

maas doesn't like new lines in the status string so lets escape them.
