### PR TITLE
Enable MaaS verify by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -536,20 +536,20 @@ maas_requires_pip_packages:
 # maas_pip_packages: These packages are installed inside the virtualenv.
 #
 maas_pip_packages:
+  - apache-libcloud<2.0.0
   - cryptography
   - ipaddr
   - lxml
   - psutil
-  - apache-libcloud<2.0.0
-  - rackspace-monitoring-cli
   - python-cinderclient
   - python-glanceclient
   - python-heatclient
   - python-keystoneclient
   - python-magnumclient
+  - python-memcached
   - python-neutronclient
   - python-novaclient
-  - python-memcached
+  - rackspace-monitoring-cli
   - requests
   - swift
   - waxeye

--- a/files/plugins/swift-recon.py
+++ b/files/plugins/swift-recon.py
@@ -66,11 +66,15 @@ def recon_output(for_ring, options=None):
     """
 
     # grab the current release
-    with open("/etc/openstack-release") as search:
-        for line in search:
-            if 'DISTRIB_RELEASE' in line:
-                openstack_version = line.replace('\"',
-                                                 '').strip().split("=")[1]
+    with open("/etc/openstack-release") as f:
+        for line in f.readlines():
+            if line.startswith('DISTRIB_RELEASE'):
+                openstack_version = line.split("=")[-1].strip()
+                break
+        else:
+            raise SystemExit(
+                'DISTRIB_RELEASE not found in "/etc/openstack-release"'
+            )
 
     # identify the container we will use for monitoring
     get_container = shlex.split('lxc-ls -1 --running ".*(swift_proxy|swift)"')

--- a/manual-test.rc
+++ b/manual-test.rc
@@ -30,5 +30,5 @@ export ANSIBLE_SSH_ARGS="-o ControlMaster=no \
   -o ForwardAgent=yes"
 
 echo "Run manual functional tests by executing the following:"
-echo "# ./.tox/functional/bin/ansible-playbook -i tests/inventory tests/test.yml"
+echo "# ./.tox/functional/bin/ansible-playbook -i tests/inventory -e @tests/common/test-vars.yml -e @tests/rpc-maas-overrides.yml tests/test.yml"
 

--- a/tasks/maas_host_agent_install_local.yml
+++ b/tasks/maas_host_agent_install_local.yml
@@ -35,6 +35,17 @@
     dest: "{{ maas_plugin_dir }}"
     delete: yes
 
+# NOTE(cloudnull): This should be replaced later, the plugin(s) are too rigid
+#                  and make too many assumptions based on 1 simple architecture.
+- name: Set RabbitMQ plugin deployed cluster size
+  lineinfile:
+    dest: "{{ maas_plugin_dir }}/rabbitmq_status.py"
+    regexp: "^CLUSTER_SIZE.*=.*"
+    line: "CLUSTER_SIZE={{ groups['rabbitmq_all'] | length }}"
+  when:
+    - "'rabbitmq_all' in groups"
+    - groups['rabbitmq_all'] | length > 0
+
 - name: Drop in wrapper script to run maas plugins in venv
   template:
     src: "run_plugin_in_venv.sh.j2"

--- a/tasks/maas_host_install.yml
+++ b/tasks/maas_host_install.yml
@@ -46,26 +46,33 @@
     cache_valid_time: 600
   with_items: "{{ maas_apt_packages }}"
 
+- name: Converge MaaS container pip packages
+  set_fact:
+    maas_requires_pip_packages: "{{ maas_requires_pip_packages | union(maas_pip_container_packages) }}"
+  when:
+    - "'lxc_hosts' in groups"
+    - inventory_hostname in groups['lxc_hosts']
+
 - name: Install requires pip packages
   pip:
-    name: "{{ item }}"
+    name: "{{ maas_requires_pip_packages | join(' ')}}"
     state: "{{ maas_pip_package_state }}"
     extra_args: "{{ pip_install_options | default('') }}"
   register: install_packages
   until: install_packages|success
   retries: 5
   delay: 2
-  with_items: "{{ maas_requires_pip_packages }}"
 
-- name: Update pip
-  pip:
-    name: pip
-    state: "{{ maas_pip_package_state }}"
-    virtualenv: "{{ maas_venv }}"
+- name: Converge MaaS container pip packages
+  set_fact:
+    maas_pip_packages: "{{ maas_pip_packages | union(maas_pip_container_packages) }}"
+  when:
+    - "'lxc_hosts' in groups"
+    - inventory_hostname in groups['lxc_hosts']
 
 - name: Install pip packages to venv
   pip:
-    name: "{{ item }}"
+    name: "{{ maas_pip_packages | join(' ') }}"
     state: "{{ maas_pip_package_state }}"
     extra_args: >-
       {{ (pip_install_upper_constraints is defined) | ternary('--constraint ' + pip_install_upper_constraints | default(''),'') }}
@@ -75,20 +82,3 @@
   until: install_pip_packages|success
   retries: 5
   delay: 2
-  with_items: "{{ maas_pip_packages }}"
-
-- name: Install pip packages for containers to venv
-  pip:
-    name: "{{ item }}"
-    state: "{{ maas_pip_package_state }}"
-    extra_args: >-
-      {{ (pip_install_upper_constraints is defined) | ternary('--constraint ' + pip_install_upper_constraints | default(''),'') }}
-      {{ pip_install_options | default('') }}
-    virtualenv: "{{ maas_venv }}"
-  register: install_pip_container_packages
-  until: install_pip_container_packages|success
-  retries: 5
-  delay: 2
-  with_items: "{{ maas_pip_container_packages }}"
-  when:
-    - inventory_hostname in groups['lxc_hosts']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,8 +40,6 @@
 
 - include: maas_host_monitoring.yml
   when:
-    - "'hosts' in groups"
-    - groups['hosts'] | length > 0
     - inventory_hostname in groups['hosts']
   tags:
     - maas-checks
@@ -55,7 +53,6 @@
 - include: maas_ceph.yml
   when:
     - "'ceph_all' in groups"
-    - groups['ceph_all'] | length > 0
     - inventory_hostname in groups['ceph_all']
   tags:
     - maas-checks

--- a/templates/neutron_dhcp_agent_check.yaml.j2
+++ b/templates/neutron_dhcp_agent_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}" "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_dhcp_agent_status :
         label                   : neutron_dhcp_agent_status--{{ ansible_hostname }}

--- a/templates/neutron_l3_agent_check.yaml.j2
+++ b/templates/neutron_l3_agent_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--`fqdn", "{{ ansible_fqdn }}" "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_l3_agent_status :
         label                   : neutron_l3_agent_status--{{ ansible_hostname }}

--- a/templates/neutron_linuxbridge_agent_check.yaml.j2
+++ b/templates/neutron_linuxbridge_agent_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}" "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_linuxbridge_agent_status :
         label                   : neutron_linuxbridge_agent_status--{{ ansible_hostname }}

--- a/templates/neutron_metadata_agent_check.yaml.j2
+++ b/templates/neutron_metadata_agent_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}" "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_metadata_agent_status :
         label                   : neutron_metadata_agent_status--{{ ansible_hostname }}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,5 +17,6 @@ reno>=1.8.0 # Apache-2.0
 sphinxmark>=0.1.14 # Apache-2.0
 
 # MaaS specific
+futures
 rackspace_monitoring
 waxeye

--- a/tests/ansible-role-requirements.yml
+++ b/tests/ansible-role-requirements.yml
@@ -51,6 +51,10 @@
   src: https://git.openstack.org/openstack/openstack-ansible-os_glance
   scm: git
   version: stable/newton
+- name: os_heat
+  src: https://git.openstack.org/openstack/openstack-ansible-os_heat
+  scm: git
+  version: stable/newton
 - name: os_horizon
   src: https://git.openstack.org/openstack/openstack-ansible-os_horizon
   scm: git

--- a/tests/inventory
+++ b/tests/inventory
@@ -67,7 +67,7 @@ openstack1
 openstack1
 
 [cinder_volume]
-localhost
+openstack1
 
 [cinder_all:children]
 cinder_api
@@ -122,7 +122,6 @@ openstack1
 
 [neutron_linuxbridge_agent]
 openstack1
-localhost
 
 [neutron_openvswitch_agent]
 
@@ -162,7 +161,7 @@ openstack1
 openstack1
 
 [nova_compute]
-localhost
+openstack1
 
 [nova_conductor]
 openstack1

--- a/tests/rpc-maas-overrides.yml
+++ b/tests/rpc-maas-overrides.yml
@@ -55,6 +55,8 @@ nova_console_ports:
 
 nova_console_port: "{{ nova_console_ports[nova_console_type] }}"
 
+neutron_metadata: True
+neutron_l3: True
 
 # This is used for RPC specific things and is required
 # NOTE(cloudnull): Before this was hardcoded, now it will look at the playbook path and
@@ -85,10 +87,15 @@ swift:
         index: 0
         default: True
 
+# Name of the virtual env to deploy into (maas)
+maas_venv: "/openstack/venvs/maas-{{ rpc_release }}"
+maas_venv_bin: "{{ maas_venv }}/bin"
 
 ####  Set testing venv tags ####
 # Set the venv tags for all services, This is done to
 #  ensure the installation and pathing are correct within RPC MaaS
+openstack_distrib_release: "testing"
+
 cinder_venv_tag: "testing"
 glance_venv_tag: "testing"
 heat_venv_tag: "testing"

--- a/tests/test-rpc-maas-functional.yml
+++ b/tests/test-rpc-maas-functional.yml
@@ -1,0 +1,47 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Verify MaaS
+  hosts: localhost
+  user: root
+  gather_facts: false
+  tasks:
+    - name: Ensure log directories
+      file:
+        path: "{{ workspace_logs }}"
+        state: "directory"
+        mode: "0755"
+    - name: Create log link
+      file:
+        src: "{{ workspace_logs }}"
+        dest: "{{ working_dir_logs }}"
+        state: link
+    - name: Retrieve checks
+      command: "cp -R /etc/rackspace-monitoring-agent.conf.d {{ workspace_logs }}/"
+    - name: Clone RPC-O
+      git:
+        repo: 'https://github.com/rcbops/rpc-openstack'
+        dest: /tmp/rpco
+        version: master
+    - name: Run MaaS verify local
+      command: "{{ maas_venv_bin }}/python /tmp/rpco/scripts/rpc-maas-tool.py --logfile {{ workspace_logs }}/rpc-maas-logs.txt verify-local"
+      become: true
+      register: maas_verify
+      until: maas_verify | success
+      retries: 3
+      delay: 5
+  vars:
+    working_dir_logs: "{{ lookup('env', 'WORKING_DIR') | default('/tmp', true) }}/logs"
+    workspace_logs: "{{ lookup('env', 'WORKING_DIR') | default('/tmp', true) }}/../../logs"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -43,5 +43,11 @@
 # Install Nova
 - include: common/test-install-nova.yml
 
+# Install Heat
+- include: common/test-install-heat.yml
+
 # Install rpc-maas
 - include: test-install-rpc-maas.yml
+
+# Ensure all plugins are functional
+- include: test-rpc-maas-functional.yml


### PR DESCRIPTION
This change allows maas to run verify-local on all checks post
deployment. This ensures that maas is now gating on a full convergence
test and that all of the checks being deployed will work as intended in
an OpenStack cloud.

Notes:
  * Heat has been added to the installation becuase it is required by
    MaaS at this time.
  * A new functional playbook has been added to exercise maas.
  * changes to the swift and rabbitmq plug was needed because it was far
    too rigid and could not be tested outside of the larger RPC
    deployment.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>