### PR TITLE
Update cinder_api_local_check.py

### DIFF
--- a/cinder_api_local_check.py
+++ b/cinder_api_local_check.py
@@ -54,7 +54,9 @@ def check(auth_ref, args):
     except (exc.ConnectionError,
             exc.HTTPError,
             exc.Timeout) as e:
-        status_err(str(e))
+        is_up = False
+    except Exception as e:
+           status_err(str(e))
     else:
         # gather some metrics
         vol_statuses = [v['status'] for v in vol.json()['volumes']]


### PR DESCRIPTION
This minor change doesn't throw a plugin error if the cinder API is
down, but rather continues on and returns a status metric of 0.  This
is more in line w/ the other plugins.
