### PR TITLE
Re-factor the rabbit check to accept config options

### DIFF
--- a/rabbitmq_status.py
+++ b/rabbitmq_status.py
@@ -55,7 +55,8 @@ def parse_args():
                       help='Password to use for authentication')
     parser.add_option('-n', '--name', action='store', dest='name',
                       default=None,
-                      help='Hostname to check for cluster membership')
+                      help=("Check a node's cluster membership using the "
+                            'provided name'))
     return parser.parse_args()
 
 


### PR DESCRIPTION
If we're going to monitor rabbit from outside the container, we'll need some
of these options to construct the proper URL. While we're fixing this, might
as well allow for specification of the username and password as well.
