### PR TITLE
Tap check fix

### DIFF
--- a/tap_dhcp.py
+++ b/tap_dhcp.py
@@ -40,7 +40,6 @@ def main():
     # We should alarm on the following condition, i.e., if it isn't 0.
     metric('namespaces_with_more_than_one_tap', 'int32', number_of_namespaces)
     if number_of_namespaces > 0:
-        status_err('a namespace had an unexpected number of TAPs present')
         for (name, number) in too_many_taps:
             metric(name, 'uint32', number)
 


### PR DESCRIPTION
Previously we were reporting the metrics incorrectly and misusing `status okay`/`status error`

I'm also wondering if we should use a boolean metric to alarm on or if the way it is now written will be sufficient. 

Another question: is it worth reporting the specific namespaces as metrics with how many TAPs they have?
