### PR TITLE
synchronize kilo branch with all plugins in rpc-openstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ The contents of this file would look something like this:
 
 ##### Description:
 Polls a nova API living on the specified IP. Checks to see if the API is up, and then also gathers a list of metrics to return
-##### mandatory args:
+##### Mandatory Arguments:
 IP address of service to test
-##### example output:
+##### Example Output:
 
     status okay
     metric nova_api_local_status uint32 1
@@ -47,9 +47,9 @@ IP address of service to test
 ##### Description:
 Polls a cinder API living on the specified IP. Checks to see if the API is up, and then also gathers a list of metrics to return--
 
-##### mandatory args:
+##### Mandatory Arguments:
 IP address of service to test
-##### example output:
+##### Example Output:
 
     status okay
     metric cinder_api_local_status uint32 1
@@ -68,9 +68,9 @@ IP address of service to test
 
 ##### Description:
 Polls a keystone API living on the specified IP. Checks to see if the API is up, and then also gathers a list of metrics to return--
-##### mandatory args:
+##### Mandatory Arguments:
 IP address of service to test
-##### example output:
+##### Example Output:
 
     status okay
     metric keystone_api_local_status uint32 1
@@ -83,9 +83,9 @@ IP address of service to test
 
 ##### Description:
 Polls a neutron API living on the specified IP. Checks to see if the API is up, and then also gathers a list of metrics to return--
-##### mandatory args:
+##### Mandatory Arguments:
 IP address of service to test
-##### example output:
+##### Example Output:
 
     status okay
     metric neutron_api_local_status uint32 1
@@ -101,9 +101,9 @@ IP address of service to test
 ##### Description:
 Polls a glance API living on the specified IP. Checks to see if the API is up, and then also gathers a list of metrics to return--
 
-##### mandatory args:
+##### Mandatory Arguments:
 IP address of service to test
-##### example output:
+##### Example Output:
 
     status okay
     metric glance_api_local_status uint32 1
@@ -118,9 +118,9 @@ IP address of service to test
 ##### Description:
 Polls a (native) heat API living on the specified IP. Checks to see if the API is up, and then also gathers a list of metrics to return--
 
-##### mandatory args:
+##### Mandatory Arguments:
 IP address of service to test
-##### example output:
+##### Example Output:
 
     metric heat_api_local_status uint32 1
     metric heat_api_local_response_time double 22.752 ms
@@ -128,17 +128,17 @@ IP address of service to test
 ***
 #### service_api_local_check.py
 
-##### mandatory args:
-<name> of service to test
-IP address of service to test
-Port of service to test
-##### optional args:
---path: path to tag on to the end of the url
---auth: whether to authenticate with keystone before the request
---ssl: use https or not
---version: hit a specific version of the api
+##### Mandatory Arguments:
+- Name of service to test
+- IP address of service to test
+- Port of service to test
+##### Optional Arguments:
+- --path: path to tag on to the end of the url
+- --auth: whether to authenticate with keystone before the request
+- --ssl: use https or not
+- --version: hit a specific version of the api
 
-##### example output:
+##### Example Output:
 
     metric <name>_api_local_status uint32 1
     metric <name>_api_local_response_time double 6.222 ms
@@ -153,9 +153,9 @@ Port of service to test
 ##### Description:
 polls the nova api and gets a list of all nova services running in the environment, then checks the output to see if each one is up or not. If a service is marked as administratively down, the check will skip it.
 
-##### mandatory args:
+##### Mandatory Arguments:
 Hostname or IP address of service to test
-##### example output:
+##### Example Output:
 
     metric nova-scheduler_on_host_aio1_nova_scheduler_container-e7b92e0f uint32 1
     metric nova-conductor_on_host_aio1_nova_conductor_container-dcddd54a uint32 1
@@ -168,9 +168,9 @@ Hostname or IP address of service to test
 ##### Description:
 polls the cinder api and gets a list of all cinder services running in the environment, then checks the output to see if each one is up or not. If a service is marked as administratively down, the check will skip it.
 
-##### mandatory args:
+##### Mandatory Arguments:
 Hostname or IP address of service to test
-##### example output:
+##### Example Output:
 
     metric cinder-scheduler_on_host_aio1_cinder_volumes_container-b6ad3de7 uint32 1
     metric cinder-volume_on_host_aio1_cinder_volumes_container-b6ad3de7 uint32 1
@@ -182,14 +182,27 @@ Hostname or IP address of service to test
 ##### Description:
 polls the neutron api and gets a list of all neutron agents running in the environment, then checks the output to see if each one is up or not. If an agent is marked as administratively down, the check will skip it.
 
-##### mandatory args:
+##### Mandatory Arguments:
 Hostname or IP address of service to test
-##### example output:
+##### Example Output:
 
     metric neutron-metadata-agent_8a1a5b16-8546-4801-a31f-e07dce8c068b_on_host_big3.localdomain uint32 1
     metric neutron-linuxbridge-agent_cac1fd39-e23d-47ea-aa20-99f0accf5584_on_host_aio1_nova_compute_container-19824c74 uint32 1
     metric neutron-dhcp-agent_d89db127-2bc7-473a-bcb0-ac89345397e0_on_host_big3.localdomain uint32 1
     metric neutron-linuxbridge-agent_e86cee43-47bf-42cd-872f-a623e458e549_on_host_big3.localdomain uint32 1
+    ...
+
+***
+#### neutron_metadata_local_check.py
+
+##### Description:
+polls the neutron metadata agent proxies in each network namespace with DHCP enabled to ensure the agent is responsive.
+
+##### Mandatory Arguments:
+Hostname or IP address of Neutron API service
+##### Example Output:
+
+    metric neutron-metadata-agent-proxy_status uint32 1
     ...
 
 ***
@@ -201,10 +214,10 @@ Hostname or IP address of service to test
 ##### Description:
 Connects directly to the glance registry and tests status by calling an arbitry url
 
-##### mandatory args:
+##### Mandatory Arguments:
 IP address of service to test
 
-##### example output:
+##### Example Output:
 
     metric glance_registry_local_status uint32 1
     metric glance_registry_local_response_time uint32 356.917 ms
@@ -215,13 +228,13 @@ IP address of service to test
 ##### Description:
 Connects to a memcached server
 
-##### mandatory args:
+##### Mandatory Arguments:
 IP address of memcached server
 
-##### optional args:
+##### Optional Arguments:
 --port: port of service to test (default '15672')
 
-##### example output:
+##### Example Output:
 
     metric memcache_api_local_status uint32 1
     metric memcache_total_items uint64 563324 items
@@ -235,9 +248,9 @@ IP address of memcached server
 ##### Description:
 Checks the status of the horizon dashboard. First checks that the login page is available, then uses the creds from the openrc-maas file to actually log in.
 
-##### mandatory args:
+##### Mandatory Arguments:
 IP address of service to test
-##### example output:
+##### Example Output:
 
     metric splash_status_code uint32 200
     metric splash_milliseconds double 83.557 ms
@@ -250,13 +263,13 @@ IP address of service to test
 ##### Description:
 connects to an individual member of a rabbit cluster and grabs statistics from the rabbit status API
 
-##### optional args:
---host: IP of service to test (default 'localhost')
---port: port of service to test (default '15672')
---username: username to test with (default 'guest')
---password: password to test with (default 'guest')
+##### Optional Arguments:
+- --host: IP of service to test (default 'localhost')
+- --port: port of service to test (default '15672')
+- --username: username to test with (default 'guest')
+- --password: password to test with (default 'guest')
 
-##### example output:
+##### Example Output:
 
     metric rabbitmq_uptime int64 73439448 ms
     metric rabbitmq_proc_total int64 1048576 processes
@@ -279,11 +292,11 @@ connects to an individual member of a rabbit cluster and grabs statistics from t
 ##### Description:
 connects to an individual member of a galera cluster and checks various statuses to ensure the member is fully synced and considered active
 
-##### optional args:
---host: IP of service to test (default 'localhost')
---port: port of service to test (default '15672')
+##### Optional Arguments:
+- --host: IP of service to test (default 'localhost')
+- --port: port of service to test (default '15672')
 
-##### example output:
+##### Example Output:
 
     metric wsrep_replicated_bytes int64 320737952 bytes
     metric wsrep_received_bytes int64 33470 bytes
@@ -298,26 +311,79 @@ connects to an individual member of a galera cluster and checks various statuses
 ***
 #### conntrack_count.py
 
-#### Description:
+##### Description:
 Returns, as metrics, the values of /proc/sys/net/netfilter/nf_conntrack_count and /proc/sys/net/netfilter/nf_conntrack_max.
 
 The kernel modules nf_conntrack_ipv4 and/or nf_conntrack_ipv6 must be loaded for this plugin to work.
 
-#### Example output:
+##### Example Output:
 
-    status okay
     metric nf_conntrack_max uint32 262144
     metric nf_conntrack_count uint32 354
 
 ***
 #### hp_monitoring.py
 
-#### Description:
+##### Description:
 Returns metrics indicating the status of parts of HP hardware.
 
-#### Example output:
+##### Example Output:
 
-    status okay
     metric hardware_memory_status uint32 1
     metric hardware_processors_status uint32 1
     metric hardware_disk_status uint32 1
+
+***
+#### ceph_monitoring.py
+
+##### Description:
+Connects to a Ceph cluster with the specified user/key and returns a number of metrics which can be used to monitor general health and availability of that cluster
+
+##### Mandatory Arguments:
+- {cluster,mon,osd}: Specify the type of data to return
+- --name NAME: Ceph client name to use when connecting to cluster
+- --keyring KEYRING: Ceph client keyring to use when connecting to cluster
+
+##### Mandatory Arguments (when osd argument given):
+- --osd_ids OSD_IDS: Space-separated list of OSDs, required when `--type osd`
+
+##### Mandatory Arguments (when mon argument given):
+- --host HOST: Specific MON to connect to, required when `--type mon`
+
+##### Example Output:
+Cluster:
+
+    metric cluster_health uint32 2
+    metric monmap_epoch uint32 1
+    metric osdmap_epoch uint32 16
+    metric osds_total uint32 3
+    metric osds_up uint32 3
+    metric osds_in uint32 3
+    metric osds_kb uint64 495007068
+    metric osds_kb_avail uint64 284983032
+    metric osds_kb_used uint64 189214596
+    metric pgs_active_clean uint32 512
+    metric pgs_total uint32 512
+
+MON:
+
+    metric mon_in_quorum uint32 1
+    metric mon_health uint32 2
+
+OSDs:
+
+    metric osd.0_up uint32 1
+    metric osd.0_in uint32 1
+    metric osd.0_kb uint64 165002356
+    metric osd.0_kb_used uint64 63071532
+    metric osd.0_kb_avail uint64 94994344
+    metric osd.1_up uint32 1
+    metric osd.1_in uint32 1
+    metric osd.1_kb uint64 165002356
+    metric osd.1_kb_used uint64 63071532
+    metric osd.1_kb_avail uint64 94994344
+    metric osd.2_up uint32 1
+    metric osd.2_in uint32 1
+    metric osd.2_kb uint64 165002356
+    metric osd.2_kb_used uint64 63071532
+    metric osd.2_kb_avail uint64 94994344

--- a/ceph_monitoring.py
+++ b/ceph_monitoring.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import maas_common
+import subprocess
+
+
+STATUSES = {'HEALTH_OK': 2, 'HEALTH_WARN': 1, 'HEALTH_ERR': 0}
+
+
+def check_command(command):
+    output = subprocess.check_output(command, stderr=subprocess.STDOUT)
+    lines = output.strip().split('\n')
+    return json.loads(lines[-1])
+
+
+def get_ceph_report(client, keyring, fmt='json'):
+    return check_command(('ceph', '--format', fmt, '--name', client,
+                          '--keyring', keyring, 'report'))
+
+
+def get_mon_statistics(report=None, host=None):
+    mon = [m for m in report['monmap']['mons']
+           if m['name'] == host]
+    mon_in = mon[0]['rank'] in report['quorum']
+    maas_common.metric_bool('mon_in_quorum', mon_in)
+    health_status = 0
+    for each in report['health']['health']['health_services'][0]['mons']:
+        if each['name'] == host:
+            health_status = STATUSES[each['health']]
+            break
+    maas_common.metric('mon_health', 'uint32', health_status)
+
+
+def get_osd_statistics(report=None, osd_ids=None):
+    for osd_id in osd_ids:
+        osd_ref = 'osd.%s' % osd_id
+        for _osd in report['osdmap']['osds']:
+            if _osd['osd'] == osd_id:
+                osd = _osd
+                break
+        else:
+            msg = 'The OSD ID %s does not exist.' % osd_id
+            raise maas_common.MaaSException(msg)
+        for key in ('up', 'in'):
+            name = '_'.join((osd_ref, key))
+            maas_common.metric_bool(name, osd[key])
+
+        for _osd in report['pgmap']['osd_stats']:
+            if _osd['osd'] == osd_id:
+                osd = _osd
+                break
+        for key in ('kb', 'kb_used', 'kb_avail'):
+            name = '_'.join((osd_ref, key))
+            maas_common.metric(name, 'uint64', osd[key])
+
+
+def get_cluster_statistics(report=None):
+    metrics = []
+
+    # Get overall cluster health
+    metrics.append({'name': 'cluster_health',
+                    'type': 'uint32',
+                    'value': STATUSES[report['health']['overall_status']]})
+
+    # Collect epochs for the mon and osd maps
+    for map_name in ('monmap', 'osdmap'):
+        metrics.append({'name': "%(map)s_epoch" % {'map': map_name},
+                        'type': 'uint32',
+                        'value': report[map_name]['epoch']})
+
+    # Collect OSDs per state
+    osds = {'total': 0, 'up': 0, 'in': 0}
+    for osd in report['osdmap']['osds']:
+        osds['total'] += 1
+        if osd['up'] == 1:
+            osds['up'] += 1
+        if osd['in'] == 1:
+            osds['in'] += 1
+    for k in osds:
+        metrics.append({'name': 'osds_%s' % k,
+                        'type': 'uint32',
+                        'value': osds[k]})
+
+    # Collect cluster size & utilisation
+    osds_stats = ('kb', 'kb_avail', 'kb_used')
+    for k in report['pgmap']['osd_stats_sum']:
+        if k in osds_stats:
+            metrics.append({'name': 'osds_%s' % k,
+                            'type': 'uint64',
+                            'value': report['pgmap']['osd_stats_sum'][k]})
+
+    # Collect num PGs and num healthy PGs
+    pgs = {'total': 0, 'active_clean': 0}
+    for pg in report['pgmap']['pg_stats']:
+        pgs['total'] += 1
+        if pg['state'] == 'active+clean':
+            pgs['active_clean'] += 1
+    for k in pgs:
+        metrics.append({'name': 'pgs_%s' % k,
+                        'type': 'uint32',
+                        'value': pgs[k]})
+
+    # Submit gathered metrics
+    for m in metrics:
+        maas_common.metric(m['name'], m['type'], m['value'])
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--name', required=True, help='Ceph client name')
+    parser.add_argument('--keyring', required=True, help='Ceph client keyring')
+
+    subparsers = parser.add_subparsers(dest='subparser_name')
+
+    parser_mon = subparsers.add_parser('mon')
+    parser_mon.add_argument('--host', required=True, help='Mon hostname')
+
+    parser_osd = subparsers.add_parser('osd')
+    parser_osd.add_argument('--osd_ids', required=True,
+                            help='Space separated list of OSD IDs')
+
+    subparsers.add_parser('cluster')
+    return parser.parse_args()
+
+
+def main(args):
+    get_statistics = {'cluster': get_cluster_statistics,
+                      'mon': get_mon_statistics,
+                      'osd': get_osd_statistics}
+    report = get_ceph_report(client=args.name, keyring=args.keyring)
+    kwargs = {'report': report}
+    if args.subparser_name == 'osd':
+        kwargs['osd_ids'] = [int(i) for i in args.osd_ids.split(' ')]
+    if args.subparser_name == 'mon':
+        kwargs['host'] = args.host
+    get_statistics[args.subparser_name](**kwargs)
+    maas_common.status_ok()
+
+
+if __name__ == '__main__':
+    with maas_common.print_output():
+        args = get_args()
+        main(args)

--- a/cinder_api_local_check.py
+++ b/cinder_api_local_check.py
@@ -16,10 +16,18 @@
 
 import argparse
 import collections
+
+import ipaddr
+# Technically maas_common isn't third-party but our own thing but hacking
+# consideres it third-party
+from maas_common import get_auth_ref
+from maas_common import get_keystone_client
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
 import requests
-from ipaddr import IPv4Address
-from maas_common import (status_ok, status_err, metric, metric_bool,
-                         get_keystone_client, get_auth_ref, print_output)
 from requests import exceptions as exc
 
 VOLUME_STATUSES = ['available', 'in-use', 'error']
@@ -56,7 +64,7 @@ def check(auth_ref, args):
             exc.Timeout) as e:
         is_up = False
     except Exception as e:
-           status_err(str(e))
+        status_err(str(e))
     else:
         # gather some metrics
         vol_statuses = [v['status'] for v in vol.json()['volumes']]
@@ -95,7 +103,7 @@ if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(description='Check cinder API')
         parser.add_argument('ip',
-                            type=IPv4Address,
+                            type=ipaddr.IPv4Address,
                             help='cinder API IP address')
         args = parser.parse_args()
         main(args)

--- a/cinder_service_check.py
+++ b/cinder_service_check.py
@@ -15,9 +15,16 @@
 # limitations under the License.
 
 import argparse
+
+# Technically maas_common isn't third-party but our own thing but hacking
+# consideres it third-party
+from maas_common import get_auth_ref
+from maas_common import get_keystone_client
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
 import requests
-from maas_common import (status_ok, status_err, get_keystone_client,
-                         metric_bool, get_auth_ref, print_output)
 from requests import exceptions as exc
 
 # NOTE(mancdaz): until https://review.openstack.org/#/c/111051/
@@ -29,9 +36,10 @@ def check(auth_ref, args):
 
     keystone = get_keystone_client(auth_ref)
     auth_token = keystone.auth_token
-    VOLUME_ENDPOINT = 'http://{hostname}:8776/v1/{tenant}' \
-                      .format(hostname=args.hostname,
-                              tenant=keystone.tenant_id)
+    VOLUME_ENDPOINT = (
+        'http://{hostname}:8776/v1/{tenant}'.format(hostname=args.hostname,
+                                                    tenant=keystone.tenant_id)
+    )
 
     s = requests.Session()
 
@@ -53,6 +61,13 @@ def check(auth_ref, args):
 
     services = r.json()['services']
 
+    # We need to match against a host of X and X@lvm (or whatever backend)
+    if args.host:
+        backend = ''.join((args.host, '@'))
+        services = [service for service in services
+                    if (service['host'].startswith(backend) or
+                        service['host'] == args.host)]
+
     if len(services) == 0:
         status_err('No host(s) found in the service list')
 
@@ -62,8 +77,7 @@ def check(auth_ref, args):
         if service['status'] == 'enabled' and service['state'] != 'up':
             service_is_up = False
 
-        # We need to match against a host of X and X@lvm (or whatever backend)
-        if args.host and args.host in service['host']:
+        if args.host:
             name = '%s_status' % service['binary']
         else:
             name = '%s_on_host_%s' % (service['binary'], service['host'])

--- a/conntrack_count.py
+++ b/conntrack_count.py
@@ -15,11 +15,13 @@
 # limitations under the License.
 
 import errno
+
 import maas_common
 
 
 class MissingModuleError(maas_common.MaaSException):
     pass
+
 
 def get_value(path):
     try:

--- a/disk_utilisation.py
+++ b/disk_utilisation.py
@@ -1,13 +1,32 @@
 #!/usr/bin/env python
 
-from maas_common import metric, status_err, status_ok, print_output
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import shlex
 import subprocess
+
+from maas_common import metric
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+
 
 def utilisation(time):
     output = subprocess.check_output(shlex.split('iostat -x -d %s 2' % time))
     device_lines = output.split('\nDevice:')[-1].strip().split('\n')[1:]
-    devices = [d for d in device_lines if not d.startswith(('dm-', 'nb')) ]
+    devices = [d for d in device_lines if not d.startswith(('dm-', 'nb'))]
     devices = [d.split() for d in devices]
     utils = [(d[0], d[-1]) for d in devices]
     return utils

--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -18,9 +18,12 @@ import json
 import optparse
 import os
 import re
-import requests
 
-from maas_common import metric, status_ok, status_err, print_output
+from maas_common import metric
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+import requests
 
 
 def get_elasticsearch_bind_host():

--- a/glance_api_local_check.py
+++ b/glance_api_local_check.py
@@ -16,10 +16,16 @@
 
 import argparse
 import collections
-from ipaddr import IPv4Address
-from maas_common import (status_ok, status_err, metric, metric_bool,
-                         get_keystone_client, get_auth_ref, print_output)
-from requests import Session
+
+import ipaddr
+from maas_common import get_auth_ref
+from maas_common import get_keystone_client
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+import requests
 from requests import exceptions as exc
 
 IMAGE_STATUSES = ['active', 'queued', 'killed']
@@ -32,7 +38,7 @@ def check(auth_ref, args):
     auth_token = keystone.auth_token
     api_endpoint = 'http://{ip}:9292/v1'.format(ip=args.ip)
 
-    s = Session()
+    s = requests.Session()
 
     s.headers.update(
         {'Content-type': 'application/json',
@@ -70,7 +76,10 @@ def check(auth_ref, args):
                '%.3f' % milliseconds,
                'ms')
         for status in IMAGE_STATUSES:
-            metric('glance_%s_images' % status, 'uint32', status_count[status], 'images')
+            metric('glance_%s_images' % status,
+                   'uint32',
+                   status_count[status],
+                   'images')
 
 
 def main(args):
@@ -82,7 +91,7 @@ if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(description='Check glance API')
         parser.add_argument('ip',
-                            type=IPv4Address,
+                            type=ipaddr.IPv4Address,
                             help='glance API IP address')
         args = parser.parse_args()
         main(args)

--- a/glance_registry_local_check.py
+++ b/glance_registry_local_check.py
@@ -15,10 +15,16 @@
 # limitations under the License.
 
 import argparse
-from ipaddr import IPv4Address
-from maas_common import (status_ok, status_err, metric, get_keystone_client,
-                         get_auth_ref, metric_bool, print_output)
-from requests import Session
+
+import ipaddr
+from maas_common import get_auth_ref
+from maas_common import get_keystone_client
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+import requests
 from requests import exceptions as exc
 
 
@@ -29,7 +35,7 @@ def check(auth_ref, args):
     auth_token = keystone.auth_token
     registry_endpoint = 'http://{ip}:9191'.format(ip=args.ip)
 
-    s = Session()
+    s = requests.Session()
 
     s.headers.update(
         {'Content-type': 'application/json',
@@ -62,7 +68,7 @@ if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(description='Check glance registry')
         parser.add_argument('ip',
-                            type=IPv4Address,
+                            type=ipaddr.IPv4Address,
                             help='glance registry IP address')
         args = parser.parse_args()
         main(args)

--- a/heat_api_local_check.py
+++ b/heat_api_local_check.py
@@ -15,11 +15,17 @@
 # limitations under the License.
 
 import argparse
-from time import time
-from ipaddr import IPv4Address
-from maas_common import (get_auth_ref, get_heat_client, metric_bool,
-                         metric, status_ok, status_err, print_output)
+import time
+
 from heatclient import exc
+import ipaddr
+from maas_common import get_auth_ref
+from maas_common import get_heat_client
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
 
 
 def check(args, tenant_id):
@@ -37,9 +43,9 @@ def check(args, tenant_id):
         status_err(str(e))
     else:
         # time something arbitrary
-        start = time()
+        start = time.time()
         heat.build_info.build_info()
-        end = time()
+        end = time.time()
         milliseconds = (end - start) * 1000
 
     status_ok()
@@ -54,7 +60,7 @@ def check(args, tenant_id):
 
 def main(args):
     auth_ref = get_auth_ref()
-    tenant_id = auth_ref['token']['tenant']['id']
+    tenant_id = auth_ref['project']['id']
     check(args, tenant_id)
 
 
@@ -62,7 +68,7 @@ if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(description='Check heat API')
         parser.add_argument('ip',
-                            type=IPv4Address,
+                            type=ipaddr.IPv4Address,
                             help='heat API IP address')
         args = parser.parse_args()
         main(args)

--- a/horizon_check.py
+++ b/horizon_check.py
@@ -15,18 +15,24 @@
 # limitations under the License.
 
 import argparse
-from ipaddr import IPv4Address
-import requests
 import re
-from maas_common import (get_auth_details, metric, metric_bool, status_err,
-                         status_ok, print_output)
-from requests import exceptions as exc
+
+import ipaddr
 from lxml import html
+from maas_common import get_auth_details
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+import requests
+from requests import exceptions as exc
 
 
 def check(args):
     # disable warning for insecure cert on horizon
-    requests.packages.urllib3.disable_warnings()
+    if requests.__build__ >= 0x020400:
+        requests.packages.urllib3.disable_warnings()
 
     splash_status_code = 0
     splash_milliseconds = 0.0
@@ -103,7 +109,7 @@ if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(description='Check horizon dashboard')
         parser.add_argument('ip',
-                            type=IPv4Address,
+                            type=ipaddr.IPv4Address,
                             help='horizon dashboard IP address')
         args = parser.parse_args()
         main(args)

--- a/hp_monitoring.py
+++ b/hp_monitoring.py
@@ -52,11 +52,30 @@ def get_drive_status():
                          'logicaldrive', 'OK)')
 
 
+def get_controller_status():
+    return check_command(('hpssacli', 'ctrl', 'all', 'show', 'status'),
+                         'Controller Status', 'OK')
+
+
+def get_controller_cache_status():
+    return check_command(('hpssacli', 'ctrl', 'all', 'show', 'status'),
+                         'Cache Status', 'OK')
+
+
+def get_controller_battery_status():
+    return check_command(('hpssacli', 'ctrl', 'all', 'show', 'status'),
+                         'Battery/Capacitor Status', 'OK')
+
+
 def main():
     status = {}
     status['hardware_processors_status'] = get_hpasmcli_status('server')
     status['hardware_memory_status'] = get_hpasmcli_status('dimm')
     status['hardware_disk_status'] = get_drive_status()
+    status['hardware_controller_status'] = get_controller_status()
+    status['hardware_controller_cache_status'] = get_controller_cache_status()
+    status['hardware_controller_battery_status'] = \
+        get_controller_battery_status()
 
     maas_common.status_ok()
     for name, value in status.viewitems():

--- a/memcached_status.py
+++ b/memcached_status.py
@@ -14,13 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 import argparse
-import memcache
-from ipaddr import IPv4Address
+import re
 
-from maas_common import (status_ok, status_err, metric, metric_bool,
-                         print_output)
+import ipaddr
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+import memcache
 
 
 VERSION_RE = re.compile('STAT version (\d+\.\d+\.\d+)(?![-+0-9\\.])')
@@ -53,7 +56,7 @@ def main(args):
     try:
         stats = item_stats(bind_ip, port)
         current_version = stats['version']
-    except TypeError, IndexError:
+    except (TypeError, IndexError):
         is_up = False
     else:
         is_up = True
@@ -72,7 +75,8 @@ def main(args):
 if __name__ == '__main__':
     with print_output():
         parser = argparse.ArgumentParser(description='Check memcached status')
-        parser.add_argument('ip', type=IPv4Address, help='memcached IP address.')
+        parser.add_argument('ip', type=ipaddr.IPv4Address,
+                            help='memcached IP address.')
         parser.add_argument('--port', type=int,
                             default=11211, help='memcached port.')
         args = parser.parse_args()

--- a/neutron_api_local_check.py
+++ b/neutron_api_local_check.py
@@ -15,10 +15,15 @@
 # limitations under the License.
 
 import argparse
-from time import time
-from ipaddr import IPv4Address
-from maas_common import (get_neutron_client, metric,
-                         status_err, status_ok, metric_bool, print_output)
+import time
+
+import ipaddr
+from maas_common import get_neutron_client
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
 from neutronclient.client import exceptions as exc
 
 
@@ -38,9 +43,9 @@ def check(args):
         status_err(str(e))
     else:
         # time something arbitrary
-        start = time()
+        start = time.time()
         neutron.list_agents()
-        end = time()
+        end = time.time()
         milliseconds = (end - start) * 1000
 
         # gather some metrics
@@ -71,7 +76,7 @@ if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(description='Check neutron API')
         parser.add_argument('ip',
-                            type=IPv4Address,
+                            type=ipaddr.IPv4Address,
                             help='neutron API IP address')
         args = parser.parse_args()
         main(args)

--- a/neutron_metadata_local_check.py
+++ b/neutron_metadata_local_check.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import shlex
+import subprocess
+
+from maas_common import get_neutron_client
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+
+# identify the first active neutron agents container on this host
+# network namespaces can only be accessed from within neutron agents container
+FIND_CONTAINER = shlex.split('lxc-ls -1 --running .*neutron_agents')
+SERVICE_CHECK = 'ip netns exec %s curl -fvs 127.0.0.1:80'
+
+
+def check(args):
+    # identify the container we will use for monitoring
+    try:
+        containers_list = subprocess.check_output(FIND_CONTAINER)
+        container = containers_list.splitlines()[0]
+    except (IndexError, subprocess.CalledProcessError):
+        status_err('no running neutron agents containers found')
+
+    network_endpoint = 'http://{host}:9696'.format(host=args.neutron_host)
+    try:
+        neutron = get_neutron_client(endpoint_url=network_endpoint)
+
+    # not gathering api status metric here so catch any exception
+    except Exception as e:
+        status_err(str(e))
+
+    # only check networks which have a port with DHCP enabled
+    ports = neutron.list_ports(device_owner='network:dhcp')['ports']
+    nets = set([p['network_id'] for p in ports])
+
+    # perform checks for each identified network
+    failures = []
+    for net_id in nets:
+        namespace = 'qdhcp-%s' % net_id
+        service_check_cmd = SERVICE_CHECK % namespace
+        command = shlex.split('lxc-attach -n %s -- %s' % (container,
+                                                          service_check_cmd))
+        try:
+            subprocess.check_output(command, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            # HTTP 404 response indicates the service is responsive.
+            # this is the expected response because the maas testing host IP
+            # is used to look up metadata and no metadata exists for this IP
+            if '404 Not Found' not in e.output:
+                failures.append(net_id)
+
+    is_ok = len(failures) == 0
+    metric_bool('neutron-metadata-agent-proxy_status', is_ok)
+
+    if is_ok:
+        status_ok()
+    else:
+        status_err('neutron metadata agent proxies fail on host %s '
+                   'net_ids: %s' % (container, ','.join(failures)))
+
+
+def main(args):
+    check(args)
+
+
+if __name__ == "__main__":
+    with print_output():
+        parser = argparse.ArgumentParser(description='Check neutron proxies')
+        parser.add_argument('neutron_host',
+                            type=str,
+                            help='Neutron API hostname or IP address')
+        main(parser.parse_args())

--- a/neutron_service_check.py
+++ b/neutron_service_check.py
@@ -15,8 +15,12 @@
 # limitations under the License.
 
 import argparse
-from maas_common import (get_neutron_client, status_err, status_ok,
-                         metric_bool, print_output)
+
+from maas_common import get_neutron_client
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
 
 
 def check(args):

--- a/nova_api_local_check.py
+++ b/nova_api_local_check.py
@@ -16,10 +16,16 @@
 
 import argparse
 import collections
-from time import time
-from ipaddr import IPv4Address
-from maas_common import (get_auth_ref, get_nova_client, status_err, metric,
-                         status_ok, metric_bool, print_output)
+import time
+
+import ipaddr
+from maas_common import get_auth_ref
+from maas_common import get_nova_client
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
 from novaclient.client import exceptions as exc
 
 SERVER_STATUSES = ['ACTIVE', 'STOPPED', 'ERROR']
@@ -27,11 +33,13 @@ SERVER_STATUSES = ['ACTIVE', 'STOPPED', 'ERROR']
 
 def check(args):
     auth_ref = get_auth_ref()
-    auth_token = auth_ref['token']['id']
-    tenant_id = auth_ref['token']['tenant']['id']
+    auth_token = auth_ref['auth_token']
+    tenant_id = auth_ref['project']['id']
 
-    COMPUTE_ENDPOINT = 'http://{ip}:8774/v2/{tenant_id}' \
-                       .format(ip=args.ip, tenant_id=tenant_id)
+    COMPUTE_ENDPOINT = (
+        'http://{ip}:8774/v2/{tenant_id}'.format(ip=args.ip,
+                                                 tenant_id=tenant_id)
+    )
 
     try:
         nova = get_nova_client(auth_token=auth_token,
@@ -44,15 +52,14 @@ def check(args):
         status_err(str(e))
     else:
         # time something arbitrary
-        start = time()
+        start = time.time()
         nova.services.list()
-        end = time()
+        end = time.time()
         milliseconds = (end - start) * 1000
 
+        servers = nova.servers.list(search_opts={'all_tenants': 1})
         # gather some metrics
-        status_count = collections.Counter(
-            [s.status for s in nova.servers.list(search_opts={'all_tenants': 1})]
-        )
+        status_count = collections.Counter([s.status for s in servers])
 
     status_ok()
     metric_bool('nova_api_local_status', is_up)
@@ -76,7 +83,7 @@ if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(description='Check nova API')
         parser.add_argument('ip',
-                            type=IPv4Address,
+                            type=ipaddr.IPv4Address,
                             help='nova API IP address')
         args = parser.parse_args()
         main(args)

--- a/nova_api_metadata_local_check.py
+++ b/nova_api_metadata_local_check.py
@@ -15,10 +15,14 @@
 # limitations under the License.
 
 import argparse
+
+import ipaddr
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
 import requests
-from ipaddr import IPv4Address
-from maas_common import (status_ok, status_err, metric, metric_bool,
-                         print_output)
 from requests import exceptions as exc
 
 
@@ -60,7 +64,7 @@ if __name__ == "__main__":
         parser = argparse.ArgumentParser(
             description='Check nova-api-metdata API')
         parser.add_argument('ip',
-                            type=IPv4Address,
+                            type=ipaddr.IPv4Address,
                             help='nova-api-metadata IP address')
         args = parser.parse_args()
         main(args)

--- a/nova_service_check.py
+++ b/nova_service_check.py
@@ -15,17 +15,24 @@
 # limitations under the License.
 
 import argparse
-from maas_common import (get_auth_ref, get_nova_client, status_err, status_ok,
-                         metric_bool, print_output)
+
+from maas_common import get_auth_ref
+from maas_common import get_nova_client
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
 
 
 def check(args):
     auth_ref = get_auth_ref()
-    auth_token = auth_ref['token']['id']
-    tenant_id = auth_ref['token']['tenant']['id']
+    auth_token = auth_ref['auth_token']
+    tenant_id = auth_ref['project']['id']
 
-    COMPUTE_ENDPOINT = 'http://{hostname}:8774/v2/{tenant_id}' \
-                       .format(hostname=args.hostname, tenant_id=tenant_id)
+    COMPUTE_ENDPOINT = (
+        'http://{hostname}:8774/v2/{tenant_id}'.format(hostname=args.hostname,
+                                                       tenant_id=tenant_id)
+    )
     try:
         nova = get_nova_client(auth_token=auth_token,
                                bypass_url=COMPUTE_ENDPOINT)

--- a/openmanage.py
+++ b/openmanage.py
@@ -15,21 +15,28 @@
 # limitations under the License.
 
 import re
-import sys
 import subprocess
+import sys
 
-from maas_common import status_err, status_ok, metric_bool, print_output
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
 
-SUPPORTED_VERSIONS = set([ "7.1.0", "7.4.0" ])
+SUPPORTED_VERSIONS = set(["7.1.0", "7.4.0"])
 OM_PATTERN = '(?:%(field)s)\s+:\s+(%(group_pattern)s)'
-CHASSIS = re.compile(OM_PATTERN % {'field': '^Health', 'group_pattern': '\w+'}, re.MULTILINE)
-STORAGE = re.compile(OM_PATTERN % {'field': '^Status', 'group_pattern': '\w+'}, re.MULTILINE)
+CHASSIS = re.compile(OM_PATTERN % {'field': '^Health', 'group_pattern': '\w+'},
+                     re.MULTILINE)
+STORAGE = re.compile(OM_PATTERN % {'field': '^Status', 'group_pattern': '\w+'},
+                     re.MULTILINE)
 regex = {'storage': STORAGE, 'chassis': CHASSIS}
 
 
 def hardware_report(report_type, report_request):
     """Return the report as a string."""
-    return subprocess.check_output(['/opt/dell/srvadmin/bin/omreport', report_type, report_request])
+    return subprocess.check_output(['/opt/dell/srvadmin/bin/omreport',
+                                    report_type,
+                                    report_request])
 
 
 def all_okay(report, regex_find):
@@ -51,7 +58,8 @@ def check_openmanage_version():
         # https://github.com/rcbops/rcbops-maas/issues/82#issuecomment-52315709
         # we need to redirect sdterr to stdout just so MaaS does not see any
         # extra output
-        output = subprocess.check_output(['/opt/dell/srvadmin/bin/omconfig', 'about'],
+        output = subprocess.check_output(['/opt/dell/srvadmin/bin/omconfig',
+                                          'about'],
                                          stderr=subprocess.STDOUT)
     except OSError:
         # OSError happens when subprocess cannot find the executable to run

--- a/rabbitmq_status.py
+++ b/rabbitmq_status.py
@@ -16,15 +16,18 @@
 
 
 import optparse
-import requests
 import subprocess
 
-from maas_common import (metric, metric_bool, status_ok, status_err,
-                         print_output)
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+import requests
 
 OVERVIEW_URL = "http://%s:%s/api/overview"
 NODES_URL = "http://%s:%s/api/nodes"
-CHANNEL_URL = "http://%s:%s/api/channels"
+CONNECTIONS_URL = "http://%s:%s/api/connections?columns=channels"
 
 CLUSTERED = True
 CLUSTER_SIZE = 3
@@ -50,6 +53,8 @@ NODES_METRICS = {"proc_used": "processes",
                  "mem_alarm": "status",
                  "disk_free_alarm": "status",
                  "uptime": "ms"}
+
+CONNECTIONS_METRICS = {"max_channels_per_conn": "channels"}
 
 
 def hostname():
@@ -87,18 +92,19 @@ def main():
     s.auth = (options.username, options.password)
 
     try:
-        r = s.get(CHANNEL_URL % (options.host, options.port))
+        r = s.get(CONNECTIONS_URL % (options.host, options.port))
     except requests.exceptions.ConnectionError as e:
         status_err(str(e))
 
     if r.ok:
         resp_json = r.json()  # Parse the JSON once
-        if any(channel['number'] > 1 for channel in resp_json):
-            status_err('Detected RabbitMQ connections with multiple channels. Please check RabbitMQ and all Openstack consumers')
+        max_chans = max(connection['channels'] for connection in resp_json
+                        if 'channels' in connection)
+        for k in CONNECTIONS_METRICS:
+            metrics[k] = {'value': max_chans, 'unit': CONNECTIONS_METRICS[k]}
     else:
         status_err('Received status {0} from RabbitMQ API'.format(
             r.status_code))
-
 
     try:
         r = s.get(OVERVIEW_URL % (options.host, options.port))
@@ -139,7 +145,7 @@ def main():
         # Check that all other queues are equal to it
         if not all(first == q for q in queues):
             # If they're not, the queues are not synchronized
-            print "status err cluster not replicated across all nodes"
+            status_err('Cluster not replicated across all nodes')
     else:
         status_err('Received status {0} from RabbitMQ API'.format(
             r.status_code))
@@ -149,8 +155,6 @@ def main():
             status_err('cluster too small')
         if not is_cluster_member:
             status_err('{0} not a member of the cluster'.format(name))
-
-
 
     status_ok()
 

--- a/service_api_local_check.py
+++ b/service_api_local_check.py
@@ -14,10 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from maas_common import (status_ok, metric, metric_bool,
-                         get_keystone_client, get_auth_ref, print_output)
 import argparse
-from ipaddr import IPv4Address
+
+import ipaddr
+from maas_common import get_auth_ref
+from maas_common import get_keystone_client
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_ok
 import requests
 from requests import exceptions as exc
 
@@ -29,9 +34,9 @@ def check(args):
         auth_ref = get_auth_ref()
         keystone = get_keystone_client(auth_ref)
         auth_token = keystone.auth_token
-        tenant_id = keystone.tenant_id
+        project_id = keystone.project_id
         headers['auth_token'] = auth_token
-        path_options['tenant_id'] = tenant_id
+        path_options['project_id'] = project_id
 
     scheme = args.ssl and 'https' or 'http'
     endpoint = '{scheme}://{ip}:{port}'.format(ip=args.ip, port=args.port,
@@ -76,12 +81,13 @@ if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(description='Check service is up.')
         parser.add_argument('name', help='Service name.')
-        parser.add_argument('ip', type=IPv4Address, help='Service IP address.')
+        parser.add_argument('ip', type=ipaddr.IPv4Address,
+                            help='Service IP address.')
         parser.add_argument('port', type=int, help='Service port.')
         parser.add_argument('--path', default='',
                             help='Service API path, this should include '
-                                 'placeholders for the version "{version}" and '
-                                 'tenant ID "{tenant_id}" if required.')
+                                 'placeholders for the version "{version}" and'
+                                 ' tenant ID "{tenant_id}" if required.')
         parser.add_argument('--auth', action='store_true', default=False,
                             help='Does this API check require auth?')
         parser.add_argument('--ssl', action='store_true', default=False,

--- a/swift-dispersion.py
+++ b/swift-dispersion.py
@@ -43,7 +43,7 @@ PARSE_RE = re.compile(
     # Last line for both types
     "Sample represents (?P<partition_percent>\d+.\d+)% of the \w+ "
     "partition space"
-    )
+)
 
 
 def generate_report(on):

--- a/swift-recon.py
+++ b/swift-recon.py
@@ -23,9 +23,10 @@
 # python swift-recon.py quarantine
 
 import argparse
-import maas_common
 import re
 import subprocess
+
+import maas_common
 
 
 class ParseError(maas_common.MaaSException):
@@ -43,12 +44,18 @@ def recon_output(for_ring, options=None):
 
         >>> recon_output('account', '-r')
         ['[2014-11-21 00:25:16] Checking on replication',
-         '[replication_failure] low: 0, high: 0, avg: 0.0, total: 0, Failed: 0.0%, no_result: 0, reported: 2',
-         '[replication_success] low: 2, high: 4, avg: 3.0, total: 6, Failed: 0.0%, no_result: 0, reported: 2',
-         '[replication_time] low: 0, high: 0, avg: 0.0, total: 0, Failed: 0.0%, no_result: 0, reported: 2',
-         '[replication_attempted] low: 1, high: 2, avg: 1.5, total: 3, Failed: 0.0%, no_result: 0, reported: 2',
-         'Oldest completion was 2014-11-21 00:24:51 (25 seconds ago) by 192.168.31.1:6002.',
-         'Most recent completion was 2014-11-21 00:24:56 (20 seconds ago) by 192.168.31.2:6002.']
+         '[replication_failure] low: 0, high: 0, avg: 0.0, total: 0, \
+                 Failed: 0.0%, no_result: 0, reported: 2',
+         '[replication_success] low: 2, high: 4, avg: 3.0, total: 6, \
+                 Failed: 0.0%, no_result: 0, reported: 2',
+         '[replication_time] low: 0, high: 0, avg: 0.0, total: 0, \
+                 Failed: 0.0%, no_result: 0, reported: 2',
+         '[replication_attempted] low: 1, high: 2, avg: 1.5, total: 3, \
+                 Failed: 0.0%, no_result: 0, reported: 2',
+         'Oldest completion was 2014-11-21 00:24:51 (25 seconds ago) by \
+                 192.168.31.1:6002.',
+         'Most recent completion was 2014-11-21 00:24:56 (20 seconds ago) by \
+                 192.168.31.2:6002.']
 
     :param str for_ring: Which ring to run swift-recon on
     :param list options: Command line options with which to run swift-recon
@@ -67,7 +74,8 @@ def stat_regexp_generator(data):
 
     Lines printed by swift-recon look like::
 
-        [data] low: 0, high: 0, avg: 0.0, total: 0, Failed: 0.0%, no_result: 0, reported: 0
+        [data] low: 0, high: 0, avg: 0.0, total: 0, Failed: 0.0%, \
+                no_result: 0, reported: 0
 
     Where data above is the value of the ``data`` parameter passed to the
     function.
@@ -95,7 +103,8 @@ def recon_stats_dicts(for_ring, options, starting_with, parsed_by):
 
     Swift-recon has a standard format for it's statistics:
 
-    [name] low: 0, high: 0, avg: 0.0, total: 0, Failed: 0.0%, no_result: 0, reported: 0
+    [name] low: 0, high: 0, avg: 0.0, total: 0, Failed: 0.0%, no_result: 0, \
+            reported: 0
 
     Using the regular expression passed by the user in ``parsed_by``, we parse
     this out and return dictionaries of lines that start with
@@ -196,7 +205,7 @@ def swift_async():
         # If we didn't find a non-empty dict, error out
         maas_common.status_err(
             'No data could be collected about pending async operations'
-            )
+        )
     return {'async': stats}
 
 
@@ -256,7 +265,7 @@ def swift_md5():
     error_re = re.compile('https?://(?P<address>[^:]+):\d+')
     result_re = re.compile(
         '(?P<success>\d+)/(?P<total>\d+)[^\d]+(?P<errors>\d+).*'
-        )
+    )
     output = recon_output('--md5')  # We need to pass --md5 as a string here
     md5_statistics = {}
     checking_dict = {}
@@ -272,7 +281,7 @@ def swift_md5():
             error_dict = error_re.search(line).groupdict()
             maas_common.status_err('md5 mismatch for {0} on host {1}'.format(
                 checking_dict.get('check'), error_dict['address']
-                ))
+            ))
         results_match = result_re.match(line)
         if results_match:
             check_name = checking_dict['check'].replace('.', '_')
@@ -315,7 +324,7 @@ def print_nested_stats(statistics):
 metrics_per_stat = {
     'avg': lambda name, val: maas_common.metric(name, 'double', val),
     'failed': lambda name, val: maas_common.metric(name, 'double', val[:-1])
-    }
+}
 
 DEFAULT_METRIC = lambda name, val: maas_common.metric(name, 'uint64', val)
 
@@ -332,7 +341,7 @@ def print_stats(prefix, statistics):
 def make_parser():
     parser = argparse.ArgumentParser(
         description='Process and print swift-recon statistics'
-        )
+    )
     parser.add_argument('recon',
                         help='Which statistics to collect. Acceptable recon: '
                              '"async-pendings", "md5", "quarantine", '


### PR DESCRIPTION
We have a requirement to move the plugins back out to rpc-maas, in
order that other groups can consume (and contribute to) the plugins
more easily.

This commit synchronises the plugins here with those that exist inside
rpc-openstack at this time.

Note - there is a funky way of preserving all history of commits to
these files when they were in rpc-openstack (using git filter-branch).
Sadly, there is very little history to preserve since we lost it in
the commit which moved all plugins to the plugins directory (7a3cd17)
because 'git mv' was not used from what I can tell. This means that I
can't cleanly apply that history here, and so a big commit including
all the changes is the only way to go. Sorry.