### PR TITLE
Create rabbitmq_max_channels_per_conn metric

### DIFF
--- a/rabbitmq_status.py
+++ b/rabbitmq_status.py
@@ -24,7 +24,7 @@ from maas_common import (metric, metric_bool, status_ok, status_err,
 
 OVERVIEW_URL = "http://%s:%s/api/overview"
 NODES_URL = "http://%s:%s/api/nodes"
-CONNECTIONS_URL = "http://%s:%s/api/connections"
+CONNECTIONS_URL = "http://%s:%s/api/connections?columns=channels"
 
 CLUSTERED = True
 CLUSTER_SIZE = 3
@@ -50,6 +50,8 @@ NODES_METRICS = {"proc_used": "processes",
                  "mem_alarm": "status",
                  "disk_free_alarm": "status",
                  "uptime": "ms"}
+
+CONNECTIONS_METRICS = {"max_channels_per_conn": "channels"}
 
 
 def hostname():
@@ -93,12 +95,12 @@ def main():
 
     if r.ok:
         resp_json = r.json()  # Parse the JSON once
-        if any('channels' in connection and connection['channels'] > 1 for connection in resp_json):
-            status_err('Detected RabbitMQ connections with multiple channels. Please check RabbitMQ and all Openstack consumers')
+        max_chans = max(connection['channels'] for connection in resp_json if 'channels' in connection)
+        for k in CONNECTIONS_METRICS:
+            metrics[k] = {'value': max_chans, 'unit': CONNECTIONS_METRICS[k]}
     else:
         status_err('Received status {0} from RabbitMQ API'.format(
             r.status_code))
-
 
     try:
         r = s.get(OVERVIEW_URL % (options.host, options.port))
@@ -149,8 +151,6 @@ def main():
             status_err('cluster too small')
         if not is_cluster_member:
             status_err('{0} not a member of the cluster'.format(name))
-
-
 
     status_ok()
 


### PR DESCRIPTION
Currently, we alarm if connection['channels'] > 1.  This change creates
a new metric called rabbitmq_max_channels_per_conn which we can alarm
against using a MaaS alarm.  Additionally, this change updates
CONNECTIONS_URL so we only return the data from /api/connections that
we need (channels).

TODO: We will need to create an alarm on rpc-extras which ideally
      alarms if rabbitmq_max_channels_per_conn > 10.  Running a
      dev cluster periodically sees rabbitmq_max_channels_per_conn > 1
      and 10 is an 'arbitrary but likely reasonable limit' which we can
      use to prevent channel ballooning.

Closes issue #188