### PR TITLE
Add conntrack_count.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,3 +294,17 @@ connects to an individual member of a galera cluster and checks various statuses
     metric wsrep_cluster_status string primary
     metric wsrep_local_state_uuid string 67e41d08-165d-11e4-9d87-7e94ef43b302
     metric wsrep_local_state_comment string synced
+
+***
+#### conntrack_count.py
+
+#### Description:
+Returns, as metrics, the values of /proc/sys/net/netfilter/nf_conntrack_count and /proc/sys/net/netfilter/nf_conntrack_max.
+
+The kernel modules nf_conntrack_ipv4 and/or nf_conntrack_ipv6 must be loaded for this plugin to work.
+
+#### Example output:
+
+    status okay
+    metric nf_conntrack_max uint32 262144
+    metric nf_conntrack_count uint32 354

--- a/conntrack_count.py
+++ b/conntrack_count.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import errno
+import maas_common
+
+
+class MissingModuleError(Exception):
+    pass
+
+def get_value(path):
+    try:
+        with open(path) as f:
+            value = f.read()
+    except IOError as e:
+        if e.errno == errno.ENOENT:
+            msg = ('Unable to read "%s", the appropriate kernel module is '
+                   'probably not loaded.' % path)
+            raise MissingModuleError(msg)
+
+    return value.strip()
+
+
+def get_metrics():
+    metrics = {
+        'nf_conntrack_count': {
+            'path': '/proc/sys/net/netfilter/nf_conntrack_count'},
+        'nf_conntrack_max': {
+            'path': '/proc/sys/net/netfilter/nf_conntrack_max'}}
+
+    for data in metrics.viewvalues():
+        data['value'] = get_value(data['path'])
+
+    return metrics
+
+
+def main():
+    try:
+        metrics = get_metrics()
+    except MissingModuleError as e:
+        maas_common.status_err(str(e))
+    else:
+        maas_common.status_ok()
+        for name, data in metrics.viewitems():
+            maas_common.metric(name, 'uint32', data['value'])
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commit adds a plugin to allow the number of connections and the
maximum number allowed to be monitored.

Issue: https://github.com/rcbops/rpc-maas/issues/163
(cherry picked from commit f17443a3260aef5c531d38c012ef727bc0db0f86)

Conflicts:
	README.md