### PR TITLE
Add additional functional testing with haproxy

### DIFF
--- a/files/plugins/swift-recon.py
+++ b/files/plugins/swift-recon.py
@@ -73,7 +73,7 @@ def recon_output(for_ring, options=None):
                                                  '').strip().split("=")[1]
 
     # identify the container we will use for monitoring
-    get_container = shlex.split('lxc-ls -1 --running .*swift_proxy')
+    get_container = shlex.split('lxc-ls -1 --running ".*(swift_proxy|swift)"')
 
     try:
         containers_list = subprocess.check_output(get_container)

--- a/tests/ansible-role-requirements.yml
+++ b/tests/ansible-role-requirements.yml
@@ -79,7 +79,6 @@
   src: https://git.openstack.org/openstack/openstack-ansible-plugins
   scm: git
   version: stable/newton
-  version: stable/newton
 - name: haproxy_server
   src: https://git.openstack.org/openstack/openstack-ansible-haproxy_server
   scm: git

--- a/tests/ansible-role-requirements.yml
+++ b/tests/ansible-role-requirements.yml
@@ -79,3 +79,8 @@
   src: https://git.openstack.org/openstack/openstack-ansible-plugins
   scm: git
   version: stable/newton
+  version: stable/newton
+- name: haproxy_server
+  src: https://git.openstack.org/openstack/openstack-ansible-haproxy_server
+  scm: git
+  version: stable/newton

--- a/tests/host_vars/hap1.yaml
+++ b/tests/host_vars/hap1.yaml
@@ -13,20 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-neutron_provider_networks:
-  network_types: "vxlan,flat"
-  network_mappings: "flat:eth12"
-  network_vxlan_ranges: "1:1000"
-
-ansible_host: 10.1.1.101
-ansible_ssh_host: 10.1.1.101  # Added for compatibility
-tunnel_address: 10.2.1.101
-storage_address: 10.3.1.101
-
+ansible_host: 10.1.1.51
+ansible_ssh_host: 10.1.1.51  # Added for compatibility
 ansible_become: True
 ansible_user: root
-neutron_local_ip: "{{ ansible_host }}"
-
-swift_replication_address: 10.4.1.101
+tunnel_address: 10.2.1.51
+storage_address: 10.3.1.51
+swift_replication_address: 10.4.1.51
 
 swift_storage_address: "{{ storage_address }}"

--- a/tests/host_vars/infra1.yml
+++ b/tests/host_vars/infra1.yml
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 ansible_host: 10.1.1.201
+ansible_ssh_host: 10.1.1.201  # Added for compatibility
 ansible_become: True
 ansible_user: root
 tunnel_address: 10.2.1.201

--- a/tests/host_vars/infra2.yml
+++ b/tests/host_vars/infra2.yml
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 ansible_host: 10.1.1.202
+ansible_ssh_host: 10.1.1.202  # Added for compatibility
 ansible_become: True
 ansible_user: root
 tunnel_address: 10.2.1.202

--- a/tests/host_vars/infra3.yml
+++ b/tests/host_vars/infra3.yml
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 ansible_host: 10.1.1.203
+ansible_ssh_host: 10.1.1.203  # Added for compatibility
 ansible_become: True
 ansible_user: root
 tunnel_address: 10.2.1.203

--- a/tests/host_vars/localhost.yml
+++ b/tests/host_vars/localhost.yml
@@ -23,6 +23,7 @@ neutron_provider_networks:
   network_vxlan_ranges: "1:1000"
 
 ansible_host: 10.1.1.1
+ansible_ssh_host: 10.1.1.1  # Added for compatibility
 tunnel_address: 10.2.1.1
 storage_address: 10.3.1.1
 neutron_local_ip: "{{ ansible_host }}"

--- a/tests/host_vars/swift1.yml
+++ b/tests/host_vars/swift1.yml
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 ansible_host: 10.1.1.151
+ansible_ssh_host: 10.1.1.151  # Added for compatibility
 ansible_become: True
 ansible_user: root
 tunnel_address: 10.2.1.151

--- a/tests/inventory
+++ b/tests/inventory
@@ -5,11 +5,13 @@ localhost ansible_become=True ansible_connection=local ansible_user=root
 infra1
 openstack1
 swift1
+hap1
 
 [all_containers]
 infra1
 openstack1
 swift1
+hap1
 
 [hosts]
 localhost
@@ -20,17 +22,26 @@ localhost
 
 #### INFRA START HERE
 
-[rabbitmq_all]
-infra1
-
 [galera]
 infra1
 
 [galera_all:children]
 galera
 
+[haproxy]
+hap1
+
+[haproxy_all:children]
+haproxy
+
 [memcached_all]
 infra1
+
+[rabbitmq]
+infra1
+
+[rabbitmq_all:children]
+rabbitmq
 
 [service_all:children]
 rabbitmq_all

--- a/tests/rpc-maas-overrides.yml
+++ b/tests/rpc-maas-overrides.yml
@@ -31,10 +31,12 @@ bridges:
 
 
 # Set the vip address
-external_lb_vip_address: 127.0.0.1
-internal_lb_vip_address: 127.0.0.1
+external_lb_vip_address: 10.1.1.51
+internal_lb_vip_address: 10.2.1.51
 internal_vip_address: "{{ internal_lb_vip_address }}"
 
+# Define the galera monitoring user
+galera_monitoring_user: monitoring
 
 # In order to use loopback devices we set this line
 lxc_container_config_list:

--- a/tests/test-install-haproxy.yml
+++ b/tests/test-install-haproxy.yml
@@ -1,0 +1,235 @@
+---
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Add haproxy config
+  hosts: haproxy
+  gather_facts: true
+  user: root
+  roles:
+    - role: "haproxy_server"
+      haproxy_service_configs: "{{ haproxy_default_services + haproxy_extra_services|default([]) }}"
+  vars:
+    haproxy_default_services:
+      - service:
+          haproxy_service_name: galera
+          haproxy_backend_nodes: "{{ [groups['galera_all'][0]] | default([]) }}"  # list expected
+          haproxy_bind: "{{ [internal_lb_vip_address] }}"
+          haproxy_port: 3306
+          haproxy_balance_type: tcp
+          haproxy_timeout_client: 5000s
+          haproxy_timeout_server: 5000s
+          haproxy_backend_options:
+            - "mysql-check user {{ galera_monitoring_user }}"
+      - service:
+          haproxy_service_name: repo_git
+          haproxy_backend_nodes: "{{ groups['repo_all'] | default([]) }}"
+          haproxy_bind: "{{ [internal_lb_vip_address] }}"
+          haproxy_port: 9418
+          haproxy_balance_type: tcp
+          haproxy_backend_options:
+            - tcp-check
+      - service:
+          haproxy_service_name: repo_all
+          haproxy_backend_nodes: "{{ groups['repo_all'] | default([]) }}"
+          haproxy_bind: "{{ [internal_lb_vip_address] }}"
+          haproxy_port: 8181
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk HEAD /"
+      - service:
+          haproxy_service_name: repo_cache
+          haproxy_backend_nodes: "{{ groups['repo_all'] | default([]) }}"  # list expected
+          haproxy_bind: "{{ [internal_lb_vip_address] }}"
+          haproxy_port: 3142
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk HEAD /acng-report.html"
+      - service:
+          haproxy_service_name: glance_api
+          haproxy_backend_nodes: "{{ groups['glance_api'] | default([]) }}"
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_port: 9292
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk /healthcheck"
+      - service:
+          haproxy_service_name: glance_registry
+          haproxy_backend_nodes: "{{ groups['glance_registry'] | default([]) }}"
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_port: 9191
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk /healthcheck"
+      - service:
+          haproxy_service_name: gnocchi
+          haproxy_backend_nodes: "{{ groups['gnocchi_all'] | default([]) }}"
+          haproxy_port: 8041
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk /healthcheck"
+      - service:
+          haproxy_service_name: heat_api_cfn
+          haproxy_backend_nodes: "{{ groups['heat_api_cfn'] | default([]) }}"
+          haproxy_port: 8000
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk HEAD /"
+      - service:
+          haproxy_service_name: heat_api_cloudwatch
+          haproxy_backend_nodes: "{{ groups['heat_api_cloudwatch'] | default([]) }}"
+          haproxy_port: 8003
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk HEAD /"
+      - service:
+          haproxy_service_name: heat_api
+          haproxy_backend_nodes: "{{ groups['heat_api'] | default([]) }}"
+          haproxy_port: 8004
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk HEAD /"
+      - service:
+          haproxy_service_name: keystone_service
+          haproxy_backend_nodes: "{{ groups['keystone_all'] | default([])  }}"
+          haproxy_port: 5000
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_balance_type: "http"
+          haproxy_backend_options:
+            - "httpchk HEAD /"
+      - service:
+          haproxy_service_name: keystone_admin
+          haproxy_backend_nodes: "{{ groups['keystone_all'] | default([])  }}"
+          haproxy_port: 35357
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_balance_type: "http"
+          haproxy_backend_options:
+            - "httpchk HEAD /"
+      - service:
+          haproxy_service_name: neutron_server
+          haproxy_backend_nodes: "{{ groups['neutron_server'] | default([]) }}"
+          haproxy_port: 9696
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk HEAD /"
+      - service:
+          haproxy_service_name: nova_api_metadata
+          haproxy_backend_nodes: "{{ groups['nova_api_metadata'] | default([]) }}"
+          haproxy_port: 8775
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk HEAD /"
+      - service:
+          haproxy_service_name: nova_api_os_compute
+          haproxy_backend_nodes: "{{ groups['nova_api_os_compute'] | default([]) }}"
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_port: 8774
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk HEAD /"
+      - service:
+          haproxy_service_name: nova_console
+          haproxy_backend_nodes: "{{ groups['nova_console'] | default([]) }}"
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_port: "{{ nova_console_port }}"
+          haproxy_balance_type: tcp
+          haproxy_timeout_client: 60m
+          haproxy_timeout_server: 60m
+          haproxy_balance_alg: source
+          haproxy_backend_options:
+            - tcp-check
+      - service:
+          haproxy_service_name: cinder_api
+          haproxy_backend_nodes: "{{ groups['cinder_api'] | default([]) }}"
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_port: 8776
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk HEAD /"
+      - service:
+          haproxy_service_name: horizon
+          haproxy_backend_nodes: "{{ groups['horizon_all'] | default([]) }}"
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_ssl_all_vips: true
+          haproxy_port: "{{ haproxy_ssl | ternary(443,80) }}"
+          haproxy_backend_port: 80
+          haproxy_redirect_http_port: 80
+          haproxy_balance_type: http
+          haproxy_balance_alg: source
+          haproxy_backend_options:
+            - "httpchk HEAD /"
+      - service:
+          haproxy_service_name: sahara_api
+          haproxy_backend_nodes: "{{ groups['sahara_api'] | default([]) }}"
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_balance_alg: source
+          haproxy_port: 8386
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk /healthcheck"
+      - service:
+          haproxy_service_name: swift_proxy
+          haproxy_backend_nodes: "{{ groups['swift_proxy'] | default([]) }}"
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_balance_alg: source
+          haproxy_port: 8080
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk /healthcheck"
+      - service:
+          haproxy_service_name: ceilometer_api
+          haproxy_backend_nodes: "{{ groups['ceilometer_api_container'] | default([]) }}"
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_port: 8777
+          haproxy_balance_type: tcp
+          haproxy_backend_options:
+            - tcp-check
+      - service:
+          haproxy_service_name: aodh_api
+          haproxy_backend_nodes: "{{ groups['aodh_api'] | default([]) }}"
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_port: 8042
+          haproxy_balance_type: tcp
+          haproxy_backend_options:
+            - tcp-check
+      - service:
+          haproxy_service_name: ironic_api
+          haproxy_backend_nodes: "{{ groups['ironic_api'] | default([]) }}"
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_port: 6385
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk GET /"
+      - service:
+          haproxy_service_name: rabbitmq_mgmt
+          haproxy_backend_nodes: "{{ groups['rabbitmq'] | default([]) }}"
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_port: 15672
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk HEAD /"
+      - service:
+          haproxy_service_name: magnum
+          haproxy_backend_nodes: "{{ groups['magnum_all'] | default([]) }}"
+          haproxy_ssl: "{{ haproxy_ssl }}"
+          haproxy_port: 9511
+          haproxy_balance_type: http
+          haproxy_backend_options:
+            - "httpchk GET /"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -19,6 +19,9 @@
 # Prepare the cinder-volumes VG
 - include: common/test-setup-cinder-localhost.yml
 
+# Install HAProxy
+- include: test-install-haproxy.yml
+
 # Install RabbitMQ/MariaDB
 - include: common/test-install-infra.yml
 


### PR DESCRIPTION
This change allows the testing infra to begin verifying the checks deployed. To do this we need to have haproxy running because maas has a hard dependency on load balancer based monitoring at the moment.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>