### PR TITLE
Accept DNS hostname or IP address as API host target

### DIFF
--- a/cinder_service_check.py
+++ b/cinder_service_check.py
@@ -16,7 +16,6 @@
 
 import argparse
 import requests
-from ipaddr import IPv4Address
 from maas_common import (status_ok, status_err, get_keystone_client,
                          metric_bool, get_auth_ref, print_output)
 from requests import exceptions as exc
@@ -30,8 +29,9 @@ def check(auth_ref, args):
 
     keystone = get_keystone_client(auth_ref)
     auth_token = keystone.auth_token
-    VOLUME_ENDPOINT = 'http://{ip}:8776/v1/{tenant}' \
-                      .format(ip=args.ip, tenant=keystone.tenant_id)
+    VOLUME_ENDPOINT = 'http://{hostname}:8776/v1/{tenant}' \
+                      .format(hostname=args.hostname,
+                              tenant=keystone.tenant_id)
 
     s = requests.Session()
 
@@ -78,9 +78,9 @@ def main(args):
 if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(description='Check cinder services')
-        parser.add_argument('ip',
-                            type=IPv4Address,
-                            help='cinder API IP address')
+        parser.add_argument('hostname',
+                            type=str,
+                            help='Cinder API hostname or IP address')
         parser.add_argument('--host',
                             type=str,
                             help='Only return metrics for the specified host')

--- a/neutron_service_check.py
+++ b/neutron_service_check.py
@@ -15,14 +15,13 @@
 # limitations under the License.
 
 import argparse
-from ipaddr import IPv4Address
 from maas_common import (get_neutron_client, status_err, status_ok,
                          metric_bool, print_output)
 
 
 def check(args):
 
-    NETWORK_ENDPOINT = 'http://{ip}:9696'.format(ip=args.ip)
+    NETWORK_ENDPOINT = 'http://{hostname}:9696'.format(hostname=args.hostname)
     try:
         neutron = get_neutron_client(endpoint_url=NETWORK_ENDPOINT)
 
@@ -63,9 +62,9 @@ def main(args):
 if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(description='Check neutron agents')
-        parser.add_argument('ip',
-                            type=IPv4Address,
-                            help='neutron API IP address')
+        parser.add_argument('hostname',
+                            type=str,
+                            help='Neutron API hostname or IP address')
         parser.add_argument('--host',
                             type=str,
                             help='Only return metrics for specified host',

--- a/nova_service_check.py
+++ b/nova_service_check.py
@@ -15,14 +15,14 @@
 # limitations under the License.
 
 import argparse
-from ipaddr import IPv4Address
 from maas_common import (get_nova_client, status_err, status_ok, metric_bool,
                          print_output)
 
 
 def check(args):
 
-    COMPUTE_ENDPOINT = 'http://{ip}:8774/v3'.format(ip=args.ip)
+    COMPUTE_ENDPOINT = 'http://{hostname}:8774/v3' \
+                       .format(hostname=args.hostname)
     try:
         nova = get_nova_client(bypass_url=COMPUTE_ENDPOINT)
 
@@ -62,9 +62,9 @@ def main(args):
 if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(description='Check nova services')
-        parser.add_argument('ip',
-                            type=IPv4Address,
-                            help='nova API IP address')
+        parser.add_argument('hostname',
+                            type=str,
+                            help='Nova API hostname or IP address')
         parser.add_argument('--host',
                             type=str,
                             help='Only return metrics for specified host',


### PR DESCRIPTION
Removes the positional argument validation as IPv4 address and updates
help messages.

Fixes #157

(cherry picked from commit 557b0d6a825b96820983cf86cf572cd0bc449866)