### PR TITLE
Disable warnings conditionally

### DIFF
--- a/horizon_check.py
+++ b/horizon_check.py
@@ -26,7 +26,8 @@ from lxml import html
 
 def check(args):
     # disable warning for insecure cert on horizon
-    requests.packages.urllib3.disable_warnings()
+    if requests.__build__ >= 0x020400:
+        requests.packages.urllib3.disable_warnings()
 
     splash_status_code = 0
     splash_milliseconds = 0.0


### PR DESCRIPTION
requests.packages.urllib3.disable_warnings is only available on requests
2.4.0 or later. Right now, we package have a lower limit on 2.2.0 and
all versions before 2.4.0 will cause an AttributeError when calling
this.

/cc @stevelle 