### PR TITLE
Catch BadOutputError exception in the event of a HP RAID Battery fail…

### DIFF
--- a/files/plugins/hp_monitoring.py
+++ b/files/plugins/hp_monitoring.py
@@ -63,8 +63,11 @@ def get_controller_cache_status():
 
 
 def get_controller_battery_status():
+   try:
     return check_command(('hpssacli', 'ctrl', 'all', 'show', 'status'),
                          'Battery/Capacitor Status', 'OK')
+   except BadOutputError as e:
+    print e.message
 
 
 def main():


### PR DESCRIPTION
At the moment whenever a HP RAID battery fails, all other hardware checks are unable to complete.

```
root@computehost:~# python /usr/lib/rackspace-monitoring-agent/plugins/hp_monitoring.py 
status error ng.py", line 41, in check_command\n    'The output was not in the expected format:\n%s' % output)\nBadOutputError: The output was not in the expected format:\n\nSmart Array P840 in Slot 3\n   Controller Status: OK\n   Cache Status: Permanently Disabled\n\n\n\n
Traceback (most recent call last):
  File "/usr/lib/rackspace-monitoring-agent/plugins/hp_monitoring.py", line 87, in <module>
    main()
  File "/usr/lib/rackspace-monitoring-agent/plugins/hp_monitoring.py", line 78, in main
    get_controller_battery_status()
  File "/usr/lib/rackspace-monitoring-agent/plugins/hp_monitoring.py", line 67, in get_controller_battery_status
    'Battery/Capacitor Status', 'OK')
  File "/usr/lib/rackspace-monitoring-agent/plugins/hp_monitoring.py", line 41, in check_command
    'The output was not in the expected format:\n%s' % output)
__main__.BadOutputError: The output was not in the expected format:

Smart Array P840 in Slot 3
   Controller Status: OK
   Cache Status: Permanently Disabled
```

Catching the exceptions allows the script to complete