### PR TITLE
Add telegraf output format to the MaaS plugins

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -32,8 +32,8 @@ everything is working as expected which can be done with static inventory
 as well as within an OpenStack-Ansible deployment.
 
 
-With OpenStack-Ansible
-~~~~~~~~~~~~~~~~~~~~~~
+Running with OpenStack-Ansible
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -44,8 +44,8 @@ With OpenStack-Ansible
     openstack-ansible playbooks/maas-verify.yml
 
 
-With Static Inventory
-~~~~~~~~~~~~~~~~~~~~~
+Running with Static Inventory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -83,8 +83,22 @@ In order to enable console auth checking set the ``nova_console_type`` and
     echo 'nova_console_port: 6082' | tee -a /etc/openstack_deploy/user_variables.yml
 
 
-Recommended Overrides when deploying with specific versions of OpenStack-Ansible
---------------------------------------------------------------------------------
+Collecting metrics for time series analysis
+-------------------------------------------
+
+An available plugin can be executed at any time to run all discovered checks
+found in ``/etc/rackspace-monitoring-agent.conf.d``. These plugins will be
+executed having the output format converted to telegraf line format. This is
+useful when storing local checks in a time series database like influxdb. To
+run the plugin execute the following:
+
+.. code-block:: bash
+
+    /openstack/venvs/maas-${VERSION_NUM}/bin/python /usr/lib/rackspace-monitoring-agent/plugins/maas_telegraf_format.py
+
+
+Recommended Overrides for specific versions of OpenStack-Ansible
+----------------------------------------------------------------
 
 The following sections contain YAML options that should be added to the
 ``user_variables.yml`` file for a given deployment of OpenStack-Ansible.

--- a/playbooks/files/maas_telegraf_format.py
+++ b/playbooks/files/maas_telegraf_format.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in witing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+
+import yaml
+
+
+BASE_PATH = '/etc/rackspace-monitoring-agent.conf.d'
+RUN_VENV = '/usr/lib/rackspace-monitoring-agent/plugins/run_plugin_in_venv.sh'
+
+
+def str2bool(boolean):
+    if boolean.lower() in ("yes", "true", "1"):
+        return True
+    elif boolean.lower() in ("no", "false", "0"):
+        return False
+    else:
+        raise BaseException('Not a Boolean')
+
+
+def load_yaml(check_file):
+    with open(check_file) as f:
+        return yaml.load(f.read())
+
+
+def run_details(detail_args):
+    args = detail_args.get('args')
+    if args:
+        args.insert(0, RUN_VENV)
+        args.insert(2, '--telegraf-output')
+        with open(os.devnull, 'w') as null:
+            subprocess.call(args, stderr=null)
+
+
+def main():
+    for _, _, items in os.walk(BASE_PATH):
+        for item in items:
+            check_load = load_yaml(os.path.join(BASE_PATH, item))
+            if not str2bool(boolean=check_load.get('disabled')):
+                details = check_load.get('details')
+                if details:
+                    run_details(detail_args=details)
+
+
+if __name__ == '__main__':
+    main()

--- a/playbooks/files/pip-constraints.txt
+++ b/playbooks/files/pip-constraints.txt
@@ -1,3 +1,6 @@
+### Monitorstack plugin framework
+git+https://github.com/openstack/monitorstack@master#egg=monitorstack
+
 ### Requirements for RAX-MaaS
 apache-libcloud<2.0.0
 cryptography==1.5

--- a/playbooks/files/plugins/ceph_monitoring.py
+++ b/playbooks/files/plugins/ceph_monitoring.py
@@ -148,7 +148,10 @@ def get_args():
     parser_osd = subparsers.add_parser('osd')
     parser_osd.add_argument('--osd_ids', required=True,
                             help='Space separated list of OSD IDs')
-
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
     subparsers.add_parser('cluster')
     return parser.parse_args()
 
@@ -167,6 +170,6 @@ def main(args):
 
 
 if __name__ == '__main__':
-    with maas_common.print_output():
-        args = get_args()
+    args = get_args()
+    with maas_common.print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/cinder_api_local_check.py
+++ b/playbooks/files/plugins/cinder_api_local_check.py
@@ -53,11 +53,11 @@ def check(auth_ref, args):
     try:
         vol = s.get('%s/volumes/detail' % VOLUME_ENDPOINT,
                     verify=False,
-                    timeout=10)
+                    timeout=5)
         milliseconds = vol.elapsed.total_seconds() * 1000
         snap = s.get('%s/snapshots/detail' % VOLUME_ENDPOINT,
                      verify=False,
-                     timeout=10)
+                     timeout=5)
         is_up = vol.ok and snap.ok
     except (exc.ConnectionError,
             exc.HTTPError,
@@ -100,11 +100,15 @@ def main(args):
     check(auth_ref, args)
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(description="Check Cinder API against"
-                                         " local or remote address")
-        parser.add_argument('ip',
-                            type=ipaddr.IPv4Address,
-                            help='Cinder API server address')
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(description="Check Cinder API against"
+                                     " local or remote address")
+    parser.add_argument('ip',
+                        type=ipaddr.IPv4Address,
+                        help='Cinder API server address')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/cinder_service_check.py
+++ b/playbooks/files/plugins/cinder_service_check.py
@@ -50,7 +50,7 @@ def check(auth_ref, args):
     try:
         # We cannot do /os-services?host=X as cinder returns a hostname of
         # X@lvm for cinder-volume binary
-        r = s.get('%s/os-services' % VOLUME_ENDPOINT, verify=False, timeout=10)
+        r = s.get('%s/os-services' % VOLUME_ENDPOINT, verify=False, timeout=5)
     except (exc.ConnectionError,
             exc.HTTPError,
             exc.Timeout) as e:
@@ -102,14 +102,18 @@ def main(args):
     check(auth_ref, args)
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(description="Check Cinder API against"
-                                         " local or remote address")
-        parser.add_argument('hostname',
-                            type=str,
-                            help='Cinder API hostname or IP address')
-        parser.add_argument('--host',
-                            type=str,
-                            help='Only return metrics for the specified host')
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(description="Check Cinder API against"
+                                     " local or remote address")
+    parser.add_argument('hostname',
+                        type=str,
+                        help='Cinder API hostname or IP address')
+    parser.add_argument('--host',
+                        type=str,
+                        help='Only return metrics for the specified host')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/conntrack_count.py
+++ b/playbooks/files/plugins/conntrack_count.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import errno
 
 import maas_common
@@ -61,5 +62,11 @@ def main():
 
 
 if __name__ == '__main__':
-    with maas_common.print_output():
+    parser = argparse.ArgumentParser(description='Conntrack checks')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with maas_common.print_output(print_telegraf=args.telegraf_output):
         main()

--- a/playbooks/files/plugins/container_storage_check.py
+++ b/playbooks/files/plugins/container_storage_check.py
@@ -62,7 +62,11 @@ def container_check(thresh):
 
 
 def get_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description='Container storage checks')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
     parser.add_argument(
         '--thresh',
         required=True,
@@ -73,7 +77,6 @@ def get_args():
 
 
 def main():
-    args = get_args()
     _container_check = False
     try:
         _container_check = container_check(thresh=args.thresh)
@@ -89,5 +92,6 @@ def main():
 
 
 if __name__ == '__main__':
-    with print_output():
+    args = get_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main()

--- a/playbooks/files/plugins/disk_utilisation.py
+++ b/playbooks/files/plugins/disk_utilisation.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import shlex
 import subprocess
 
@@ -32,7 +33,13 @@ def utilisation(time):
     return utils
 
 if __name__ == '__main__':
-    with print_output():
+    parser = argparse.ArgumentParser(description='Disk utilisation checks')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         try:
             utils = utilisation(5)
         except Exception as e:

--- a/playbooks/files/plugins/elasticsearch.py
+++ b/playbooks/files/plugins/elasticsearch.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import json
-import optparse
 import os
 import re
 
@@ -104,14 +104,18 @@ def get_number_of(loglevel, index):
 
 
 def parse_args():
-    parser = optparse.OptionParser(usage='%prog [-h] [-H host] [-P port]')
-    parser.add_option('-H', '--host', action='store', dest='host',
-                      default=None,
-                      help=('Hostname or IP address to use to connect to '
-                            'Elasticsearch'))
-    parser.add_option('-P', '--port', action='store', dest='port',
-                      default=ES_PORT,
-                      help='Port to use to connect to Elasticsearch')
+    parser = argparse.ArgumentParser(description='Elasticsearch checks')
+    parser.add_argument('-H', '--host', action='store', dest='host',
+                        default=None,
+                        help=('Hostname or IP address to use to connect to '
+                              'Elasticsearch'))
+    parser.add_argument('-P', '--port', action='store', dest='port',
+                        default=ES_PORT,
+                        help='Port to use to connect to Elasticsearch')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
     return parser.parse_args()
 
 
@@ -123,7 +127,6 @@ def configure(options):
 
 
 def main():
-    options, _ = parse_args()
     configure(options)
 
     latest = most_recent_index()
@@ -136,5 +139,6 @@ def main():
 
 
 if __name__ == '__main__':
-    with print_output():
+    args = options = parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main()

--- a/playbooks/files/plugins/galera_check.py
+++ b/playbooks/files/plugins/galera_check.py
@@ -13,10 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import optparse
+
+import argparse
 import shlex
 import subprocess
-
 
 from maas_common import metric
 from maas_common import print_output
@@ -54,13 +54,23 @@ def generate_query(host, port, output_type='status'):
 
 
 def parse_args():
-    parser = optparse.OptionParser(usage='%prog [-h] [-H hostname] [-P port]')
-    parser.add_option('-H', '--host', action='store', dest='host',
-                      default=None,
-                      help='Host to override the defaults with')
-    parser.add_option('-P', '--port', action='store', dest='port',
-                      default=None,
-                      help='Port to override the defauults with')
+    parser = argparse.ArgumentParser(description='Galera checks')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    parser.add_argument('-H',
+                        '--host',
+                        action='store',
+                        dest='host',
+                        default=None,
+                        help='Host to override the defaults with')
+    parser.add_argument('-P',
+                        '--port',
+                        action='store',
+                        dest='port',
+                        default=None,
+                        help='Port to override the defauults with')
     return parser.parse_args()
 
 
@@ -107,8 +117,6 @@ def print_metrics(replica_status):
 
 
 def main():
-    options, _ = parse_args()
-
     replica_status = {}
     for output_type in ['status', 'variables']:
         retcode, output, err = galera_check(
@@ -138,5 +146,6 @@ def main():
 
 
 if __name__ == '__main__':
-    with print_output():
+    args = options = parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main()

--- a/playbooks/files/plugins/glance_api_local_check.py
+++ b/playbooks/files/plugins/glance_api_local_check.py
@@ -81,11 +81,15 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(description="Check Glance API against"
-                                         " local or remote address")
-        parser.add_argument('ip', nargs='?',
-                            type=ipaddr.IPv4Address,
-                            help='Optional Glance API server address')
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(description="Check Glance API against"
+                                     " local or remote address")
+    parser.add_argument('ip', nargs='?',
+                        type=ipaddr.IPv4Address,
+                        help='Optional Glance API server address')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/glance_registry_local_check.py
+++ b/playbooks/files/plugins/glance_registry_local_check.py
@@ -43,7 +43,7 @@ def check(auth_ref, args):
 
     try:
         # /images returns a list of public, non-deleted images
-        r = s.get('%s/images' % registry_endpoint, verify=False, timeout=10)
+        r = s.get('%s/images' % registry_endpoint, verify=False, timeout=5)
         is_up = r.ok
     except (exc.ConnectionError, exc.HTTPError, exc.Timeout):
         is_up = False
@@ -65,10 +65,14 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(description="Check Glance Registry "
-                                         " against local or remote address")
-        parser.add_argument('ip', type=ipaddr.IPv4Address,
-                            help='Glance Registry IP address')
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(description="Check Glance Registry "
+                                     " against local or remote address")
+    parser.add_argument('ip', type=ipaddr.IPv4Address,
+                        help='Glance Registry IP address')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/heat_api_local_check.py
+++ b/playbooks/files/plugins/heat_api_local_check.py
@@ -71,11 +71,15 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(
-            description='Check Heat API against local or remote address')
-        parser.add_argument('ip', nargs='?', type=ipaddr.IPv4Address,
-                            help="Check Heat API against "
-                            " local or remote address")
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description='Check Heat API against local or remote address')
+    parser.add_argument('ip', nargs='?', type=ipaddr.IPv4Address,
+                        help="Check Heat API against "
+                        " local or remote address")
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/holland_local_check.py
+++ b/playbooks/files/plugins/holland_local_check.py
@@ -47,6 +47,10 @@ def parse_args():
     parser.add_argument('holland_backupset', nargs='?',
                         help='Name of the holland backupset',
                         default='rpc_support')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
     return parser.parse_args()
 
 
@@ -84,7 +88,6 @@ def container_holland_lb_check(container, binary, backupset):
 
 
 def main():
-    args = parse_args()
     galera_container = args.galera_container_name
     holland_bin = args.holland_binary
     holland_bs = args.holland_backupset
@@ -111,5 +114,6 @@ def main():
 
 
 if __name__ == '__main__':
-    with print_output():
+    args = parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main()

--- a/playbooks/files/plugins/horizon_check.py
+++ b/playbooks/files/plugins/horizon_check.py
@@ -53,7 +53,7 @@ def check(args):
     try:
         r = s.get('%s:%s' % (HORIZON_URL, HORIZON_PORT),
                   verify=False,
-                  timeout=10)
+                  timeout=5)
     except (exc.ConnectionError,
             exc.HTTPError,
             exc.Timeout) as e:
@@ -111,14 +111,18 @@ def main(args):
     check(args)
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(description='Check horizon dashboard')
-        parser.add_argument('ip',
-                            type=ipaddr.IPv4Address,
-                            help='horizon dashboard IP address')
-        parser.add_argument('site_name_regexp',
-                            type=str,
-                            default='openstack dashboard',
-                            help='Horizon Site Name')
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(description='Check horizon dashboard')
+    parser.add_argument('ip',
+                        type=ipaddr.IPv4Address,
+                        help='horizon dashboard IP address')
+    parser.add_argument('site_name_regexp',
+                        type=str,
+                        default='openstack dashboard',
+                        help='Horizon Site Name')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/hp_monitoring.py
+++ b/playbooks/files/plugins/hp_monitoring.py
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import maas_common
+import argparse
 import subprocess
+
+import maas_common
 
 
 class BadOutputError(maas_common.MaaSException):
@@ -83,5 +85,11 @@ def main():
 
 
 if __name__ == '__main__':
-    with maas_common.print_output():
+    parser = argparse.ArgumentParser(description='HP monitoring checks')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with maas_common.print_output(print_telegraf=args.telegraf_output):
         main()

--- a/playbooks/files/plugins/keystone_api_local_check.py
+++ b/playbooks/files/plugins/keystone_api_local_check.py
@@ -80,13 +80,17 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(
-            description='Check Keystone API against local or remote address')
-        parser.add_argument(
-            'ip',
-            nargs='?',
-            type=ipaddr.IPv4Address,
-            help='Check Keystone API against local or remote address')
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description='Check Keystone API against local or remote address')
+    parser.add_argument(
+        'ip',
+        nargs='?',
+        type=ipaddr.IPv4Address,
+        help='Check Keystone API against local or remote address')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/magnum_api_local_check.py
+++ b/playbooks/files/plugins/magnum_api_local_check.py
@@ -66,11 +66,15 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(
-            description='Check Magnum API against local or remote address')
-        parser.add_argument('ip', nargs='?', type=ipaddr.IPv4Address,
-                            help="Check Magnum API against "
-                            " local or remote address")
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description='Check Magnum API against local or remote address')
+    parser.add_argument('ip', nargs='?', type=ipaddr.IPv4Address,
+                        help="Check Magnum API against "
+                        " local or remote address")
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/magnum_service_check.py
+++ b/playbooks/files/plugins/magnum_service_check.py
@@ -58,11 +58,15 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(
-            description='Check Magnum API against local or remote address')
-        parser.add_argument('ip', nargs='?', type=ipaddr.IPv4Address,
-                            help="Check Magnum API against "
-                            " local or remote address")
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description='Check Magnum API against local or remote address')
+    parser.add_argument('ip', nargs='?', type=ipaddr.IPv4Address,
+                        help="Check Magnum API against "
+                        " local or remote address")
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/memcached_status.py
+++ b/playbooks/files/plugins/memcached_status.py
@@ -73,11 +73,15 @@ def main(args):
 
 
 if __name__ == '__main__':
-    with print_output():
-        parser = argparse.ArgumentParser(description='Check memcached status')
-        parser.add_argument('ip', type=ipaddr.IPv4Address,
-                            help='memcached IP address.')
-        parser.add_argument('--port', type=int,
-                            default=11211, help='memcached port.')
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(description='Check memcached status')
+    parser.add_argument('ip', type=ipaddr.IPv4Address,
+                        help='memcached IP address.')
+    parser.add_argument('--port', type=int,
+                        default=11211, help='memcached port.')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/neutron_api_local_check.py
+++ b/playbooks/files/plugins/neutron_api_local_check.py
@@ -77,11 +77,15 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(
-            description='Check Neutron API against local or remote address')
-        parser.add_argument('ip', nargs='?',
-                            type=ipaddr.IPv4Address,
-                            help='Optional Neutron API server address')
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description='Check Neutron API against local or remote address')
+    parser.add_argument('ip', nargs='?',
+                        type=ipaddr.IPv4Address,
+                        help='Optional Neutron API server address')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/neutron_metadata_local_check.py
+++ b/playbooks/files/plugins/neutron_metadata_local_check.py
@@ -81,9 +81,14 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(description='Check neutron proxies')
-        parser.add_argument('neutron_host',
-                            type=str,
-                            help='Neutron API hostname or IP address')
-        main(parser.parse_args())
+    parser = argparse.ArgumentParser(description='Check neutron proxies')
+    parser.add_argument('neutron_host',
+                        type=str,
+                        help='Neutron API hostname or IP address')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
+        main(args)

--- a/playbooks/files/plugins/neutron_service_check.py
+++ b/playbooks/files/plugins/neutron_service_check.py
@@ -68,18 +68,22 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(description='Check neutron agents')
-        parser.add_argument('hostname',
-                            type=str,
-                            help='Neutron API hostname or IP address')
-        parser.add_argument('--host',
-                            type=str,
-                            help='Only return metrics for specified host',
-                            default=None)
-        parser.add_argument('--fqdn',
-                            type=str,
-                            help='Only return metrics for specified fqdn',
-                            default=None)
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(description='Check neutron agents')
+    parser.add_argument('hostname',
+                        type=str,
+                        help='Neutron API hostname or IP address')
+    parser.add_argument('--host',
+                        type=str,
+                        help='Only return metrics for specified host',
+                        default=None)
+    parser.add_argument('--fqdn',
+                        type=str,
+                        help='Only return metrics for specified fqdn',
+                        default=None)
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/nova_api_local_check.py
+++ b/playbooks/files/plugins/nova_api_local_check.py
@@ -84,11 +84,15 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(
-            description='Check Nova API against local or remote address')
-        parser.add_argument('ip', nargs='?',
-                            type=ipaddr.IPv4Address,
-                            help='Optional Nova API server address')
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description='Check Nova API against local or remote address')
+    parser.add_argument('ip', nargs='?',
+                        type=ipaddr.IPv4Address,
+                        help='Optional Nova API server address')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/nova_api_metadata_local_check.py
+++ b/playbooks/files/plugins/nova_api_metadata_local_check.py
@@ -37,7 +37,7 @@ def check(args):
         # an instance ID and other headers
         versions = s.get('%s/' % metadata_endpoint,
                          verify=False,
-                         timeout=10)
+                         timeout=5)
         milliseconds = versions.elapsed.total_seconds() * 1000
         if not versions.ok or '1.0' not in versions.content.splitlines():
             is_up = False
@@ -60,11 +60,15 @@ def main(args):
     check(args)
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(
-            description='Check nova-api-metdata API')
-        parser.add_argument('ip',
-                            type=ipaddr.IPv4Address,
-                            help='nova-api-metadata IP address')
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description='Check nova-api-metdata API')
+    parser.add_argument('ip',
+                        type=ipaddr.IPv4Address,
+                        help='nova-api-metadata IP address')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/nova_cloud_stats.py
+++ b/playbooks/files/plugins/nova_cloud_stats.py
@@ -108,25 +108,29 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(
-            description='Check Nova hypervisor stats')
-        parser.add_argument('--cpu',
-                            type=float,
-                            default=1.0,
-                            required=False,
-                            action='store',
-                            dest='cpu_allocation_ratio',
-                            help='cpu allocation ratio')
-        parser.add_argument('--mem',
-                            type=float,
-                            default=1.0,
-                            required=False,
-                            action='store',
-                            dest='mem_allocation_ratio',
-                            help='mem allocation ratio')
-        parser.add_argument('ip', nargs='?',
-                            type=ipaddr.IPv4Address,
-                            help='Nova API IP address')
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description='Check Nova hypervisor stats')
+    parser.add_argument('--cpu',
+                        type=float,
+                        default=1.0,
+                        required=False,
+                        action='store',
+                        dest='cpu_allocation_ratio',
+                        help='cpu allocation ratio')
+    parser.add_argument('--mem',
+                        type=float,
+                        default=1.0,
+                        required=False,
+                        action='store',
+                        dest='mem_allocation_ratio',
+                        help='mem allocation ratio')
+    parser.add_argument('ip', nargs='?',
+                        type=ipaddr.IPv4Address,
+                        help='Nova API IP address')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/nova_service_check.py
+++ b/playbooks/files/plugins/nova_service_check.py
@@ -73,15 +73,18 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(description='Check nova services')
-        parser.add_argument('hostname',
-                            type=str,
-                            help='Nova API hostname or IP address')
-        parser.add_argument('--host',
-                            type=str,
-                            help='Only return metrics for specified host',
-                            default=None)
-        args = parser.parse_args()
-
+    parser = argparse.ArgumentParser(description='Check nova services')
+    parser.add_argument('hostname',
+                        type=str,
+                        help='Nova API hostname or IP address')
+    parser.add_argument('--host',
+                        type=str,
+                        help='Only return metrics for specified host',
+                        default=None)
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/openmanage.py
+++ b/playbooks/files/plugins/openmanage.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import re
 import subprocess
 import sys
@@ -105,5 +106,11 @@ def main():
 
 
 if __name__ == '__main__':
-    with print_output():
+    parser = argparse.ArgumentParser(description='Openmanage Checks')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main()

--- a/playbooks/files/plugins/process_check_container.py
+++ b/playbooks/files/plugins/process_check_container.py
@@ -136,10 +136,14 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(
-            description='Check a host or container for running processes')
-        parser.add_argument('-c', '--container', action='store')
-        parser.add_argument('processes', nargs=argparse.REMAINDER)
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description='Check a host or container for running processes')
+    parser.add_argument('-c', '--container', action='store')
+    parser.add_argument('processes', nargs=argparse.REMAINDER)
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/process_check_host.py
+++ b/playbooks/files/plugins/process_check_host.py
@@ -119,9 +119,13 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(
-            description='Check a host for running processes')
-        parser.add_argument('processes', nargs=argparse.REMAINDER)
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description='Check a host for running processes')
+    parser.add_argument('processes', nargs=argparse.REMAINDER)
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/service_api_local_check.py
+++ b/playbooks/files/plugins/service_api_local_check.py
@@ -54,7 +54,7 @@ def check(args):
     else:
         url = ''.join((endpoint, path))
     try:
-        r = s.get(url, verify=False, timeout=10)
+        r = s.get(url, verify=False, timeout=5)
     except (exc.ConnectionError,
             exc.HTTPError,
             exc.Timeout):
@@ -78,20 +78,24 @@ def main(args):
 
 
 if __name__ == "__main__":
-    with print_output():
-        parser = argparse.ArgumentParser(description='Check service is up.')
-        parser.add_argument('name', help='Service name.')
-        parser.add_argument('ip', type=ipaddr.IPv4Address,
-                            help='Service IP address.')
-        parser.add_argument('port', type=int, help='Service port.')
-        parser.add_argument('--path', default='',
-                            help='Service API path, this should include '
-                                 'placeholders for the version "{version}" and'
-                                 ' tenant ID "{tenant_id}" if required.')
-        parser.add_argument('--auth', action='store_true', default=False,
-                            help='Does this API check require auth?')
-        parser.add_argument('--ssl', action='store_true', default=False,
-                            help='Should SSL be used.')
-        parser.add_argument('--version', help='Service API version.')
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(description='Check service is up.')
+    parser.add_argument('name', help='Service name.')
+    parser.add_argument('ip', type=ipaddr.IPv4Address,
+                        help='Service IP address.')
+    parser.add_argument('port', type=int, help='Service port.')
+    parser.add_argument('--path', default='',
+                        help='Service API path, this should include '
+                             'placeholders for the version "{version}" and'
+                             ' tenant ID "{tenant_id}" if required.')
+    parser.add_argument('--auth', action='store_true', default=False,
+                        help='Does this API check require auth?')
+    parser.add_argument('--ssl', action='store_true', default=False,
+                        help='Should SSL be used.')
+    parser.add_argument('--version', help='Service API version.')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/plugins/swift-dispersion.py
+++ b/playbooks/files/plugins/swift-dispersion.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import re
 import subprocess
 
@@ -125,5 +126,11 @@ def main():
 # > metric container_total_copies uint64 6
 
 if __name__ == '__main__':
-    with maas_common.print_output():
+    parser = argparse.ArgumentParser(description='Swift dispersion check')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with maas_common.print_output(print_telegraf=args.telegraf_output):
         main()

--- a/playbooks/files/plugins/swift-recon.py
+++ b/playbooks/files/plugins/swift-recon.py
@@ -425,6 +425,10 @@ def make_parser():
     parser.add_argument('--ring-type', dest='ring',
                         help='Which ring to run statistics for. Only used by '
                              'replication recon.')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
     return parser
 
 
@@ -449,7 +453,6 @@ def get_stats_from(args):
 
 
 def main():
-    parser = make_parser()
     args = parser.parse_args()
 
     try:
@@ -463,5 +466,7 @@ def main():
 
 
 if __name__ == '__main__':
-    with maas_common.print_output():
+    parser = make_parser()
+    args = parser.parse_args()
+    with maas_common.print_output(print_telegraf=args.telegraf_output):
         main()

--- a/playbooks/files/plugins/vg_check.py
+++ b/playbooks/files/plugins/vg_check.py
@@ -17,7 +17,6 @@ import argparse
 import shlex
 import subprocess
 
-
 from maas_common import metric
 from maas_common import print_output
 from maas_common import status_err
@@ -40,6 +39,10 @@ def parse_args():
         description='Check space in a volume group')
     parser.add_argument('vgname',
                         help='Name of volume group to query')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
     return parser.parse_args()
 
 
@@ -54,7 +57,6 @@ def print_metrics(sizes, vgname):
 
 
 def main():
-    args = parse_args()
     vgname = args.vgname
     command = ('vgs %s --noheadings --units M '
                '--nosuffix -o vg_size,vg_free') % (vgname)
@@ -77,5 +79,6 @@ def main():
 
 
 if __name__ == '__main__':
-    with print_output():
+    args = parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main()

--- a/playbooks/maas-agent-setup.yml
+++ b/playbooks/maas-agent-setup.yml
@@ -68,6 +68,14 @@
         group: "root"
         mode: "0755"
 
+    - name: Drop MaaS telegraf output runner
+      template:
+        src: "files/maas_telegraf_format.py"
+        dest: "{{ maas_plugin_dir }}/maas_telegraf_format.py"
+        owner: "root"
+        group: "root"
+        mode: "0755"
+
   post_tasks:
     - name: Assign agent ID to entity
       raxmon:

--- a/playbooks/templates/conntrack_count.yaml.j2
+++ b/playbooks/templates/conntrack_count.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/conntrack_count.py", "{{ ansible_host }}"]
+    args    : ["{{ maas_plugin_dir }}/conntrack_count.py"]
 alarms      :
     conntrack_count_status :
         label                   : conntrack_count_status--{{ ansible_hostname }}

--- a/playbooks/templates/disk_utilisation.yaml.j2
+++ b/playbooks/templates/disk_utilisation.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/disk_utilisation.py", "{{ ansible_host }}"]
+    args    : ["{{ maas_plugin_dir }}/disk_utilisation.py"]
 alarms      :
 {% for device in maas_disk_util_devices %}
     percentage_disk_utilisation_{{ device }}:

--- a/playbooks/templates/plugins/rabbitmq_status.py
+++ b/playbooks/templates/plugins/rabbitmq_status.py
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import optparse
+import argparse
 import subprocess
 
 from itertools import chain
@@ -81,25 +80,27 @@ def rabbit_version(node):
 
 
 def parse_args():
-    parser = optparse.OptionParser(
-        usage='%prog [-h] [-H hostname] [-P port] [-u username] [-p password]'
-    )
-    parser.add_option('-H', '--host', action='store', dest='host',
-                      default='localhost',
-                      help='Host address to use when connecting')
-    parser.add_option('-P', '--port', action='store', dest='port',
-                      default='15672',
-                      help='Port to use when connecting')
-    parser.add_option('-U', '--username', action='store', dest='username',
-                      default='guest',
-                      help='Username to use for authentication')
-    parser.add_option('-p', '--password', action='store', dest='password',
-                      default='guest',
-                      help='Password to use for authentication')
-    parser.add_option('-n', '--name', action='store', dest='name',
-                      default=None,
-                      help=("Check a node's cluster membership using the "
-                            'provided name'))
+    parser = argparse.ArgumentParser(description='RabbitMQ checks')
+    parser.add_argument('-H', '--host', action='store', dest='host',
+                        default='localhost',
+                        help='Host address to use when connecting')
+    parser.add_argument('-P', '--port', action='store', dest='port',
+                        default='15672',
+                        help='Port to use when connecting')
+    parser.add_argument('-U', '--username', action='store', dest='username',
+                        default='guest',
+                        help='Username to use for authentication')
+    parser.add_argument('-p', '--password', action='store', dest='password',
+                        default='guest',
+                        help='Password to use for authentication')
+    parser.add_argument('-n', '--name', action='store', dest='name',
+                        default=None,
+                        help=("Check a node's cluster membership using the "
+                              'provided name'))
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
     return parser.parse_args()
 
 
@@ -203,7 +204,6 @@ def _get_consumer_metrics(session, metrics, host, port):
 
 
 def main():
-    (options, _) = parse_args()
     metrics = {}
     session = requests.Session()  # Make a Session to store the auth creds
     session.auth = (options.username, options.password)
@@ -225,5 +225,6 @@ def main():
 
 
 if __name__ == "__main__":
-    with print_output():
+    args = options = parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
         main()

--- a/playbooks/vars/maas-agent.yml
+++ b/playbooks/vars/maas-agent.yml
@@ -24,6 +24,7 @@ maas_pip_packages:
   - cryptography
   - ipaddr
   - lxml
+  - monitorstack
   - psutil
   - rackspace-monitoring-cli
   - requests


### PR DESCRIPTION
This change adds a telegraf output format to all of the maas checks
using the monitorstack plugin framework. This will allow the MaaS
metrics to collect local time series data without impacting the normal
rax-maas-agent capabilities.

The plugin timeout changed from 10 to 5, when locally collecting
metrics it can take several minutes per collection cycle when many
systems are down. In a future PR I will multi-thread the telegraf plugin
runner but for now its serial and a lower timeout help capture the
metrics in a more realtime way.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>