### PR TITLE
Add restart flow clontrol

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -96,6 +96,16 @@ With OpenStack-Ansible
     openstack-ansible playbooks/maas-verify.yml
 
 
+With Static Inventory
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    # Run the test playbook
+    ansible-playbook -i inventory playbooks/maas-verify.yml
+
+
+
 Running with Ansible 1.9 and OpenStack-Ansible
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -124,16 +134,6 @@ In order to enable console auth checking set the ``nova_console_type`` and
 
     echo 'nova_console_type: spice' | tee -a /etc/openstack_deploy/user_variables.yml
     echo 'nova_console_port: 6082' | tee -a /etc/openstack_deploy/user_variables.yml
-
-
-With Static Inventory
-~~~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: bash
-
-    # Run the test playbook
-    ansible-playbook -i inventory playbooks/maas-verify.yml
-
 
 Tags
 ~~~~
@@ -203,12 +203,25 @@ variable required to be set is ``maas_swift_accesscheck_password``.
     ansible-playbook -e @/etc/openstack_deploy/user_secrets.yml /opt/rpc-maas/playbooks/maas-openstack-swift.yml -i inventory
 
 
+Restart flow control
+####################
+
+When doing an initial deployment of the rpc-maas playbooks it recommended
+set the variable  ``maas_restart_independent`` to **false**. This variable
+instructs the playbooks to only restart the ``rackspace-monitoring-agent``
+once upon the completion of the ``site.yml`` playbook run. If you are
+redeploying specific checks, this variable is not needed.
+
+.. code-block:: bash
+
+    ansible-playbook -e "maas_restart_independent=false" /opt/rpc-maas/playbooks/site.yml
+
+
 Building Static Inventory
 #########################
 
-
 Mandatory Sections
-^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~
 
 To begin you likely will want to define all of your physical hosts within the
 "all" section.
@@ -235,7 +248,7 @@ host machines under the "hosts" section.
 
 
 Optional Sections
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 If you have ``containers``, these entries will be added to the "all_containers"
 section.

--- a/playbooks/maas-infra-filebeat.yml
+++ b/playbooks/maas-infra-filebeat.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Gather facts
-  hosts: all
+  hosts: "hosts:all_containers"
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
@@ -22,7 +22,7 @@
     - maas-infra-filebeat
 
 - name: Install checks for infra filebeat
-  hosts: all
+  hosts: "hosts:all_containers"
   gather_facts: false
   tasks:
     - name: Install filebeat check

--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Restart MaaS
-  hosts: maas_restart_on_host
+  hosts: "{{ maas_restart_on_host_override | default('maas_restart_on_host') }}"
   gather_facts: false
   tasks:
     - name: Restart rackspace-monitoring-agent
@@ -25,3 +25,6 @@
       until: _maas_restart | success
       retries: 3
       delay: 2
+      when: >
+        maas_restart_independent | default(true) | bool or
+        maas_force_restart | default(false) | bool

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -36,3 +36,9 @@
 - include: maas-openstack-all.yml
   tags:
     - maas
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml
+  vars:
+    maas_force_restart: true


### PR DESCRIPTION
This change implements optional flow control for restarting the RAX-MaaS
agent. This is needed due to limitations in the rax-maas-agent causing
issues when multiple restarts are issued within the same minute.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>