### PR TITLE
Raise an exception on invalid replication data

### DIFF
--- a/maas_common.py
+++ b/maas_common.py
@@ -322,6 +322,10 @@ else:
         return heat
 
 
+class MaaSException(Exception):
+    """Base MaaS plugin exception."""
+
+
 def is_token_expired(token):
     expires = datetime.datetime.strptime(token['expires'],
                                          '%Y-%m-%dT%H:%M:%SZ')

--- a/swift-recon.py
+++ b/swift-recon.py
@@ -28,6 +28,14 @@ import re
 import subprocess
 
 
+class ParseError(maas_common.MaaSException):
+    pass
+
+
+class CommandNotRecognized(maas_common.MaaSException):
+    pass
+
+
 def recon_output(for_ring, options=None):
     """Run swift-recon and filter out extraneous printed lines.
 
@@ -79,7 +87,7 @@ def _parse_into_dict(line, parsed_by):
     if match:
         return match.groupdict()
     else:
-        return {}
+        raise ParseError("Cannot parse '{0}' for statistics.".format(line))
 
 
 def recon_stats_dicts(for_ring, options, starting_with, parsed_by):
@@ -335,10 +343,7 @@ def make_parser():
     return parser
 
 
-def main():
-    parser = make_parser()
-    args = parser.parse_args()
-
+def get_stats_from(args):
     stats = {}
     if args.recon == 'async-pendings':
         stats = swift_async()
@@ -351,9 +356,19 @@ def main():
             maas_common.status_err('no ring provided to check')
         stats = swift_replication(args.ring)
     else:
-        maas_common.status_err(
-            'unrecognized command "{0}"'.format(args.recon)
-            )
+        raise CommandNotRecognized('unrecognized command "{0}"'.format(
+            args.recon))
+    return stats
+
+
+def main():
+    parser = make_parser()
+    args = parser.parse_args()
+
+    try:
+        stats = get_stats_from(args)
+    except (ParseError, CommandNotRecognized) as e:
+        maas_common.status_err(str(e))
 
     if stats:
         maas_common.status_ok()


### PR DESCRIPTION
Instead of returning an empty dictionary, let's raise an exception
of our own which will document (in part) why we're failing here.

(cherry picked from commit 35596500c33468cf23c3e268ea16f95eb6ac8ec0)
(78c83a9657a7f31d71671ca0095fa0ea58a68f46 was squashed into this one)

Backports of #162 and #171 
Closes #172