### PR TITLE
Update rabbitmq_status.py

### DIFF
--- a/rabbitmq_status.py
+++ b/rabbitmq_status.py
@@ -24,7 +24,7 @@ from maas_common import (metric, metric_bool, status_ok, status_err,
 
 OVERVIEW_URL = "http://%s:%s/api/overview"
 NODES_URL = "http://%s:%s/api/nodes"
-CHANNEL_URL = "http://%s:%s/api/channels"
+CONNECTIONS_URL = "http://%s:%s/api/connections"
 
 CLUSTERED = True
 CLUSTER_SIZE = 3
@@ -87,13 +87,13 @@ def main():
     s.auth = (options.username, options.password)
 
     try:
-        r = s.get(CHANNEL_URL % (options.host, options.port))
+        r = s.get(CONNECTIONS_URL % (options.host, options.port))
     except requests.exceptions.ConnectionError as e:
         status_err(str(e))
 
     if r.ok:
         resp_json = r.json()  # Parse the JSON once
-        if any(channel['number'] > 1 for channel in resp_json):
+        if any('channels' in connection and connection['channels'] > 1 for connection in resp_json):
             status_err('Detected RabbitMQ connections with multiple channels. Please check RabbitMQ and all Openstack consumers')
     else:
         status_err('Received status {0} from RabbitMQ API'.format(


### PR DESCRIPTION
This commit updates rabbitmq_status.py to check /api/connections
instead of /api/channels.  According to rabbitmqctl, 'numbers'
on /api/channels is:

The number of the channel, which uniquely identifies it within a
connection.

Alarming if number > 1 is ineffective, and on OpenStack Kilo this
actually poses a problem as doing a 'rabbitmqctl list_channels
numbers' actually returns channels w/ name > 1.

Further, in https://bugs.launchpad.net/oslo.messaging/+bug/1406629 we
see the following command being used to determine problem state:

rabbitmqctl list_connections name channels | awk '{ if ($4 >1) print }'

This confirms that we should be checking /api/connections and not
/api/channels.

Closes issues #188