### PR TITLE
Remove quotes in openstack_version variable

### DIFF
--- a/playbooks/files/plugins/swift-recon.py
+++ b/playbooks/files/plugins/swift-recon.py
@@ -69,7 +69,7 @@ def recon_output(for_ring, options=None):
     with open("/etc/openstack-release") as f:
         for line in f.readlines():
             if line.startswith('DISTRIB_RELEASE'):
-                openstack_version = line.split("=")[-1].strip()
+                openstack_version = line.split("=")[-1].strip().strip('"')
                 break
         else:
             raise SystemExit(


### PR DESCRIPTION
Fix bug in swift-recon plugin to remove quotes from the `openstack_version` variable. Allow's Kilo to function as there are no virtual environments.