### PR TITLE
Check json_resp before using max()

### DIFF
--- a/rabbitmq_status.py
+++ b/rabbitmq_status.py
@@ -95,9 +95,12 @@ def main():
 
     if r.ok:
         resp_json = r.json()  # Parse the JSON once
-        max_chans = max(connection['channels'] for connection in resp_json if 'channels' in connection)
-        for k in CONNECTIONS_METRICS:
-            metrics[k] = {'value': max_chans, 'unit': CONNECTIONS_METRICS[k]}
+        if resp_json:
+            max_chans = max(connection['channels'] for connection in resp_json
+                            if 'channels' in connection)
+            for k in CONNECTIONS_METRICS:
+                metrics[k] = {'value': max_chans,
+                              'unit': CONNECTIONS_METRICS[k]}
     else:
         status_err('Received status {0} from RabbitMQ API'.format(
             r.status_code))


### PR DESCRIPTION
Check the JSON response body for valid data when requesting channels.

After discussions with @git-harry and thinking the error over again, I've
decided that it is not technically an error to not have channels configured.
It is an error to receive an empty response when checking the overview and
nodes API endpoints. I will fix those in a later bug report.

Closes-Bug: #442