### PR TITLE
Provide more flexible and reliable apt repo config

### DIFF
--- a/tasks/maas_host_install.yml
+++ b/tasks/maas_host_install.yml
@@ -15,12 +15,16 @@
 
 - name: Add MaaS apt keys
   apt_key:
-    url: "{{ item.url }}"
+    id: "{{ item.hash_id | default(omit) }}"
+    keyserver: "{{ item.keyserver | default(omit) }}"
+    url: "{{ item.url | default(omit) }}"
     state: "{{ item.state }}"
   with_items: "{{ maas_apt_keys }}"
   when:
     - ansible_distribution == 'Ubuntu'
-    - maas_apt_keys is defined
+  register: add_repo_keys
+  until: add_repo_keys|success
+  retries: 3
 
 - name: Add Container repos
   apt_repository:
@@ -30,7 +34,6 @@
   with_items: "{{ maas_apt_repos }}"
   when:
     - ansible_distribution == 'Ubuntu'
-    - maas_apt_keys is defined
   register: add_repos
   until: add_repos|success
   retries: 3


### PR DESCRIPTION
This patch adds the ability to use a different apt
repository for the maas packages using an alternative
key set and URL configuration. This is to facilitate
the ability to artifact the MaaS apt repo and
configure RPC-O to use the artifacted repo instead of
the upstream source.

Retries are added to the apt key addition to improve
reliability and the conditional for the repo/key
additions are removed as the values are defaulted
and are therefore always defined.

Connects https://github.com/rcbops/u-suk-dev/issues/1657