### PR TITLE
Move internal_vip_address to defaults/main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -660,5 +660,7 @@ swift_service_in_ldap: false
 holland_venv_enabled: true
 holland_venv_bin: "/openstack/venvs/holland-{{ rpc_release }}/bin"
 
+internal_vip_address: "{{ internal_lb_vip_address }}"
+
 # Set the openstack-release to testing by default
 openstack_release: testing

--- a/tasks/maas_infra.yml
+++ b/tasks/maas_infra.yml
@@ -94,4 +94,3 @@
 - include: ensure_local_checks.yml
   vars:
     checks: "{{ infra_service_local_checks_list }}"
-    internal_vip_address: "{{ internal_lb_vip_address }}"

--- a/tests/rpc-maas-overrides.yml
+++ b/tests/rpc-maas-overrides.yml
@@ -33,7 +33,6 @@ bridges:
 # Set the vip address
 external_lb_vip_address: 10.1.1.51
 internal_lb_vip_address: 10.2.1.51
-internal_vip_address: "{{ internal_lb_vip_address }}"
 
 # Define the galera monitoring user
 galera_monitoring_user: monitoring


### PR DESCRIPTION
This variables is used in various places throughout the role.
Moving it to defaults/main.yml ensures it's available to all
tasks.

This also solves the problem of some tasks not having scope to this variable.
Without this change, the following errors occur:
https://gist.github.com/anonymous/98d41a5bc0b0aaae6299c1b203c0b412