### PR TITLE
Increase control on data printed

### DIFF
--- a/cinder_api_local_check.py
+++ b/cinder_api_local_check.py
@@ -19,7 +19,7 @@ import collections
 import requests
 from ipaddr import IPv4Address
 from maas_common import (status_ok, status_err, metric, metric_bool,
-                         get_keystone_client, get_auth_ref)
+                         get_keystone_client, get_auth_ref, print_output)
 from requests import exceptions as exc
 
 VOLUME_STATUSES = ['available', 'in-use', 'error']

--- a/cinder_api_local_check.py
+++ b/cinder_api_local_check.py
@@ -92,9 +92,10 @@ def main(args):
     check(auth_ref, args)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check cinder API')
-    parser.add_argument('ip',
-                        type=IPv4Address,
-                        help='cinder API IP address')
-    args = parser.parse_args()
-    main(args)
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check cinder API')
+        parser.add_argument('ip',
+                            type=IPv4Address,
+                            help='cinder API IP address')
+        args = parser.parse_args()
+        main(args)

--- a/cinder_service_check.py
+++ b/cinder_service_check.py
@@ -76,12 +76,13 @@ def main(args):
     check(auth_ref, args)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check cinder services')
-    parser.add_argument('ip',
-                        type=IPv4Address,
-                        help='cinder API IP address')
-    parser.add_argument('--host',
-                        type=str,
-                        help='Only return metrics for the specified host')
-    args = parser.parse_args()
-    main(args)
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check cinder services')
+        parser.add_argument('ip',
+                            type=IPv4Address,
+                            help='cinder API IP address')
+        parser.add_argument('--host',
+                            type=str,
+                            help='Only return metrics for the specified host')
+        args = parser.parse_args()
+        main(args)

--- a/cinder_service_check.py
+++ b/cinder_service_check.py
@@ -18,7 +18,7 @@ import argparse
 import requests
 from ipaddr import IPv4Address
 from maas_common import (status_ok, status_err, get_keystone_client,
-                         metric_bool, get_auth_ref)
+                         metric_bool, get_auth_ref, print_output)
 from requests import exceptions as exc
 
 # NOTE(mancdaz): until https://review.openstack.org/#/c/111051/

--- a/disk_utilisation.py
+++ b/disk_utilisation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from maas_common import metric, status_err, status_ok
+from maas_common import metric, status_err, status_ok, print_output
 import shlex
 import subprocess
 

--- a/disk_utilisation.py
+++ b/disk_utilisation.py
@@ -13,11 +13,12 @@ def utilisation(time):
     return utils
 
 if __name__ == '__main__':
-    try:
-        utils = utilisation(5)
-    except Exception as e:
-        status_err(e)
-    else:
-        status_ok()
-        for util in utils:
-            metric('disk_utilisation_%s' % util[0], 'double', util[1], '%')
+    with print_output():
+        try:
+            utils = utilisation(5)
+        except Exception as e:
+            status_err(e)
+        else:
+            status_ok()
+            for util in utils:
+                metric('disk_utilisation_%s' % util[0], 'double', util[1], '%')

--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -20,7 +20,7 @@ import os
 import re
 import requests
 
-from maas_common import metric, status_ok, status_err
+from maas_common import metric, status_ok, status_err, print_output
 
 
 def get_elasticsearch_bind_host():

--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -133,4 +133,5 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    with print_output():
+        main()

--- a/galera_check.py
+++ b/galera_check.py
@@ -112,4 +112,5 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    with print_output():
+        main()

--- a/galera_check.py
+++ b/galera_check.py
@@ -18,7 +18,7 @@ import optparse
 import subprocess
 import shlex
 
-from maas_common import status_err, status_ok, metric
+from maas_common import status_err, status_ok, metric, print_output
 
 
 def galera_status_check(arg):

--- a/glance_api_local_check.py
+++ b/glance_api_local_check.py
@@ -79,9 +79,10 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check glance API')
-    parser.add_argument('ip',
-                        type=IPv4Address,
-                        help='glance API IP address')
-    args = parser.parse_args()
-    main(args)
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check glance API')
+        parser.add_argument('ip',
+                            type=IPv4Address,
+                            help='glance API IP address')
+        args = parser.parse_args()
+        main(args)

--- a/glance_api_local_check.py
+++ b/glance_api_local_check.py
@@ -18,7 +18,7 @@ import argparse
 import collections
 from ipaddr import IPv4Address
 from maas_common import (status_ok, status_err, metric, metric_bool,
-                         get_keystone_client, get_auth_ref)
+                         get_keystone_client, get_auth_ref, print_output)
 from requests import Session
 from requests import exceptions as exc
 

--- a/glance_registry_local_check.py
+++ b/glance_registry_local_check.py
@@ -59,9 +59,10 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check glance registry')
-    parser.add_argument('ip',
-                        type=IPv4Address,
-                        help='glance registry IP address')
-    args = parser.parse_args()
-    main(args)
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check glance registry')
+        parser.add_argument('ip',
+                            type=IPv4Address,
+                            help='glance registry IP address')
+        args = parser.parse_args()
+        main(args)

--- a/glance_registry_local_check.py
+++ b/glance_registry_local_check.py
@@ -17,7 +17,7 @@
 import argparse
 from ipaddr import IPv4Address
 from maas_common import (status_ok, status_err, metric, get_keystone_client,
-                         get_auth_ref, metric_bool)
+                         get_auth_ref, metric_bool, print_output)
 from requests import Session
 from requests import exceptions as exc
 

--- a/heat_api_local_check.py
+++ b/heat_api_local_check.py
@@ -59,9 +59,10 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check heat API')
-    parser.add_argument('ip',
-                        type=IPv4Address,
-                        help='heat API IP address')
-    args = parser.parse_args()
-    main(args)
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check heat API')
+        parser.add_argument('ip',
+                            type=IPv4Address,
+                            help='heat API IP address')
+        args = parser.parse_args()
+        main(args)

--- a/heat_api_local_check.py
+++ b/heat_api_local_check.py
@@ -18,7 +18,7 @@ import argparse
 from time import time
 from ipaddr import IPv4Address
 from maas_common import (get_auth_ref, get_heat_client, metric_bool,
-                         metric, status_ok, status_err)
+                         metric, status_ok, status_err, print_output)
 from heatclient import exc
 
 

--- a/horizon_check.py
+++ b/horizon_check.py
@@ -19,7 +19,7 @@ from ipaddr import IPv4Address
 import requests
 import re
 from maas_common import (get_auth_details, metric, metric_bool, status_err,
-                         status_ok)
+                         status_ok, print_output)
 from requests import exceptions as exc
 from lxml import html
 

--- a/horizon_check.py
+++ b/horizon_check.py
@@ -100,9 +100,10 @@ def main(args):
     check(args)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check horizon dashboard')
-    parser.add_argument('ip',
-                        type=IPv4Address,
-                        help='horizon dashboard IP address')
-    args = parser.parse_args()
-    main(args)
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check horizon dashboard')
+        parser.add_argument('ip',
+                            type=IPv4Address,
+                            help='horizon dashboard IP address')
+        args = parser.parse_args()
+        main(args)

--- a/keystone_api_local_check.py
+++ b/keystone_api_local_check.py
@@ -18,7 +18,7 @@ import argparse
 from time import time
 from ipaddr import IPv4Address
 from maas_common import (get_keystone_client, status_err, status_ok, metric,
-                         metric_bool)
+                         metric_bool, print_output)
 from keystoneclient.openstack.common.apiclient import exceptions as exc
 
 

--- a/keystone_api_local_check.py
+++ b/keystone_api_local_check.py
@@ -62,9 +62,10 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check keystone API')
-    parser.add_argument('ip',
-                        type=IPv4Address,
-                        help='keystone API IP address')
-    args = parser.parse_args()
-    main(args)
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check keystone API')
+        parser.add_argument('ip',
+                            type=IPv4Address,
+                            help='keystone API IP address')
+        args = parser.parse_args()
+        main(args)

--- a/maas_common.py
+++ b/maas_common.py
@@ -18,6 +18,7 @@ import contextlib
 import datetime
 import errno
 import json
+import logging
 import os
 import re
 import StringIO
@@ -445,6 +446,10 @@ def metric_bool(name, success):
     metric(name, 'uint32', value)
 
 
+logging.basicConfig(filename='/var/log/maas_plugins.log',
+                    format='%(asctime)s %(levelname)s: %(message)s')
+
+
 @contextlib.contextmanager
 def print_output():
     try:
@@ -454,6 +459,8 @@ def print_output():
             print STATUS
         raise
     except Exception as e:
+        logging.exception('The plugin %s has failed with an unhandled '
+                          'exception', sys.argv[0])
         status_err(traceback.format_exc(), force_print=True, exception=e)
     else:
         if STATUS:

--- a/maas_common.py
+++ b/maas_common.py
@@ -21,7 +21,6 @@ import json
 import logging
 import os
 import re
-import StringIO
 import sys
 import traceback
 

--- a/maas_common.py
+++ b/maas_common.py
@@ -14,12 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import datetime
 import errno
 import json
 import os
 import re
+import StringIO
 import sys
+import traceback
 
 AUTH_DETAILS = {'OS_USERNAME': None,
                 'OS_PASSWORD': None,
@@ -391,7 +394,11 @@ def force_reauth():
     return keystone_auth(auth_details)
 
 
-def status(status, message):
+STATUS = ''
+
+
+def status(status, message, force_print=False):
+    global STATUS
     if status in ('ok', 'warn', 'err'):
         raise ValueError('The status "%s" is not allowed because it creates a '
                          'metric called legacy_state' % status)
@@ -399,26 +406,57 @@ def status(status, message):
     if message is not None:
         status_line = ' '.join((status_line, str(message)))
     status_line = status_line.replace('\n', '\\n')
-    print status_line
+    STATUS = status_line
+    if force_print:
+        print STATUS
 
 
-def status_err(message=None):
-    status('error', message)
+def status_err(message=None, force_print=False, exception=None):
+    if exception:
+        # a status message cannot exceed 256 characters
+        # 'error ' plus up to 250 from the end of the exception
+        message = message[-250:]
+    status('error', message, force_print=force_print)
+    if exception:
+        raise exception
     sys.exit(1)
 
 
-def status_ok(message=None):
-    status('okay', message)
+def status_ok(message=None, force_print=False):
+    status('okay', message, force_print=force_print)
+
+
+METRICS = []
 
 
 def metric(name, metric_type, value, unit=None):
+    global METRICS
+    if len(METRICS) > 29:
+        status_err('Maximum of 30 metrics per check')
     metric_line = 'metric %s %s %s' % (name, metric_type, value)
     if unit is not None:
         metric_line = ' '.join((metric_line, unit))
     metric_line = metric_line.replace('\n', '\\n')
-    print metric_line
+    METRICS.append(metric_line)
 
 
 def metric_bool(name, success):
     value = success and 1 or 0
     metric(name, 'uint32', value)
+
+
+@contextlib.contextmanager
+def print_output():
+    try:
+        yield
+    except SystemExit as e:
+        if STATUS:
+            print STATUS
+        raise
+    except Exception as e:
+        status_err(traceback.format_exc(), force_print=True, exception=e)
+    else:
+        if STATUS:
+            print STATUS
+        for metric in METRICS:
+            print metric

--- a/memcached_status.py
+++ b/memcached_status.py
@@ -19,7 +19,8 @@ import argparse
 import memcache
 from ipaddr import IPv4Address
 
-from maas_common import status_ok, status_err, metric, metric_bool
+from maas_common import (status_ok, status_err, metric, metric_bool,
+                         print_output)
 
 
 VERSION_RE = re.compile('STAT version (\d+\.\d+\.\d+)(?![-+0-9\\.])')

--- a/memcached_status.py
+++ b/memcached_status.py
@@ -69,9 +69,10 @@ def main(args):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Check memcached status')
-    parser.add_argument('ip', type=IPv4Address, help='memcached IP address.')
-    parser.add_argument('--port', type=int,
-                        default=11211, help='memcached port.')
-    args = parser.parse_args()
-    main(args)
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check memcached status')
+        parser.add_argument('ip', type=IPv4Address, help='memcached IP address.')
+        parser.add_argument('--port', type=int,
+                            default=11211, help='memcached port.')
+        args = parser.parse_args()
+        main(args)

--- a/neutron_api_local_check.py
+++ b/neutron_api_local_check.py
@@ -68,9 +68,10 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check neutron API')
-    parser.add_argument('ip',
-                        type=IPv4Address,
-                        help='neutron API IP address')
-    args = parser.parse_args()
-    main(args)
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check neutron API')
+        parser.add_argument('ip',
+                            type=IPv4Address,
+                            help='neutron API IP address')
+        args = parser.parse_args()
+        main(args)

--- a/neutron_api_local_check.py
+++ b/neutron_api_local_check.py
@@ -18,7 +18,7 @@ import argparse
 from time import time
 from ipaddr import IPv4Address
 from maas_common import (get_neutron_client, metric,
-                         status_err, status_ok, metric_bool)
+                         status_err, status_ok, metric_bool, print_output)
 from neutronclient.client import exceptions as exc
 
 

--- a/neutron_service_check.py
+++ b/neutron_service_check.py
@@ -16,7 +16,8 @@
 
 import argparse
 from ipaddr import IPv4Address
-from maas_common import get_neutron_client, status_err, status_ok, metric_bool
+from maas_common import (get_neutron_client, status_err, status_ok,
+                         metric_bool, print_output)
 
 
 def check(args):

--- a/neutron_service_check.py
+++ b/neutron_service_check.py
@@ -60,13 +60,14 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check neutron agents')
-    parser.add_argument('ip',
-                        type=IPv4Address,
-                        help='neutron API IP address')
-    parser.add_argument('--host',
-                        type=str,
-                        help='Only return metrics for specified host',
-                        default=None)
-    args = parser.parse_args()
-    main(args)
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check neutron agents')
+        parser.add_argument('ip',
+                            type=IPv4Address,
+                            help='neutron API IP address')
+        parser.add_argument('--host',
+                            type=str,
+                            help='Only return metrics for specified host',
+                            default=None)
+        args = parser.parse_args()
+        main(args)

--- a/nova_api_local_check.py
+++ b/nova_api_local_check.py
@@ -19,7 +19,7 @@ import collections
 from time import time
 from ipaddr import IPv4Address
 from maas_common import (get_nova_client, status_err, metric,
-                         status_ok, metric_bool)
+                         status_ok, metric_bool, print_output)
 from novaclient.client import exceptions as exc
 
 SERVER_STATUSES = ['ACTIVE', 'STOPPED', 'ERROR']

--- a/nova_api_local_check.py
+++ b/nova_api_local_check.py
@@ -68,9 +68,10 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check nova API')
-    parser.add_argument('ip',
-                        type=IPv4Address,
-                        help='nova API IP address')
-    args = parser.parse_args()
-    main(args)
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check nova API')
+        parser.add_argument('ip',
+                            type=IPv4Address,
+                            help='nova API IP address')
+        args = parser.parse_args()
+        main(args)

--- a/nova_api_metadata_local_check.py
+++ b/nova_api_metadata_local_check.py
@@ -55,9 +55,11 @@ def main(args):
     check(args)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check nova-api-metdata API')
-    parser.add_argument('ip',
-                        type=IPv4Address,
-                        help='nova-api-metadata IP address')
-    args = parser.parse_args()
-    main(args)
+    with print_output():
+        parser = argparse.ArgumentParser(
+            description='Check nova-api-metdata API')
+        parser.add_argument('ip',
+                            type=IPv4Address,
+                            help='nova-api-metadata IP address')
+        args = parser.parse_args()
+        main(args)

--- a/nova_api_metadata_local_check.py
+++ b/nova_api_metadata_local_check.py
@@ -17,7 +17,8 @@
 import argparse
 import requests
 from ipaddr import IPv4Address
-from maas_common import (status_ok, status_err, metric, metric_bool)
+from maas_common import (status_ok, status_err, metric, metric_bool,
+                         print_output)
 from requests import exceptions as exc
 
 

--- a/nova_service_check.py
+++ b/nova_service_check.py
@@ -16,7 +16,8 @@
 
 import argparse
 from ipaddr import IPv4Address
-from maas_common import get_nova_client, status_err, status_ok, metric_bool
+from maas_common import (get_nova_client, status_err, status_ok, metric_bool,
+                         print_output)
 
 
 def check(args):

--- a/nova_service_check.py
+++ b/nova_service_check.py
@@ -59,14 +59,15 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check nova services')
-    parser.add_argument('ip',
-                        type=IPv4Address,
-                        help='nova API IP address')
-    parser.add_argument('--host',
-                        type=str,
-                        help='Only return metrics for specified host',
-                        default=None)
-    args = parser.parse_args()
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check nova services')
+        parser.add_argument('ip',
+                            type=IPv4Address,
+                            help='nova API IP address')
+        parser.add_argument('--host',
+                            type=str,
+                            help='Only return metrics for specified host',
+                            default=None)
+        args = parser.parse_args()
 
-    main(args)
+        main(args)

--- a/openmanage.py
+++ b/openmanage.py
@@ -68,7 +68,7 @@ def check_openmanage_version():
     version = match.groups()[0]
     if version not in SUPPORTED_VERSIONS:
         status_err(
-            'Expected version in %s to be installed but found %s' 
+            'Expected version in %s to be installed but found %s'
             % (SUPPORTED_VERSIONS, version)
         )
 
@@ -97,4 +97,5 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    with print_output():
+        main()

--- a/openmanage.py
+++ b/openmanage.py
@@ -18,7 +18,7 @@ import re
 import sys
 import subprocess
 
-from maas_common import status_err, status_ok, metric_bool
+from maas_common import status_err, status_ok, metric_bool, print_output
 
 SUPPORTED_VERSIONS = set([ "7.1.0", "7.4.0" ])
 OM_PATTERN = '(?:%(field)s)\s+:\s+(%(group_pattern)s)'

--- a/rabbitmq_status.py
+++ b/rabbitmq_status.py
@@ -161,4 +161,5 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    with print_output():
+        main()

--- a/rabbitmq_status.py
+++ b/rabbitmq_status.py
@@ -19,7 +19,8 @@ import optparse
 import requests
 import subprocess
 
-from maas_common import metric, metric_bool, status_ok, status_err
+from maas_common import (metric, metric_bool, status_ok, status_err,
+                         print_output)
 
 OVERVIEW_URL = "http://%s:%s/api/overview"
 NODES_URL = "http://%s:%s/api/nodes"

--- a/service_api_local_check.py
+++ b/service_api_local_check.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from maas_common import (status_ok, metric, metric_bool,
-                         get_keystone_client, get_auth_ref)
+                         get_keystone_client, get_auth_ref, print_output)
 import argparse
 from ipaddr import IPv4Address
 import requests

--- a/service_api_local_check.py
+++ b/service_api_local_check.py
@@ -73,18 +73,19 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Check service is up.')
-    parser.add_argument('name', help='Service name.')
-    parser.add_argument('ip', type=IPv4Address, help='Service IP address.')
-    parser.add_argument('port', type=int, help='Service port.')
-    parser.add_argument('--path', default='',
-                        help='Service API path, this should include '
-                             'placeholders for the version "{version}" and '
-                             'tenant ID "{tenant_id}" if required.')
-    parser.add_argument('--auth', action='store_true', default=False,
-                        help='Does this API check require auth?')
-    parser.add_argument('--ssl', action='store_true', default=False,
-                        help='Should SSL be used.')
-    parser.add_argument('--version', help='Service API version.')
-    args = parser.parse_args()
-    main(args)
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check service is up.')
+        parser.add_argument('name', help='Service name.')
+        parser.add_argument('ip', type=IPv4Address, help='Service IP address.')
+        parser.add_argument('port', type=int, help='Service port.')
+        parser.add_argument('--path', default='',
+                            help='Service API path, this should include '
+                                 'placeholders for the version "{version}" and '
+                                 'tenant ID "{tenant_id}" if required.')
+        parser.add_argument('--auth', action='store_true', default=False,
+                            help='Does this API check require auth?')
+        parser.add_argument('--ssl', action='store_true', default=False,
+                            help='Should SSL be used.')
+        parser.add_argument('--version', help='Service API version.')
+        args = parser.parse_args()
+        main(args)

--- a/swift-dispersion.py
+++ b/swift-dispersion.py
@@ -125,4 +125,5 @@ def main():
 # > metric container_total_copies uint64 6
 
 if __name__ == '__main__':
-    main()
+    with print_output():
+        main()

--- a/swift-dispersion.py
+++ b/swift-dispersion.py
@@ -125,5 +125,5 @@ def main():
 # > metric container_total_copies uint64 6
 
 if __name__ == '__main__':
-    with print_output():
+    with maas_common.print_output():
         main()

--- a/swift-recon.py
+++ b/swift-recon.py
@@ -361,4 +361,5 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    with print_output():
+        main()

--- a/swift-recon.py
+++ b/swift-recon.py
@@ -361,5 +361,5 @@ def main():
 
 
 if __name__ == '__main__':
-    with print_output():
+    with maas_common.print_output():
         main()


### PR DESCRIPTION
***backport from master***

maas has some particular requirements regarding the output. This
commit attempts to address the following:

Report an error if the script attempts to return more than 30 metrics.
While the agent does log this and does stop sending metrics the status
of the check remains available. This could cause issues if the metrics
aren't used with alarms

Uncaught exceptions generate a status message.
Exceptions don't generate a status message unless one is explicitly
set. Sometimes an exception may only occur if run by the agent. Status
messages have a limit of 256 characters so the text is taken from the
tail of the traceback.

Log unhandled exceptions
The agent does a poor job of tracking plugin failures. This commit will
log unhandled exceptions to make debugging issues easier.

Strip newlines from output
The agent treats each line separately. Multi-line output such as
exceptions needs to have newlines escaped so that it can be used in the
status message.

Use the last status message
The agent uses the first status message it receives and logs any that
follow as duplicates. If an error happens after an okay status message
the message needs to be updated.