### PR TITLE
Use nova API v2 instead of v2.1

### DIFF
--- a/nova_api_local_check.py
+++ b/nova_api_local_check.py
@@ -30,7 +30,7 @@ def check(args):
     auth_token = auth_ref['token']['id']
     tenant_id = auth_ref['token']['tenant']['id']
 
-    COMPUTE_ENDPOINT = 'http://{ip}:8774/v2.1/{tenant_id}' \
+    COMPUTE_ENDPOINT = 'http://{ip}:8774/v2/{tenant_id}' \
                        .format(ip=args.ip, tenant_id=tenant_id)
 
     try:

--- a/nova_service_check.py
+++ b/nova_service_check.py
@@ -24,7 +24,7 @@ def check(args):
     auth_token = auth_ref['token']['id']
     tenant_id = auth_ref['token']['tenant']['id']
 
-    COMPUTE_ENDPOINT = 'http://{hostname}:8774/v2.1/{tenant_id}' \
+    COMPUTE_ENDPOINT = 'http://{hostname}:8774/v2/{tenant_id}' \
                        .format(hostname=args.hostname, tenant_id=tenant_id)
     try:
         nova = get_nova_client(auth_token=auth_token,


### PR DESCRIPTION
In commit 347463d we changed the nova plugins to use v2.1 instead of
v3.  This was done as v3 is now deprecated and defaults to being
disabled in os-ansible-deployment.  The problem was the testing was
done on a deployment w/ v3 enabled and it appears there is some
coupling between v2.1 and v3.

This commit simply updates the nova plugins to use v2 instead of v2.1.
Thanks to @miguelgrinberg for spotting this!

Closes issue #197