### PR TITLE
Filter out QEMU DVD-ROM from disk_util_devices

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -73,7 +73,7 @@ maas_checks:
 _maas_host_disk_utilisation_alarms: |
   {% set disk_util_devices = [] %}
   {% for device in ansible_devices.keys() %}
-  {%   if (device not in maas_excluded_devices | default([])) and (ansible_devices[device].model != 'VIRTUAL-DISK') %}
+  {%   if (device not in maas_excluded_devices | default([])) and (ansible_devices[device].model != 'VIRTUAL-DISK') and (ansible_devices[device].model != 'QEMU DVD-ROM') %}
   {%     set _ = disk_util_devices.append(device) %}
   {%   endif %}
   {% endfor %}


### PR DESCRIPTION
This commit filters out QEMU DVD-ROM devices from the
disk_util_devices list, in turn removing them from
being included in alarm criteria for the disk_utilisation
plugin.

Connects https://github.com/rcbops/rpc-openstack/issues/2255