### PR TITLE
Update readme to explain current status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# RPC-MAAS IS NO LONGER MAINTAINED
+This repo has been superseded by <https://github.com/rcbops/rpc-openstack>
+
 **Please use the following rules when creating rcbops MaaS plugins:**
 
 1. Import errors result in an error status.


### PR DESCRIPTION
This repo is no longer maintained. The code it manages has been moved to
https://github.com/rcbops/rpc-openstack. This commit updates the readme
to make clear the repo's current status.