### PR TITLE
Add conntrack_count.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,3 +307,17 @@ Returns metrics indicating the status of parts of HP hardware.
     metric hardware_memory_status uint32 1
     metric hardware_processors_status uint32 1
     metric hardware_disk_status uint32 1
+
+***
+#### conntrack_count.py
+
+#### Description:
+Returns, as metrics, the values of /proc/sys/net/netfilter/nf_conntrack_count and /proc/sys/net/netfilter/nf_conntrack_max.
+
+The kernel modules nf_conntrack_ipv4 and/or nf_conntrack_ipv6 must be loaded for this plugin to work.
+
+#### Example output:
+
+    status okay
+    metric nf_conntrack_max uint32 262144
+    metric nf_conntrack_count uint32 354

--- a/conntrack_count.py
+++ b/conntrack_count.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import errno
+import maas_common
+
+
+class MissingModuleError(maas_common.MaaSException):
+    pass
+
+def get_value(path):
+    try:
+        with open(path) as f:
+            value = f.read()
+    except IOError as e:
+        if e.errno == errno.ENOENT:
+            msg = ('Unable to read "%s", the appropriate kernel module is '
+                   'probably not loaded.' % path)
+            raise MissingModuleError(msg)
+
+    return value.strip()
+
+
+def get_metrics():
+    metrics = {
+        'nf_conntrack_count': {
+            'path': '/proc/sys/net/netfilter/nf_conntrack_count'},
+        'nf_conntrack_max': {
+            'path': '/proc/sys/net/netfilter/nf_conntrack_max'}}
+
+    for data in metrics.viewvalues():
+        data['value'] = get_value(data['path'])
+
+    return metrics
+
+
+def main():
+    try:
+        metrics = get_metrics()
+    except maas_common.MaaSException as e:
+        maas_common.status_err(str(e))
+    else:
+        maas_common.status_ok()
+        for name, data in metrics.viewitems():
+            maas_common.metric(name, 'uint32', data['value'])
+
+
+if __name__ == '__main__':
+    with maas_common.print_output():
+        main()


### PR DESCRIPTION
This commit adds a plugin to allow the number of connections and the
maximum number allowed to be monitored.

Issue: https://github.com/rcbops/rpc-maas/issues/163
(cherry picked from commit 7724f307be9ec4503c931406af79f7ba9684e9c3)
(cherry picked from commit ce6c10e14685755eba2969701aabc55bd3f94694)
(cherry picked from commit a0865f1c355874591a8f1769be1b3fe0e102c66c)
(cherry picked from commit d62594bcbba68b0dce62dbb409773a80aa210606)
(cherry picked from commit b317187719258dff3533e69debc200b9353dac70)
(cherry picked from commit 9bdf8137f9f4b917ffb8711d1ecfd5e2b3afc775)