### PR TITLE
add units to all numerical metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ IP address of service to test
 
     status okay
     metric nova_api_local_status uint32 1
-    metric nova_api_local_response_time uint32 186.774 ms
-    metric nova_servers_in_state_ACTIVE uint32 2
-    metric nova_servers_in_state_STOPPED uint32 0
-    metric nova_servers_in_state_ERROR uint32 0
+    metric nova_api_local_response_time double 186.774 ms
+    metric nova_instances_in_state_ACTIVE uint32 2 instances
+    metric nova_instances_in_state_STOPPED uint32 0 instances
+    metric nova_instances_in_state_ERROR uint32 0 instances
 
 ***
 #### cinder_api_local_check.py
@@ -53,15 +53,15 @@ IP address of service to test
 
     status okay
     metric cinder_api_local_status uint32 1
-    metric cinder_api_local_response_time uint32 211.968 ms
-    metric total_cinder_volumes uint32 2
-    metric cinder_available_volumes uint32 1
-    metric cinder_in-use_volumes uint32 1
-    metric cinder_error_volumes uint32 0
-    metric total_cinder_snapshots uint32 0
-    metric cinder_available_snaps uint32 0
-    metric cinder_in-use_snaps uint32 0
-    metric cinder_error_snaps uint32 0
+    metric cinder_api_local_response_time double 211.968 ms
+    metric total_cinder_volumes uint32 2 volumes
+    metric cinder_available_volumes uint32 1 volumes
+    metric cinder_in-use_volumes uint32 1 volumes
+    metric cinder_error_volumes uint32 0 volumes
+    metric total_cinder_snapshots uint32 0 snapshots
+    metric cinder_available_snaps uint32 0 snapshots
+    metric cinder_in-use_snaps uint32 0 snapshots
+    metric cinder_error_snaps uint32 0 snapshots
 
 ***
 #### keystone_api_local_check.py
@@ -74,9 +74,9 @@ IP address of service to test
 
     status okay
     metric keystone_api_local_status uint32 1
-    metric keystone_api_local_response_time uint32 67.161 ms
-    metric keystone_user_count uint32 12
-    metric keystone_tenant_count uint32 2
+    metric keystone_api_local_response_time double 67.161 ms
+    metric keystone_user_count uint32 12 users
+    metric keystone_tenant_count uint32 2 tenants
 
 ***
 #### neutron_api_local_check.py
@@ -89,11 +89,11 @@ IP address of service to test
 
     status okay
     metric neutron_api_local_status uint32 1
-    metric neutron_api_local_response_time uint32 188.356 ms
-    metric neutron_networks uint32 1
-    metric neutron_agents uint32 21
-    metric neutron_routers uint32 0
-    metric neutron_subnets uint32 1
+    metric neutron_api_local_response_time double 188.356 ms
+    metric neutron_networks uint32 1 networks
+    metric neutron_agents uint32 21 agents
+    metric neutron_routers uint32 0 routers
+    metric neutron_subnets uint32 1 subnets
 
 ***
 #### glance_api_local_check.py
@@ -107,10 +107,10 @@ IP address of service to test
 
     status okay
     metric glance_api_local_status uint32 1
-    metric glance_api_local_response_time uint32 325.883 ms
-    metric glance_active_images uint32 2
-    metric glance_queued_images uint32 0
-    metric glance_killed_images uint32 0
+    metric glance_api_local_response_time double 325.883 ms
+    metric glance_active_images uint32 2 images
+    metric glance_queued_images uint32 0 images
+    metric glance_killed_images uint32 0 images
 
 ***
 #### heat_api_local_check.py
@@ -123,7 +123,7 @@ IP address of service to test
 ##### example output:
 
     metric heat_api_local_status uint32 1
-    metric heat_api_local_response_time uint32 22.752 ms
+    metric heat_api_local_response_time double 22.752 ms
 
 ***
 #### service_api_local_check.py
@@ -141,7 +141,7 @@ Port of service to test
 ##### example output:
 
     metric <name>_api_local_status uint32 1
-    metric <name>_api_local_response_time uint32 6.222 ms
+    metric <name>_api_local_response_time double 6.222 ms
 
 ***
 ***
@@ -207,7 +207,7 @@ IP address of service to test
 ##### example output:
 
     metric glance_registry_local_status uint32 1
-    metric glance_registry_local_response_time uint32 356.917
+    metric glance_registry_local_response_time uint32 356.917 ms
 
 ***
 #### memcached_status.py
@@ -224,10 +224,10 @@ IP address of memcached server
 ##### example output:
 
     metric memcache_api_local_status uint32 1
-    metric memcache_total_items uint64 563324
-    metric memcache_get_hits uint64 4543534
-    metric memcache_get_misses uint64 2346565
-    metric memcache_total_connections uint64 42565
+    metric memcache_total_items uint64 563324 items
+    metric memcache_get_hits uint64 4543534 hits
+    metric memcache_get_misses uint64 2346565 misses
+    metric memcache_total_connections uint64 42565 connections
 
 ***
 #### horizon_check.py
@@ -241,7 +241,7 @@ IP address of service to test
 
     metric splash_status_code uint32 200
     metric splash_milliseconds double 83.557 ms
-    metric login_status_code uint32 200
+    metric login_status_code uint32 200 http_status
     metric login_milliseconds double 1344.399 ms
 
 ***
@@ -258,24 +258,20 @@ connects to an individual member of a rabbit cluster and grabs statistics from t
 
 ##### example output:
 
-    metric disk_free_alarm int64 1
-    metric uptime int64 869767336
-    metric messages int64 0
-    metric ack int64 632168
-    metric deliver_get int64 632168
-    metric deliver int64 632168
-    metric fd_used int64 65
-    metric publish int64 632171
-    metric fd_total int64 1024
-    metric mem_used int64 64421424
-    metric mem_alarm int64 1
-    metric mem_limit int64 12626460672
-    metric sockets_total int64 829
-    metric proc_used int64 710
-    metric sockets_used int64 44
-    metric messages_unacknowledged int64 0
-    metric messages_ready int64 0
-    metric proc_total int64 1048576
+    metric rabbitmq_uptime int64 73439448 ms
+    metric rabbitmq_proc_total int64 1048576 processes
+    metric rabbitmq_proc_used int64 180 processes
+    metric rabbitmq_messages int64 0 messages
+    metric rabbitmq_sockets_total int64 3594 fd
+    metric rabbitmq_fd_used int64 24 fd
+    metric rabbitmq_mem_used int64 41562432 bytes
+    metric rabbitmq_fd_total int64 4096 fd
+    metric rabbitmq_disk_free_alarm_status uint32 1
+    metric rabbitmq_mem_limit int64 3362471936 bytes
+    metric rabbitmq_mem_alarm_status uint32 1
+    metric rabbitmq_sockets_used int64 1 fd
+    metric rabbitmq_messages_unacknowledged int64 0 messages
+    metric rabbitmq_messages_ready int64 0 messages
 
 ***
 #### galera_check.py
@@ -289,12 +285,12 @@ connects to an individual member of a galera cluster and checks various statuses
 
 ##### example output:
 
-    metric WSREP_REPLICATED_BYTES int64 320737952
-    metric WSREP_RECEIVED_BYTES int64 33470
-    metric WSREP_COMMIT_WINDOW double 1.000000
-    metric WSREP_CLUSTER_SIZE int64 1
-    metric QUERIES_PER_SECOND int64 5792715
-    metric WSREP_CLUSTER_STATE_UUID string 67e41d08-165d-11e4-9d87-7e94ef43b302
-    metric WSREP_CLUSTER_STATUS string Primary
-    metric WSREP_LOCAL_STATE_UUID string 67e41d08-165d-11e4-9d87-7e94ef43b302
-    metric WSREP_LOCAL_STATE_COMMENT string Synced
+    metric wsrep_replicated_bytes int64 320737952 bytes
+    metric wsrep_received_bytes int64 33470 bytes
+    metric wsrep_commit_window double 1.000000
+    metric wsrep_cluster_size int64 3 nodes
+    metric queries_per_second int64 5792715 qps
+    metric wsrep_cluster_state_uuid string 67e41d08-165d-11e4-9d87-7e94ef43b302
+    metric wsrep_cluster_status string primary
+    metric wsrep_local_state_uuid string 67e41d08-165d-11e4-9d87-7e94ef43b302
+    metric wsrep_local_state_comment string synced

--- a/cinder_api_local_check.py
+++ b/cinder_api_local_check.py
@@ -75,16 +75,16 @@ def check(auth_ref, args):
                'uint32',
                '%.3f' % milliseconds,
                'ms')
-        metric('total_cinder_volumes', 'uint32', total_vols)
+        metric('total_cinder_volumes', 'uint32', total_vols, 'volumes')
         for status in VOLUME_STATUSES:
             metric('cinder_%s_volumes' % status,
                    'uint32',
-                   vol_status_count[status])
-        metric('total_cinder_snapshots', 'uint32', total_snaps)
+                   vol_status_count[status], 'volumes')
+        metric('total_cinder_snapshots', 'uint32', total_snaps, 'snapshots')
         for status in VOLUME_STATUSES:
             metric('cinder_%s_snaps' % status,
                    'uint32',
-                   snap_status_count[status])
+                   snap_status_count[status], 'snapshots')
 
 
 def main(args):

--- a/galera_check.py
+++ b/galera_check.py
@@ -61,23 +61,23 @@ def parse_args():
 
 def print_metrics(replica_status):
     status_ok()
-    metric('WSREP_REPLICATED_BYTES', 'int64',
-           replica_status['wsrep_replicated_bytes'])
-    metric('WSREP_RECEIVED_BYTES', 'int64',
-           replica_status['wsrep_received_bytes'])
-    metric('WSREP_COMMIT_WINDOW', 'double',
-           replica_status['wsrep_commit_window'])
-    metric('WSREP_CLUSTER_SIZE', 'int64',
-           replica_status['wsrep_cluster_size'])
-    metric('QUERIES_PER_SECOND', 'int64',
-           replica_status['Queries'])
-    metric('WSREP_CLUSTER_STATE_UUID', 'string',
+    metric('wsrep_replicated_bytes', 'int64',
+           replica_status['wsrep_replicated_bytes'], 'bytes')
+    metric('wsrep_received_bytes', 'int64',
+           replica_status['wsrep_received_bytes'], 'bytes')
+    metric('wsrep_commit_window_size', 'double',
+           replica_status['wsrep_commit_window'], 'sequence_delta')
+    metric('wsrep_cluster_size', 'int64',
+           replica_status['wsrep_cluster_size'], 'nodes')
+    metric('queries_per_second', 'int64',
+           replica_status['Queries'], 'qps')
+    metric('wsrep_cluster_state_uuid', 'string',
            replica_status['wsrep_cluster_state_uuid'])
-    metric('WSREP_CLUSTER_STATUS', 'string',
+    metric('wsrep_cluster_status', 'string',
            replica_status['wsrep_cluster_status'])
-    metric('WSREP_LOCAL_STATE_UUID', 'string',
+    metric('wsrep_local_state_uuid', 'string',
            replica_status['wsrep_local_state_uuid'])
-    metric('WSREP_LOCAL_STATE_COMMENT', 'string',
+    metric('wsrep_local_state_comment', 'string',
            replica_status['wsrep_local_state_comment'])
 
 

--- a/glance_api_local_check.py
+++ b/glance_api_local_check.py
@@ -70,7 +70,7 @@ def check(auth_ref, args):
                '%.3f' % milliseconds,
                'ms')
         for status in IMAGE_STATUSES:
-            metric('glance_%s_images' % status, 'uint32', status_count[status])
+            metric('glance_%s_images' % status, 'uint32', status_count[status], 'images')
 
 
 def main(args):

--- a/horizon_check.py
+++ b/horizon_check.py
@@ -90,9 +90,9 @@ def check(args):
     metric_bool('horizon_local_status', is_up)
 
     if is_up:
-        metric('splash_status_code', 'uint32', splash_status_code)
+        metric('splash_status_code', 'uint32', splash_status_code, 'http_code')
         metric('splash_milliseconds', 'double', splash_milliseconds, 'ms')
-        metric('login_status_code', 'uint32', login_status_code)
+        metric('login_status_code', 'uint32', login_status_code, 'http_code')
         metric('login_milliseconds', 'double', login_milliseconds, 'ms')
 
 

--- a/keystone_api_local_check.py
+++ b/keystone_api_local_check.py
@@ -53,8 +53,8 @@ def check(args):
                'uint32',
                '%.3f' % milliseconds,
                'ms')
-        metric('keystone_user_count', 'uint32', user_count)
-        metric('keystone_tenant_count', 'uint32', tenant_count)
+        metric('keystone_user_count', 'uint32', user_count, 'users')
+        metric('keystone_tenant_count', 'uint32', tenant_count, 'tenants')
 
 
 def main(args):

--- a/memcached_status.py
+++ b/memcached_status.py
@@ -24,10 +24,10 @@ from maas_common import status_ok, status_err, metric, metric_bool
 
 VERSION_RE = re.compile('STAT version (\d+\.\d+\.\d+)(?![-+0-9\\.])')
 VERSION = '1.4.14 (Ubuntu)'
-MEMCACHE_METRICS = ['total_items',
-                    'get_hits',
-                    'get_misses',
-                    'total_connections']
+MEMCACHE_METRICS = {'total_items': 'items',
+        'get_hits': 'cache_hits',
+        'get_misses': 'cache_misses',
+        'total_connections': 'connections']
 
 
 def item_stats(host, port):
@@ -64,8 +64,8 @@ def main(args):
     status_ok()
     metric_bool('memcache_api_local_status', is_up)
     if is_up:
-        for m in MEMCACHE_METRICS:
-            metric('memcache_%s' % m, 'uint64', stats[m])
+        for metric, unit in MEMCACHE_METRICS.iteritems():
+            metric('memcache_%s' % metric, 'uint64', stats[metric], unit)
 
 
 if __name__ == '__main__':

--- a/neutron_api_local_check.py
+++ b/neutron_api_local_check.py
@@ -57,10 +57,10 @@ def check(args):
                'uint32',
                '%.3f' % milliseconds,
                'ms')
-        metric('neutron_networks', 'uint32', networks)
-        metric('neutron_agents', 'uint32', agents)
-        metric('neutron_routers', 'uint32', routers)
-        metric('neutron_subnets', 'uint32', subnets)
+        metric('neutron_networks', 'uint32', networks, 'networks')
+        metric('neutron_agents', 'uint32', agents, 'agents')
+        metric('neutron_routers', 'uint32', routers, 'agents')
+        metric('neutron_subnets', 'uint32', subnets, 'subnets')
 
 
 def main(args):

--- a/nova_api_local_check.py
+++ b/nova_api_local_check.py
@@ -58,9 +58,9 @@ def check(args):
                '%.3f' % milliseconds,
                'ms')
         for status in SERVER_STATUSES:
-            metric('nova_servers_in_state_%s' % status,
+            metric('nova_instances_in_state_%s' % status,
                    'uint32',
-                   status_count[status])
+                   status_count[status], 'instances')
 
 
 def main(args):

--- a/rabbitmq_status.py
+++ b/rabbitmq_status.py
@@ -26,25 +26,27 @@ NODES_URL = "http://%s:%s/api/nodes"
 CLUSTERED = True
 CLUSTER_SIZE = 3
 
-OVERVIEW_METRICS = {"queue_totals": ("messages",
-                                     "messages_ready",
-                                     "messages_unacknowledged"),
-                    "message_stats": ("get",
-                                      "ack",
-                                      "deliver_get",
-                                      "deliver",
-                                      "publish")}
-NODES_METRICS = ("proc_used",
-                 "proc_total",
-                 "fd_used",
-                 "fd_total",
-                 "sockets_used",
-                 "sockets_total",
-                 "mem_used",
-                 "mem_limit",
-                 "mem_alarm",
-                 "disk_free_alarm",
-                 "uptime")
+# {metric_category: {metric_name: metric_unit}}
+OVERVIEW_METRICS = {"queue_totals": {"messages": "messages",
+                                     "messages_ready": "messages",
+                                     "messages_unacknowledged": "messages"},
+                    "message_stats": {"get": "messages",
+                                      "ack": "messages",
+                                      "deliver_get": "messages",
+                                      "deliver": "messages",
+                                      "publish": "messages"}}
+# {metric_name: metric_unit}
+NODES_METRICS = {"proc_used": "processes",
+                 "proc_total": "processes",
+                 "fd_used": "fd",
+                 "fd_total": "fd",
+                 "sockets_used": "fd",
+                 "sockets_total": "fd",
+                 "mem_used": "bytes",
+                 "mem_limit": "bytes",
+                 "mem_alarm": "status",
+                 "disk_free_alarm": "status",
+                 "uptime": "ms"}
 
 
 def hostname():
@@ -90,9 +92,9 @@ def main():
         resp_json = r.json()  # Parse the JSON once
         for k in OVERVIEW_METRICS:
             if k in resp_json:
-                for i in OVERVIEW_METRICS[k]:
-                    if i in resp_json[k]:
-                        metrics[i] = resp_json[k][i]
+                for a, b in OVERVIEW_METRICS[k].items():
+                    if a in resp_json[k]:
+                        metrics[a] = {'value': resp_json[k][a], 'unit': b}
     else:
         status_err('Received status {0} from RabbitMQ API'.format(
             r.status_code))
@@ -108,8 +110,8 @@ def main():
     is_cluster_member = False
     if r.ok:
         resp_json = r.json()
-        for i in NODES_METRICS:
-            metrics[i] = resp_json[0][i]
+        for k, v in NODES_METRICS.items():
+            metrics[k] = {'value': resp_json[0][k], 'unit': v}
 
         # Ensure this node is a member of the cluster
         is_cluster_member = any(n['name'].endswith(name) for n in resp_json)
@@ -134,10 +136,10 @@ def main():
     status_ok()
 
     for k, v in metrics.items():
-        if v is True or v is False:
-            metric_bool(k, not v)
+        if v['value'] is True or v['value'] is False:
+            metric_bool('rabbitmq_%s_status' % k, not v['value'])
         else:
-            metric(k, 'int64', v)
+            metric('rabbitmq_%s' % k, 'int64', v['value'], v['unit'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Where a metric is a numerical (non boolean) value, we add a descriptive
unit to be displayed with the metric

Also ensure that all metrics include the name of the service/plugin from
which they are generated.

Finally, ensure that all boolean status metrics include 'status' in
their name

closes: #142
(cherry picked from commit b05d0d1b98171c5594cde735d4921b86bb86d35d)

Conflicts:
	README.md