### PR TITLE
Set the vars to proper defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,7 +88,7 @@ maas_target_alias: public0_v4
 #
 # ssl_check: This flag indicates if the ssl-related checks and alarms should be deployed.
 #
-ssl_check: true
+ssl_check: false
 
 #
 # host_check: This flag indicates if the host-related hardware monitoring checks and alarms should


### PR DESCRIPTION
RPC-Openstack sets ssl_check to false in user variables and this
was never tested in gating with a different variable.

Let's adapt the default, and if needed later, increase test
coverage by adding a scenario to test this.