### PR TITLE
ensure True/False metrics are returned as 1 or 0

### DIFF
--- a/rabbitmq_status.py
+++ b/rabbitmq_status.py
@@ -73,7 +73,6 @@ def main():
 
     if r.ok:
         resp_json = r.json()  # Parse the JSON once
-        print resp_json
         for k in OVERVIEW_METRICS:
             if k in resp_json:
                 for i in OVERVIEW_METRICS[k]:


### PR DESCRIPTION
This allows consistency with all the API alarms - 1 means 'do not alarm', 0 means 'alarm now please'
