### PR TITLE
Fix default value for for max_chans metric

### DIFF
--- a/files/plugins/rabbitmq_status.py
+++ b/files/plugins/rabbitmq_status.py
@@ -117,7 +117,7 @@ def _get_connection_metrics(session, metrics, host, port):
     response = _get_rabbit_json(session, CONNECTIONS_URL % (host, port))
 
     max_chans = max(chain(connection['channels'] for connection in response
-                    if 'channels' in connection), [0])
+                    if 'channels' in connection), '0')
     for k in CONNECTIONS_METRICS:
         metrics[k] = {'value': max_chans, 'unit': CONNECTIONS_METRICS[k]}
 


### PR DESCRIPTION
The default for max_chans should be a bare '0' value, not a single-item list.
Prior to this commit, the plugin returns the '0' in a list, which the MaaS
agent won't parse.

Closes: #253