### PR TITLE
Update nova plugins to use v2.1 API

### DIFF
--- a/nova_api_local_check.py
+++ b/nova_api_local_check.py
@@ -18,7 +18,7 @@ import argparse
 import collections
 from time import time
 from ipaddr import IPv4Address
-from maas_common import (get_nova_client, status_err, metric,
+from maas_common import (get_auth_ref, get_nova_client, status_err, metric,
                          status_ok, metric_bool, print_output)
 from novaclient.client import exceptions as exc
 
@@ -26,11 +26,16 @@ SERVER_STATUSES = ['ACTIVE', 'STOPPED', 'ERROR']
 
 
 def check(args):
+    auth_ref = get_auth_ref()
+    auth_token = auth_ref['token']['id']
+    tenant_id = auth_ref['token']['tenant']['id']
 
-    COMPUTE_ENDPOINT = 'http://{ip}:8774/v3'.format(ip=args.ip)
+    COMPUTE_ENDPOINT = 'http://{ip}:8774/v2.1/{tenant_id}' \
+                       .format(ip=args.ip, tenant_id=tenant_id)
 
     try:
-        nova = get_nova_client(bypass_url=COMPUTE_ENDPOINT)
+        nova = get_nova_client(auth_token=auth_token,
+                               bypass_url=COMPUTE_ENDPOINT)
         is_up = True
     except exc.ClientException:
         is_up = False

--- a/nova_service_check.py
+++ b/nova_service_check.py
@@ -15,16 +15,20 @@
 # limitations under the License.
 
 import argparse
-from maas_common import (get_nova_client, status_err, status_ok, metric_bool,
-                         print_output)
+from maas_common import (get_auth_ref, get_nova_client, status_err, status_ok,
+                         metric_bool, print_output)
 
 
 def check(args):
+    auth_ref = get_auth_ref()
+    auth_token = auth_ref['token']['id']
+    tenant_id = auth_ref['token']['tenant']['id']
 
-    COMPUTE_ENDPOINT = 'http://{hostname}:8774/v3' \
-                       .format(hostname=args.hostname)
+    COMPUTE_ENDPOINT = 'http://{hostname}:8774/v2.1/{tenant_id}' \
+                       .format(hostname=args.hostname, tenant_id=tenant_id)
     try:
-        nova = get_nova_client(bypass_url=COMPUTE_ENDPOINT)
+        nova = get_nova_client(auth_token=auth_token,
+                               bypass_url=COMPUTE_ENDPOINT)
 
     # not gathering api status metric here so catch any exception
     except Exception as e:


### PR DESCRIPTION
Currently, these scripts use v3 API however upstream os-a-d project no
longer enables v3 API.  This change uses v2.1 API instead, which
requires including tenant_id in the URL.

Closes issue #197