### PR TITLE
drop python-glanceclient back to working version (0.13.1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ipaddr==2.1.11
 requests==2.4.3
 lxml==3.4.0
 python-cinderclient==1.1.1
-python-glanceclient==0.14.1
+python-glanceclient==0.13.1
 python-heatclient==0.2.12
 python-keystoneclient==0.11.1
 python-neutronclient==2.3.9


### PR DESCRIPTION
Once 0.14.3 is released we can bump back up
