### PR TITLE
Adding try-catch for HP commands

### DIFF
--- a/files/plugins/hp_monitoring.py
+++ b/files/plugins/hp_monitoring.py
@@ -23,22 +23,22 @@ class BadOutputError(maas_common.MaaSException):
 
 
 def check_command(command, startswith, endswith):
-    output = subprocess.check_output(command)
-    lines = output.split('\n')
-    matches = False
-    for line in lines:
-        line = line.strip()
-        if line.startswith(startswith):
-            matches = True
-            if not line.endswith(endswith):
-                status = 0
-                break
-    else:
-        if matches:
-            status = 1
+    status = 0
+    try:
+        output = subprocess.check_output(command)
+        lines = output.split('\n')
+        matches = False
+        for line in lines:
+            line = line.strip()
+            if line.startswith(startswith):
+                matches = True
+                if not line.endswith(endswith):
+                    break
         else:
-            raise BadOutputError(
-                'The output was not in the expected format:\n%s' % output)
+            if matches:
+                status = 1
+    except:
+        pass
     return status
 
 


### PR DESCRIPTION
This fix add a try catch for a given HP utility command
and returns false if the output did not match expectations.
This also solves issues where output is omitted,
for example the RAID battery issue, leading to BadOutputError.

Closing-Bug: rcbops/u-suk-dev#1241