### PR TITLE
Fix swift-recon.py

### DIFF
--- a/swift-recon.py
+++ b/swift-recon.py
@@ -368,7 +368,7 @@ def main():
     try:
         stats = get_stats_from(args)
     except (ParseError, CommandNotRecognized) as e:
-        maas_common.status_error(str(e))
+        maas_common.status_err(str(e))
 
     if stats:
         maas_common.status_ok()


### PR DESCRIPTION
This update fixes the call to a non-existent method in maas_common
(status_error).

It does not look like this needs to be back-ported to juno

Fixes #170 