### PR TITLE
Replace glanceclient with openstacksdk

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -546,6 +546,7 @@ maas_pip_packages:
   - psutil<=1.2.1
   - apache-libcloud<2.0.0
   - rackspace-monitoring-cli
+  - openstacksdk
   - python-cinderclient
   - python-glanceclient
   - python-heatclient

--- a/files/plugins/glance_api_local_check.py
+++ b/files/plugins/glance_api_local_check.py
@@ -16,12 +16,9 @@
 
 import argparse
 import collections
-import ipaddr
 import time
 
-from glanceclient import exc as exc
-from maas_common import get_auth_ref
-from maas_common import get_glance_client
+from maas_common import get_openstack_conn
 from maas_common import metric
 from maas_common import metric_bool
 from maas_common import print_output
@@ -32,31 +29,20 @@ from maas_common import status_ok
 IMAGE_STATUSES = ['active', 'queued', 'killed']
 
 
-def check(auth_ref, args):
-    GLANCE_ENDPOINT = (
-        'http://{ip}:9292/v1'.format(ip=args.ip)
-    )
-
+def check(args):
     try:
-        if args.ip:
-            glance = get_glance_client(endpoint=GLANCE_ENDPOINT)
-        else:
-            glance = get_glance_client()
-
+        conn = get_openstack_conn()
         is_up = True
-    except exc.HTTPException:
-        is_up = False
-    # Any other exception presumably isn't an API error
+    # Catching all Exceptions
     except Exception as e:
         status_err(str(e))
     else:
-        # time something arbitrary
+        # Time something arbitrary
         start = time.time()
-        glance.images.list(search_opts={'all_tenants': 1})
+        images = conn.image.images(search_opts={'all_tenants': 1})
         end = time.time()
         milliseconds = (end - start) * 1000
         # gather some metrics
-        images = glance.images.list(search_opts={'all_tenants': 1})
         status_count = collections.Counter([s.status for s in images])
 
     status_ok()
@@ -76,16 +62,12 @@ def check(auth_ref, args):
 
 
 def main(args):
-    auth_ref = get_auth_ref()
-    check(auth_ref, args)
+    check(args)
 
 
 if __name__ == "__main__":
     with print_output():
         parser = argparse.ArgumentParser(description="Check Glance API against"
                                          " local or remote address")
-        parser.add_argument('ip', nargs='?',
-                            type=ipaddr.IPv4Address,
-                            help='Optional Glance API server address')
         args = parser.parse_args()
         main(args)

--- a/templates/glance_api_local_check.yaml.j2
+++ b/templates/glance_api_local_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}glance_api_local_check.py", "{{ ansible_ssh_host }}"]
+    args    : ["{{ maas_plugin_dir }}glance_api_local_check.py"]
 alarms      :
     glance_api_local_status :
         label                   : glance_api_local_status--{{ ansible_hostname }}


### PR DESCRIPTION
This commit is the first of serveral in an effort to replace
all openstack service clients with the openstacksdk. This commit
does the following:

* Adds the get_openstack_conn() method to maas_common.py. This
  method returns back the Connection object required to perform
  operations on openstack resource objects.
* Modifies the glance_api_local_check plugin to use the openstacksdk
  instead of querying the glance endpoint directly.
* Adds the openstacksdk pip package to defaults/main.