### PR TITLE
Add some connection related metrics to galera_check plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,9 @@ connects to an individual member of a galera cluster and checks various statuses
     metric wsrep_cluster_status string primary
     metric wsrep_local_state_uuid string 67e41d08-165d-11e4-9d87-7e94ef43b302
     metric wsrep_local_state_comment string synced
+    metric mysql_max_configured_connections int64 800 connections
+    metric mysql_current_connections int64 1 connections
+    metric mysql_max_seen_connections int64 2 connections
 
 ***
 #### hp_monitoring.py

--- a/galera_check.py
+++ b/galera_check.py
@@ -13,15 +13,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import optparse
-import subprocess
 import shlex
+import subprocess
 
-from maas_common import status_err, status_ok, metric, print_output
+
+from maas_common import metric
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
 
 
-def galera_status_check(arg):
+def galera_check(arg):
     proc = subprocess.Popen(shlex.split(arg),
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
@@ -32,7 +35,7 @@ def galera_status_check(arg):
     return ret, out, err
 
 
-def generate_query(host, port):
+def generate_query(host, port, output_type='status'):
     if host:
         host = ' -h %s' % host
     else:
@@ -42,10 +45,12 @@ def generate_query(host, port):
         port = ' -P %s' % port
     else:
         port = ''
-
-    return ('/usr/bin/mysql --defaults-file=/root/.my.cnf'
-            '%s%s -e "SHOW STATUS WHERE Variable_name REGEXP '
-            "'^(wsrep.*|queries)'\"") % (host, port)
+    if output_type == 'status':
+        return ('/usr/bin/mysql --defaults-file=/root/.my.cnf '
+                '%s%s -e "SHOW GLOBAL STATUS"') % (host, port)
+    elif output_type == 'variables':
+        return ('/usr/bin/mysql --defaults-file=/root/.my.cnf '
+                '%s%s -e "SHOW GLOBAL VARIABLES"') % (host, port)
 
 
 def parse_args():
@@ -79,25 +84,32 @@ def print_metrics(replica_status):
            replica_status['wsrep_local_state_uuid'])
     metric('wsrep_local_state_comment', 'string',
            replica_status['wsrep_local_state_comment'])
+    metric('mysql_max_configured_connections', 'int64',
+           replica_status['max_connections'], 'connections')
+    metric('mysql_current_connections', 'int64',
+           replica_status['Threads_connected'], 'connections')
+    metric('mysql_max_seen_connections', 'int64',
+           replica_status['Max_used_connections'], 'connections')
 
 
 def main():
     options, _ = parse_args()
 
-    retcode, output, err = galera_status_check(
-        generate_query(options.host, options.port)
-    )
-
-    if retcode > 0:
-        status_err(err)
-
-    if not output:
-        status_err('No output received from mysql. Cannot gather metrics.')
-
-    show_status_list = output.split('\n')[1:-1]
     replica_status = {}
-    for i in show_status_list:
-        replica_status[i.split('\t')[0]] = i.split('\t')[1]
+    for output_type in ['status', 'variables']:
+        retcode, output, err = galera_check(
+            generate_query(options.host, options.port, output_type=output_type)
+        )
+
+        if retcode > 0:
+            status_err(err)
+
+        if not output:
+            status_err('No output received from mysql. Cannot gather metrics.')
+
+        show_list = output.split('\n')[1:-1]
+        for i in show_list:
+            replica_status[i.split('\t')[0]] = i.split('\t')[1]
 
     if replica_status['wsrep_cluster_status'] != "Primary":
         status_err("there is a partition in the cluster")


### PR DESCRIPTION
_NOTE: this is a partial cherry-pick (essentially without the template bits, and only the plugin bits) of the following (already merged) commit from master:_

_https://github.com/rcbops/rpc-openstack/commit/5b24196daa6112f711912bea928542f9ae0a23c9_

---
add some connection related metrics to galera_check plugin

Up to now, we've been grabbing specific matching data from the output
of 'SHOW STATUS'. This commit adds the output from 'SHOW VARIABLES', so
that we can grab the configuration vars too. Additionally, we no longer
limit the captured data from 'SHOW STATUS'.

Having all of the output from 'SHOW VARIABLES' and 'SHOW STATUS' will
make it easy to add any further metrics/alarms to this plugin in the
future.

Additionally, 'SHOW STATUS' was changed to 'SHOW GLOBAL STATUS' to
ensure we are gathering global stats as opposed to 'this session' stats.

Some new metrics are also added:

current_connections
max_configured_connections
max_seen_connections

Partially addresses: https://github.com/rcbops/rpc-openstack/issues/550