### PR TITLE
Expect openrc to exist as /root/openrc-maas

### DIFF
--- a/maas_common.py
+++ b/maas_common.py
@@ -12,7 +12,7 @@ AUTH_DETAILS = {'OS_USERNAME': None,
                 'OS_TENANT_NAME': None,
                 'OS_AUTH_URL': None}
 
-OPENRC = '/root/openrc'
+OPENRC = '/root/openrc-maas'
 TOKEN_FILE = '/root/.auth_ref.json'
 
 


### PR DESCRIPTION
Since we now create a separate maas keystone user, it makes sense to use a different non-standard openrc file name to reflect this.
