### PR TITLE
Build in Ansible 1.9 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,19 @@ Example usage with OpenStack-Ansible
     openstack-ansible playbooks/site.yml
 
 
+Running with Ansible 1.9 with OpenStack-Ansible
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Prior to running with Ansible 1.9 with OpenStack-Ansible (using the Mitaka, Liberty, Kilo)
+export the Role and Library path prior to running the playbooks.
+
+.. code-block:: bash
+
+    export ANSIBLE_ROLES_PATH=/opt/openstack-ansible/playbooks/roles
+    export ANSIBLE_LIBRARY=/opt/openstack-ansible/playbooks/library
+    echo 'ansible_host: "{{ ansible_ssh_host }}"' | tee -a /etc/openstack_deploy/user_variables.yml
+
+
 Validating the deployment
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -84,8 +84,8 @@ After deployment you can run a local validation playbook to ensure that
 everything is working as expected which can be done with static inventory
 as well as within an OpenStack-Ansible deployment.
 
-
-**With OpenStack-Ansible**
+With OpenStack-Ansible
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -96,7 +96,38 @@ as well as within an OpenStack-Ansible deployment.
     openstack-ansible playbooks/maas-verify.yml
 
 
-**With Static Inventory**
+Running with Ansible 1.9 and OpenStack-Ansible
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Prior to running with Ansible 1.9 with OpenStack-Ansible (using the Mitaka,
+Liberty, Kilo) export the Role and Library path prior to running the
+playbooks.
+
+.. code-block:: bash
+
+    export ANSIBLE_ROLES_PATH=/opt/openstack-ansible/playbooks/roles
+    export ANSIBLE_LIBRARY=/opt/openstack-ansible/playbooks/library
+
+
+The variable ``ansible_ssh_host`` needs to be set within the
+``user_variables.yml`` file.
+
+.. code-block:: bash
+
+    echo 'ansible_host: "{{ ansible_ssh_host }}"' | tee -a /etc/openstack_deploy/user_variables.yml
+
+
+In order to enable console auth checking set the ``nova_console_type`` and
+``nova_console_port`` variables in your ``user_variables.yml`` file.
+
+.. code-block:: bash
+
+    echo 'nova_console_type: spice' | tee -a /etc/openstack_deploy/user_variables.yml
+    echo 'nova_console_port: 6082' | tee -a /etc/openstack_deploy/user_variables.yml
+
+
+With Static Inventory
+~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -112,7 +143,6 @@ This role supports several high level tags: ``maas``, ``maas-agent``,
 ``maas-openstack``. Within each group a tag exists for a specific playbook.
 This gives the deployer the ability to control orchestration even when
 running the general ``site.yml`` playbook.
-
 
 
 Paybook Specific Notes

--- a/playbooks/common-tasks/maas-host-vendor-dell.yml
+++ b/playbooks/common-tasks/maas-host-vendor-dell.yml
@@ -15,7 +15,7 @@
 
 - name: Install openmanage memory checks
   template:
-    src: "openmanage-memory.yaml.j2"
+    src: "templates/openmanage-memory.yaml.j2"
     dest: "/etc/rackspace-monitoring-agent.conf.d/openmanage-memory--{{ inventory_hostname }}.yaml"
     owner: "root"
     group: "root"
@@ -27,7 +27,7 @@
 
 - name: Install openmanage processors checks
   template:
-    src: "openmanage-processors.yaml.j2"
+    src: "templates/openmanage-processors.yaml.j2"
     dest: "/etc/rackspace-monitoring-agent.conf.d/openmanage-processors--{{ inventory_hostname }}.yaml"
     owner: "root"
     group: "root"
@@ -39,7 +39,7 @@
 
 - name: Install openmanage vdisk checks
   template:
-    src: "openmanage-vdisk.yaml.j2"
+    src: "templates/openmanage-vdisk.yaml.j2"
     dest: "/etc/rackspace-monitoring-agent.conf.d/openmanage-vdisk--{{ inventory_hostname }}.yaml"
     owner: "root"
     group: "root"

--- a/playbooks/common-tasks/maas-host-vendor-hp.yml
+++ b/playbooks/common-tasks/maas-host-vendor-hp.yml
@@ -15,7 +15,7 @@
 
 - name: Install hp checks
   template:
-    src: "hp-check.yaml.j2"
+    src: "templates/hp-check.yaml.j2"
     dest: "/etc/rackspace-monitoring-agent.conf.d/hp-check--{{ inventory_hostname }}.yaml"
     owner: "root"
     group: "root"

--- a/playbooks/common-tasks/maas_get_openrc.yml
+++ b/playbooks/common-tasks/maas_get_openrc.yml
@@ -13,7 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Restart rax-maas
-  add_host:
-    name: "{{ physical_host | default(ansible_host) }}"
-    groups: maas_restart_on_host
+- name: Retrieve openrc file
+  slurp:
+    src: /root/openrc
+  register: openrc_data
+  delegate_to: "{{ groups['utility_all'][0] }}"
+
+- name: Register a fact for the openrc
+  set_fact:
+     openrc_fact: "{{ openrc_data.content }}"
+
+- name: Distribute openrc
+  copy:
+    dest: "/root/openrc"
+    content: "{{ openrc_fact | b64decode }}"
+    mode: "0640"
+  delegate_to: "{{ physical_host | default(ansible_host) }}"

--- a/playbooks/files/pip-constraints.txt
+++ b/playbooks/files/pip-constraints.txt
@@ -1,11 +1,10 @@
-### Monitorstack plugin framework
-git+https://github.com/openstack/monitorstack@master#egg=monitorstack
-
 ### Requirements for RAX-MaaS
 apache-libcloud<2.0.0
 cryptography==1.5
+httplib2==0.9.2
 ipaddr==2.1.11
-lxml===3.6.4
+lxml==3.6.4
+lxc-python2==0.1
 psutil==5.2.2
 
 ### TO BE REPLACED BY MONITORSTACK
@@ -16,6 +15,7 @@ python-keystoneclient==3.5.1
 python-magnumclient==2.3.1
 python-neutronclient==6.0.0
 python-novaclient==6.0.1
+python-openstackclient==3.2.1
 ### TO BE REPLACED BY MONITORSTACK
 
 ### General dependencies

--- a/playbooks/maas-agent-install.yml
+++ b/playbooks/maas-agent-install.yml
@@ -42,12 +42,9 @@
           skip: true
 
     - name: Include distro install tasks
-      include: "{{ item }}"
-      with_first_found:
-        - files:
-            - "common-tasks/maas-agent-{{ ansible_distribution | lower }}-install.yml"
-            - "common-tasks/maas-agent-{{ ansible_os_family | lower }}-install.yml"
-          skip: true
+      include: "common-tasks/maas-agent-ubuntu-install.yml"
+      when:
+        - ansible_distribution | lower == 'ubuntu'
 
     - name: Converge MaaS container pip packages
       set_fact:
@@ -101,3 +98,7 @@
     - vars/maas-{{ ansible_distribution | lower }}.yml
   tags:
     - maas-agent-install
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-agent-setup.yml
+++ b/playbooks/maas-agent-setup.yml
@@ -54,7 +54,7 @@
 
     - name: Drop in wrapper script to run maas plugins in venv
       template:
-        src: "run_plugin_in_venv.sh.j2"
+        src: "templates/run_plugin_in_venv.sh.j2"
         dest: "{{ maas_plugin_dir }}/run_plugin_in_venv.sh"
         owner: "root"
         group: "root"
@@ -67,13 +67,6 @@
         owner: "root"
         group: "root"
         mode: "0755"
-
-  roles:
-    - role: "openstack_openrc"
-      when:
-        - maas_openstack_install | bool
-      tags:
-        - openrc
 
   post_tasks:
     - name: Assign agent ID to entity
@@ -126,3 +119,7 @@
     - vars/maas-agent.yml
   tags:
     - maas-agent-setup
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-ceph-mon.yml
+++ b/playbooks/maas-ceph-mon.yml
@@ -64,3 +64,7 @@
     - vars/main.yml
   tags:
     - maas-ceph-mons
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-ceph-osd.yml
+++ b/playbooks/maas-ceph-osd.yml
@@ -49,3 +49,7 @@
     - vars/main.yml
   tags:
     - maas-ceph-osds
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-container-storage.yml
+++ b/playbooks/maas-container-storage.yml
@@ -14,20 +14,47 @@
 # limitations under the License.
 
 - name: Gather facts
-  hosts: all_containers
+  hosts: hosts
   gather_facts: "{{ gather_facts | default(true) }}"
-  tasks:
+  pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+
+  tasks:
+    - name: Copy over pip constraints
+      copy:
+        src: "files/pip-constraints.txt"
+        dest: "/tmp/pip-constraints.txt"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+  post_tasks:
+    - name: Install glance pip packages to venv
+      pip:
+        name: "{{ maas_container_pip_packages | join(' ') }}"
+        state: "{{ maas_pip_package_state }}"
+        extra_args: >-
+          --isolated
+          --constraint /tmp/pip-constraints.txt
+          {{ pip_install_options | default('') }}
+        virtualenv: "{{ maas_venv }}"
+      register: install_pip_packages
+      until: install_pip_packages|success
+      retries: 5
+      delay: 2
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas-container.yml
   tags:
     - maas-container-storage
 
 - name: Install checks for infra memcached
-  hosts: all_containers
+  hosts: hosts
   gather_facts: false
   tasks:
     - name: Install local checks
       template:
-        src: "container_storage_checks.yaml.j2"
+        src: "templates/container_storage_checks.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/container_storage_check--{{ inventory_hostname }}.yaml"
         owner: "root"
         group: "root"
@@ -46,3 +73,7 @@
     - vars/maas-container.yml
   tags:
     - maas-container-storage
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-host-cdm.yml
+++ b/playbooks/maas-host-cdm.yml
@@ -75,3 +75,7 @@
     - vars/maas-host.yml
   tags:
     - maas-ceph-osds
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-host-kernel.yml
+++ b/playbooks/maas-host-kernel.yml
@@ -42,3 +42,7 @@
     - vars/maas-host.yml
   tags:
     - maas-hosts-kernel
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-host-network.yml
+++ b/playbooks/maas-host-network.yml
@@ -63,3 +63,7 @@
     - vars/maas-host.yml
   tags:
     - maas-hosts-network
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-host-vendor.yml
+++ b/playbooks/maas-host-vendor.yml
@@ -20,14 +20,17 @@
     - include: "common-tasks/maas_excluded_regex.yml"
 
   post_tasks:
-    - name: Gather variables for each operating system
-      include: "{{ item }}"
-      with_first_found:
-        - files:
-            - "common-tasks/maas-host-vendor-{{ ansible_system_vendor.split()[0] | lower }}.yml"
-          skip: true
+    - name: Run HP tasks
+      include: "common-tasks/maas-host-vendor-hp.yml"
       when:
         - maas_host_check | bool
+        - ansible_system_vendor.split()[0] | lower == 'hp'
+
+    - name: Run DELL tasks
+      include: "common-tasks/maas-host-vendor-dell.yml"
+      when:
+        - maas_host_check | bool
+        - ansible_system_vendor.split()[0] | lower == 'dell'
 
   handlers:
     - include: handlers/main.yml
@@ -35,3 +38,7 @@
     - vars/main.yml
   tags:
     - maas-hosts-vendor
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-infra-elasticsearch.yml
+++ b/playbooks/maas-infra-elasticsearch.yml
@@ -43,3 +43,7 @@
     - vars/maas-infra.yml
   tags:
     - maas-infra-elasticsearch
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-infra-filebeat.yml
+++ b/playbooks/maas-infra-filebeat.yml
@@ -46,3 +46,7 @@
     - vars/maas-infra.yml
   tags:
     - maas-infra-filebeat
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-infra-galera.yml
+++ b/playbooks/maas-infra-galera.yml
@@ -33,13 +33,10 @@
             - "vars/maas-{{ ansible_os_family | lower }}.yml"
           skip: true
 
-    - name: Include distro install tasks
-      include: "{{ item }}"
-      with_first_found:
-        - files:
-            - "common-tasks/maas-infra-{{ ansible_distribution | lower }}-install.yml"
-            - "common-tasks/maas-infra-{{ ansible_os_family | lower }}-install.yml"
-          skip: true
+    - name: Include ubuntu install tasks
+      include: "common-tasks/maas-infra-ubuntu-install.yml"
+      when:
+        - ansible_distribution | lower == 'ubuntu'
 
     - name: Check for holland
       stat:
@@ -92,3 +89,7 @@
     - vars/maas-infra.yml
   tags:
     - maas-infra-galera
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-infra-lb-ssl.yml
+++ b/playbooks/maas-infra-lb-ssl.yml
@@ -44,3 +44,7 @@
     - vars/main.yml
   tags:
     - maas-infra-lb-ssl
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-infra-memcached.yml
+++ b/playbooks/maas-infra-memcached.yml
@@ -27,7 +27,7 @@
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
   post_tasks:
-    - name: Install glance pip packages to venv
+    - name: Install memcached pip packages to venv
       pip:
         name: "{{ maas_memcached_pip_packages | join(' ') }}"
         state: "{{ maas_pip_package_state }}"
@@ -69,3 +69,7 @@
     - vars/main.yml
   tags:
     - maas-infra-memcached
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-infra-rabbitmq.yml
+++ b/playbooks/maas-infra-rabbitmq.yml
@@ -16,8 +16,24 @@
 - name: Gather facts
   hosts: rabbitmq_all
   gather_facts: "{{ gather_facts | default(true) }}"
-  tasks:
+  pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+
+  tasks:
+    - name: Install rabbitmq pip packages
+      pip:
+        name: "{{ maas_rabbitmq_pip_packages | join(' ') }}"
+        state: "{{ maas_pip_package_state }}"
+        extra_args: >-
+          {{ pip_install_options | default('') }}
+      register: install_pip_packages
+      until: install_pip_packages|success
+      retries: 5
+      delay: 2
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas-infra.yml
   tags:
     - maas-infra-rabbitmq
 
@@ -81,3 +97,7 @@
     - vars/maas-infra.yml
   tags:
     - maas-infra-rabbitmq
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-infra-rsyslogd.yml
+++ b/playbooks/maas-infra-rsyslogd.yml
@@ -43,3 +43,7 @@
     - vars/maas-infra.yml
   tags:
     - maas-infra-rsyslog
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-openstack-cinder.yml
+++ b/playbooks/maas-openstack-cinder.yml
@@ -18,6 +18,7 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - include: "common-tasks/maas_get_openrc.yml"
 
   tasks:
     - name: Copy over pip constraints
@@ -112,7 +113,7 @@
   tasks:
     - name: Install cinder backup checks
       template:
-        src: "cinder_backup_check.yaml.j2"
+        src: "templates/cinder_backup_check.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/cinder_backup_check--{{ inventory_hostname }}.yaml"
         owner: "root"
         group: "root"
@@ -167,3 +168,7 @@
     - vars/maas-openstack.yml
   tags:
     - maas-openstack-cinder
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-openstack-glance.yml
+++ b/playbooks/maas-openstack-glance.yml
@@ -18,6 +18,7 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - include: "common-tasks/maas_get_openrc.yml"
 
   tasks:
     - name: Copy over pip constraints
@@ -106,3 +107,7 @@
     - vars/maas-openstack.yml
   tags:
     - maas-openstack-glance
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-openstack-heat.yml
+++ b/playbooks/maas-openstack-heat.yml
@@ -18,6 +18,7 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - include: "common-tasks/maas_get_openrc.yml"
 
   tasks:
     - name: Copy over pip constraints
@@ -155,3 +156,7 @@
     - vars/maas-openstack.yml
   tags:
     - maas-openstack-heat
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-openstack-horizon.yml
+++ b/playbooks/maas-openstack-horizon.yml
@@ -18,6 +18,8 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - include: "common-tasks/maas_get_openrc.yml"
+
   tags:
     - maas-openstack-horizon
 
@@ -56,3 +58,7 @@
     - vars/maas-openstack.yml
   tags:
     - maas-openstack-horizon
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-openstack-keystone.yml
+++ b/playbooks/maas-openstack-keystone.yml
@@ -18,6 +18,7 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - include: "common-tasks/maas_get_openrc.yml"
 
   tasks:
     - name: Copy over pip constraints
@@ -53,41 +54,29 @@
   gather_facts: false
   pre_tasks:
     - name: Create keystone user for monitoring
-      keystone:
-        command: "ensure_user"
-        endpoint: "{{ keystone_service_adminurl }}"
-        login_user: "{{ keystone_admin_user_name }}"
-        login_password: "{{ keystone_auth_admin_password }}"
-        login_project_name: "{{ keystone_admin_tenant_name }}"
-        user_name: "{{ maas_keystone_user }}"
-        tenant_name: "{{ keystone_admin_tenant_name }}"
-        password: "{{ maas_keystone_password }}"
-        insecure: "{{ keystone_service_adminuri_insecure }}"
+      shell: |
+        . /root/openrc
+        if ! {{ maas_venv_bin }}/openstack user show "{{ maas_keystone_user }}"; then
+          MAAS_ID=$({{ maas_venv_bin }}/openstack user create \
+                                                  --domain default \
+                                                  --password "{{ maas_keystone_password }}" \
+                                                  "{{ maas_keystone_user }}" | grep -w id | awk '{print $4}')
+          sleep 1
+          {{ maas_venv_bin }}/openstack role add \
+                                        --project admin \
+                                        --user "${MAAS_ID}" \
+                                        admin
+          exit 3
+        fi
+      args:
+        executable: "/bin/bash"
+      changed_when:
+        - mon_user.rc == 3
+      failed_when:
+        - mon_user.rc not in [0, 3]
+      register: mon_user
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
-        - keystone_service_adminurl is defined
-        - keystone_admin_user_name is defined
-        - keystone_auth_admin_password is defined
-        - keystone_admin_tenant_name is defined
-        - keystone_service_adminuri_insecure is defined
-        - inventory_hostname in groups['keystone_all'][0]
-
-    - name: Add monitoring keystone user to admin role
-      keystone:
-        command: "ensure_user_role"
-        endpoint: "{{ keystone_service_adminurl }}"
-        login_user: "{{ keystone_admin_user_name }}"
-        login_password: "{{ keystone_auth_admin_password }}"
-        login_project_name: "{{ keystone_admin_tenant_name }}"
-        user_name: "{{ maas_keystone_user }}"
-        tenant_name: "{{ keystone_admin_tenant_name }}"
-        role_name: "admin"
-        insecure: "{{ keystone_service_adminuri_insecure }}"
-      when:
-        - keystone_service_adminurl is defined
-        - keystone_admin_user_name is defined
-        - keystone_auth_admin_password is defined
-        - keystone_admin_tenant_name is defined
-        - keystone_service_adminuri_insecure is defined
         - inventory_hostname in groups['keystone_all'][0]
 
   tasks:
@@ -122,3 +111,7 @@
     - vars/maas-openstack.yml
   tags:
     - maas-openstack-keystone
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-openstack-magnum.yml
+++ b/playbooks/maas-openstack-magnum.yml
@@ -18,6 +18,7 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - include: "common-tasks/maas_get_openrc.yml"
 
   tasks:
     - name: Copy over pip constraints
@@ -81,3 +82,7 @@
     - vars/maas-openstack.yml
   tags:
     - maas-openstack-magnum
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-openstack-neutron.yml
+++ b/playbooks/maas-openstack-neutron.yml
@@ -18,6 +18,7 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - include: "common-tasks/maas_get_openrc.yml"
 
   tasks:
     - name: Copy over pip constraints
@@ -41,7 +42,6 @@
       retries: 5
       delay: 2
       delegate_to: "{{ physical_host | default(ansible_host) }}"
-
 
   vars_files:
     - vars/main.yml
@@ -199,3 +199,7 @@
     - vars/maas-openstack.yml
   tags:
     - maas-openstack-neutron
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-openstack-nova.yml
+++ b/playbooks/maas-openstack-nova.yml
@@ -18,6 +18,7 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - include: "common-tasks/maas_get_openrc.yml"
 
   tasks:
     - name: Copy over pip constraints
@@ -54,7 +55,7 @@
   tasks:
     - name: Install nova nova-api-metadata checks
       template:
-        src: "nova_api_metadata_local_check.yaml.j2"
+        src: "templates/nova_api_metadata_local_check.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/nova_api_metadata_local_check--{{ inventory_hostname }}.yaml"
         owner: "root"
         group: "root"
@@ -145,7 +146,7 @@
   tasks:
     - name: Install nova nova-api-metadata checks
       template:
-        src: "nova_cert_check.yaml.j2"
+        src: "templates/nova_cert_check.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/nova_cert_check--{{ inventory_hostname }}.yaml"
         owner: "root"
         group: "root"
@@ -167,7 +168,7 @@
   tasks:
     - name: Install nova nova-compute checks
       template:
-        src: "nova_compute_check.yaml.j2"
+        src: "templates/nova_compute_check.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/nova_compute_check--{{ inventory_hostname }}.yaml"
         owner: "root"
         group: "root"
@@ -189,7 +190,7 @@
   tasks:
     - name: Install nova nova-conductor checks
       template:
-        src: "nova_conductor_check.yaml.j2"
+        src: "templates/nova_conductor_check.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/nova_conductor_check--{{ inventory_hostname }}.yaml"
         owner: "root"
         group: "root"
@@ -211,7 +212,7 @@
   tasks:
     - name: Install nova nova-conductor checks
       template:
-        src: "nova_consoleauth_check.yaml.j2"
+        src: "templates/nova_consoleauth_check.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/nova_consoleauth_check--{{ inventory_hostname }}.yaml"
         owner: "root"
         group: "root"
@@ -222,7 +223,7 @@
 
     - name: Install nova nova-conductor checks
       template:
-        src: "nova_console_check.yaml.j2"
+        src: "templates/nova_console_check.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/nova_console_check--{{ inventory_hostname }}.yaml"
         owner: "root"
         group: "root"
@@ -237,3 +238,7 @@
     - vars/main.yml
   tags:
     - maas-openstack-nova
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-openstack-swift.yml
+++ b/playbooks/maas-openstack-swift.yml
@@ -18,6 +18,7 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - include: "common-tasks/maas_get_openrc.yml"
 
   tasks:
     - name: Copy over pip constraints
@@ -25,6 +26,16 @@
         src: "files/pip-constraints.txt"
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+    - name: Retrieve openrc file
+      fetch:
+        src: /root/openrc
+        dest: /root/openrc
+        flat: true
+      delegate_to: "{{ item }}"
+      with_items: "{{ groups['hosts'] }}"
+      when:
+        - "'hosts' in groups"
 
   post_tasks:
     - name: Install swift pip packages to venv
@@ -190,46 +201,40 @@
   hosts: swift_proxy
   gather_facts: false
   tasks:
-    # Add a swift user for file checking
-    - name: Create a keystone user for swift filecheck
-      keystone:
-        command: "ensure_user"
-        endpoint: "{{ keystone_service_adminurl }}"
-        login_user: "{{ keystone_admin_user_name }}"
-        login_password: "{{ keystone_auth_admin_password }}"
-        login_project_name: "{{ keystone_admin_tenant_name }}"
-        user_name: "{{ maas_swift_accesscheck_user_name }}"
-        tenant_name: "{{ maas_swift_service_project_name }}"
-        password: "{{ maas_swift_accesscheck_password }}"
-        insecure: "{{ keystone_service_adminuri_insecure }}"
-      register: add_user
-      until: add_user | success
-      retries: 5
-      delay: 10
+    - name: Create keystone user for swift filecheck
+      shell: |
+        source /root/openrc
+        if ! {{ maas_venv_bin }}/openstack user show "{{ maas_swift_accesscheck_user_name }}"; then
+          if ! {{ maas_venv_bin }}/openstack project show "{{ maas_swift_service_project_name }}"; then
+            {{ maas_venv_bin }}/openstack project create \
+                                          --domain default \
+                                          --description "Service Project" \
+                                          {{ maas_swift_service_project_name }}
+          fi
+          if ! {{ maas_venv_bin }}/openstack role show "{{ maas_swift_operator_role }}"; then
+            {{ maas_venv_bin }}/openstack role create \
+                                          {{ maas_swift_operator_role }}
+          fi
+          MAAS_ID=$({{ maas_venv_bin }}/openstack user create \
+                                                  --domain default \
+                                                  --password "{{ maas_swift_accesscheck_password }}" \
+                                                  "{{ maas_swift_accesscheck_user_name }}" | grep -w id | awk '{print $4}')
+          sleep 1
+          {{ maas_venv_bin }}/openstack role add \
+                                        --project admin \
+                                        --user "${MAAS_ID}" \
+                                        "{{ maas_swift_operator_role }}"
+          exit 3
+        fi
+      args:
+        executable: "/bin/bash"
+      changed_when:
+        - mon_user.rc == 3
+      failed_when:
+        - mon_user.rc not in [0, 3]
+      register: mon_user
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
-        - not maas_swift_service_in_ldap | bool
-        - maas_remote_check | bool
-        - maas_swift_accesscheck_enabled | bool
-        - inventory_hostname in groups['swift_proxy'][0]
-
-    # Assign the swiftoperator role to the file checking user
-    - name: Add swift role to user
-      keystone:
-        command: "ensure_user_role"
-        endpoint: "{{ keystone_service_adminurl }}"
-        login_user: "{{ keystone_admin_user_name }}"
-        login_password: "{{ keystone_auth_admin_password }}"
-        login_project_name: "{{ keystone_admin_tenant_name }}"
-        user_name: "{{ maas_swift_accesscheck_user_name }}"
-        tenant_name: "{{ maas_swift_service_project_name }}"
-        role_name: "{{ maas_swift_operator_role }}"
-        insecure: "{{ keystone_service_adminuri_insecure }}"
-      register: add_user_role
-      until: add_user_role | success
-      retries: 5
-      delay: 10
-      when:
-        - not maas_swift_service_in_ldap | bool
         - maas_remote_check | bool
         - maas_swift_accesscheck_enabled | bool
         - inventory_hostname in groups['swift_proxy'][0]
@@ -238,7 +243,7 @@
     - name: Create index file
       copy:
         dest: "/tmp/index.html"
-        src: "index.html"
+        src: "files/index.html"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
@@ -248,7 +253,7 @@
     # Place an HTML file in a swift container
     - name: Setup swift container monitoring check
       shell: |
-        source /root/openrc
+        source /root/openrc;
         {{ maas_venv_bin }}/swift upload \
           --object-name index.html \
           {{ maas_swift_accesscheck_container }} \
@@ -416,3 +421,7 @@
     - vars/maas-openstack.yml
   tags:
     - maas-openstack-swift
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -13,7 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Restart rax-maas
-  add_host:
-    name: "{{ physical_host | default(ansible_host) }}"
-    groups: maas_restart_on_host
+- name: Restart MaaS
+  hosts: maas_restart_on_host
+  gather_facts: false
+  tasks:
+    - name: Restart rackspace-monitoring-agent
+      service:
+        name: rackspace-monitoring-agent
+        state: restarted
+      register: _maas_restart
+      until: _maas_restart | success
+      retries: 3
+      delay: 2

--- a/playbooks/vars/maas-agent.yml
+++ b/playbooks/vars/maas-agent.yml
@@ -24,7 +24,6 @@ maas_pip_packages:
   - cryptography
   - ipaddr
   - lxml
-  - monitorstack
   - psutil
   - rackspace-monitoring-cli
   - requests

--- a/playbooks/vars/maas-container.yml
+++ b/playbooks/vars/maas-container.yml
@@ -14,6 +14,12 @@
 # limitations under the License.
 
 #
+# pip installable packages for given services used within maas
+#
+maas_container_pip_packages:
+  - lxc-python2
+
+#
 # Set the container storage threshold
 #
 maas_percent_used_critical_threshold: 85

--- a/playbooks/vars/maas-infra.yml
+++ b/playbooks/vars/maas-infra.yml
@@ -49,3 +49,6 @@ rsyslogd_process_names:
 
 maas_memcached_pip_packages:
   - python-memcached
+
+maas_rabbitmq_pip_packages:
+  - httplib2

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -43,7 +43,7 @@ maas_openstack_heat_pip_packages:
   - python-keystoneclient
 
 maas_openstack_keystone_pip_packages:
-  - python-heatclient
+  - python-openstackclient
 
 maas_openstack_magnum_pip_packages:
   - python-keystoneclient
@@ -58,7 +58,7 @@ maas_openstack_nova_pip_packages:
   - python-novaclient
 
 maas_openstack_swift_pip_packages:
-  - python-keystoneclient
+  - python-openstackclient
 
 maas_cinder_volumes_vg_warning_threshold: 80.0
 maas_cinder_volumes_vg_critical_threshold: 90.0

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -182,12 +182,6 @@ maas_remote_check: true
 maas_keystone_user: maas
 
 #
-# maas_openstack_install: Instructions to installing checks within an OpenStack cloud
-#                         This drops the "openrc" role in places where MaaS will need it.
-#
-maas_openstack_install: true
-
-#
 # maas_agent_upgrade: Allow for automatic MaaS agent upgrades
 #
 #

--- a/tests/inventory
+++ b/tests/inventory
@@ -49,7 +49,7 @@ galera_all
 memcached_all
 
 [utility]
-infra1
+openstack1
 
 [utility_all:children]
 utility


### PR DESCRIPTION
These changes ensure that the playbooks used to deploy maas are both 2.x
and 1.9 compatible at the same time.

This change also removes the OSA library and role dependencies which are
platform specific.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>