### PR TITLE
Fix RabbitMQ status plugin for swift-only control planes

### DIFF
--- a/files/plugins/rabbitmq_status.py
+++ b/files/plugins/rabbitmq_status.py
@@ -18,6 +18,7 @@
 import optparse
 import subprocess
 
+from itertools import chain
 from maas_common import metric
 from maas_common import metric_bool
 from maas_common import print_output
@@ -113,8 +114,8 @@ def _get_connection_metrics(session, metrics, host, port):
 
     response = _get_rabbit_json(session, CONNECTIONS_URL % (host, port))
 
-    max_chans = max(connection['channels'] for connection in response
-                    if 'channels' in connection)
+    max_chans = max(chain(connection['channels'] for connection in response
+                    if 'channels' in connection), [0])
     for k in CONNECTIONS_METRICS:
         metrics[k] = {'value': max_chans, 'unit': CONNECTIONS_METRICS[k]}
 


### PR DESCRIPTION
This commit fixes a `ValueError: max() arg is an empty sequence` error
encountered in some environments.  This error is triggered when the plugin
runs while there are no connections reported by RabbitMQ, which is an expected
scenario in a swift-only or keystone-only environment.

The change effectively adds a '0' default to max()'s arguments.

Connects: #253