### PR TITLE
Avoid empty dictionaries in swift_replication

### DIFF
--- a/swift-recon.py
+++ b/swift-recon.py
@@ -153,6 +153,8 @@ def swift_replication(for_ring):
     # less readable than this loop
     replication_statistics = {}
     for rep_dict in replication_dicts:
+        if not rep_dict:
+            continue
         replication_statistics[rep_dict.pop('replication_type')] = rep_dict
 
     return replication_statistics


### PR DESCRIPTION
Calling pop on an empty dictionary will cause a KeyError. We'd like to avoid that if possible.