### PR TITLE
Fix the openmanage.py script status reports

### DIFF
--- a/openmanage.py
+++ b/openmanage.py
@@ -39,7 +39,7 @@ def main():
         status_err(str(e))
 
     status_ok()
-    metric_bool('%s_okay' % report_type, all_okay(report, regex[report_type]))
+    metric_bool('hardware_%s_status' % report_request, all_okay(report, regex[report_type]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- The previous statuses overlapped and were ambiguous
- Adjust to "Hardware_x_status"
- Can be vdisk, processors, memory
