### PR TITLE
Raise an exception on invalid replication data

### DIFF
--- a/maas_common.py
+++ b/maas_common.py
@@ -322,6 +322,10 @@ else:
         return heat
 
 
+class MaaSException(Exception):
+    """Base MaaS plugin exception."""
+
+
 def is_token_expired(token):
     expires = datetime.datetime.strptime(token['expires'],
                                          '%Y-%m-%dT%H:%M:%SZ')


### PR DESCRIPTION
Instead of returning an empty dictionary, let's raise an exception
of our own which will document (in part) why we're failing here.