### PR TITLE
Allow the use of FQDNs in neutron_service_check.py

### DIFF
--- a/files/plugins/neutron_service_check.py
+++ b/files/plugins/neutron_service_check.py
@@ -36,6 +36,8 @@ def check(args):
     # gather nova service states
     if args.host:
         agents = neutron.list_agents(host=args.host)['agents']
+    elif args.fqdn:
+        agents = neutron.list_agents(host=args.fqdn)['agents']
     else:
         agents = neutron.list_agents()['agents']
 
@@ -51,6 +53,8 @@ def check(args):
 
         if args.host:
             name = '%s_status' % agent['binary']
+        elif args.fqdn:
+            name = '%z_status' % agent['binary']
         else:
             name = '%s_%s_on_host_%s' % (agent['binary'],
                                          agent['id'],
@@ -72,6 +76,10 @@ if __name__ == "__main__":
         parser.add_argument('--host',
                             type=str,
                             help='Only return metrics for specified host',
+                            default=None)
+        parser.add_argument('--fqdn',
+                            type=str,
+                            help='Only return metrics for specified fqdn',
                             default=None)
         args = parser.parse_args()
         main(args)

--- a/releasenotes/notes/neutron-service-check-uses-fqdn-d861768de0f95f92.yaml
+++ b/releasenotes/notes/neutron-service-check-uses-fqdn-d861768de0f95f92.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The neutron_service_check.py script was not recognizing Fully Qualified
+    Domain Names (FQDNS). This addresses the issue by passing the FQDN through
+    the checks to the script, and having the script check both the hostname 
+    and the FQDNs.

--- a/templates/neutron_dhcp_agent_check.yaml.j2
+++ b/templates/neutron_dhcp_agent_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}" "{{ internal_vip_address }}"]
 alarms      :
     neutron_dhcp_agent_status :
         label                   : neutron_dhcp_agent_status--{{ ansible_hostname }}

--- a/templates/neutron_l3_agent_check.yaml.j2
+++ b/templates/neutron_l3_agent_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--`fqdn", "{{ ansible_fqdn }}" "{{ internal_vip_address }}"]
 alarms      :
     neutron_l3_agent_status :
         label                   : neutron_l3_agent_status--{{ ansible_hostname }}

--- a/templates/neutron_linuxbridge_agent_check.yaml.j2
+++ b/templates/neutron_linuxbridge_agent_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}" "{{ internal_vip_address }}"]
 alarms      :
     neutron_linuxbridge_agent_status :
         label                   : neutron_linuxbridge_agent_status--{{ ansible_hostname }}

--- a/templates/neutron_metadata_agent_check.yaml.j2
+++ b/templates/neutron_metadata_agent_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}" "{{ internal_vip_address }}"]
 alarms      :
     neutron_metadata_agent_status :
         label                   : neutron_metadata_agent_status--{{ ansible_hostname }}


### PR DESCRIPTION
This change modifies the neutron_service_check.py plugin to
utilize the FQDN as an argument for checking neutron services.
It was previously only using the hostname.

Connects rcbops/rpc-openstack#1603