### PR TITLE
Detect container hosts

### DIFF
--- a/playbooks/handlers/main.yml
+++ b/playbooks/handlers/main.yml
@@ -15,5 +15,6 @@
 
 - name: Restart rax-maas
   add_host:
-    name: "{{ physical_host | default(ansible_host) }}"
+    name: "{{ hostvars[item]['physical_host'] | default(ansible_host) }}"
     groups: maas_restart_on_host
+  with_items: "{{ groups[maas_current_group] }}"

--- a/playbooks/maas-agent-install.yml
+++ b/playbooks/maas-agent-install.yml
@@ -18,6 +18,9 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: hosts
 
   tasks:
     - name: Copy over pip constraints

--- a/playbooks/maas-agent-setup.yml
+++ b/playbooks/maas-agent-setup.yml
@@ -18,6 +18,10 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: hosts
+
   tags:
     - maas-agent-setup
 

--- a/playbooks/maas-ceph-mon.yml
+++ b/playbooks/maas-ceph-mon.yml
@@ -18,6 +18,10 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: mons
+
   tags:
     - maas-ceph-mons
 

--- a/playbooks/maas-ceph-osd.yml
+++ b/playbooks/maas-ceph-osd.yml
@@ -18,6 +18,10 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: osds
+
   tags:
     - maas-ceph-osds
 

--- a/playbooks/maas-container-storage.yml
+++ b/playbooks/maas-container-storage.yml
@@ -13,11 +13,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Generate container host list
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Create known container hosts fact
+      set_fact:
+        _known_container_hosts: >
+          {% set _var = [] -%}
+          {% for item in groups['all_containers'] -%}
+          {%   if hostvars[item]['physical_host'] | default(false) != item -%}
+          {%     if _var.append(hostvars[item]['physical_host']) -%}
+          {%     endif -%}
+          {%   endif -%}
+          {% endfor -%}
+          {{ _var | unique }}
+
+    - name: Create dynamic lxc_host group
+      add_host:
+        hostname: "{{ item }}"
+        groups: "known_container_hosts"
+      with_items: "{{ _known_container_hosts }}"
+
 - name: Gather facts
-  hosts: hosts
+  hosts: known_container_hosts
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: hosts
 
   tasks:
     - name: Copy over pip constraints
@@ -49,7 +75,7 @@
     - maas-container-storage
 
 - name: Install checks for infra memcached
-  hosts: hosts
+  hosts: known_container_hosts
   gather_facts: false
   tasks:
     - name: Install local checks

--- a/playbooks/maas-host-cdm.yml
+++ b/playbooks/maas-host-cdm.yml
@@ -18,6 +18,10 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: hosts
+
   tags:
     - maas-host-cdm
 

--- a/playbooks/maas-host-kernel.yml
+++ b/playbooks/maas-host-kernel.yml
@@ -18,6 +18,10 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: hosts
+
   tags:
     - maas-hosts-kernel
 

--- a/playbooks/maas-host-network.yml
+++ b/playbooks/maas-host-network.yml
@@ -18,6 +18,10 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: hosts
+
   tags:
     - maas-hosts-network
 

--- a/playbooks/maas-host-vendor.yml
+++ b/playbooks/maas-host-vendor.yml
@@ -18,6 +18,9 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: hosts
 
   post_tasks:
     - name: Run HP tasks

--- a/playbooks/maas-infra-elasticsearch.yml
+++ b/playbooks/maas-infra-elasticsearch.yml
@@ -18,6 +18,10 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: elasticsearch_all
+
   tags:
     - maas-infra-elasticsearch
 

--- a/playbooks/maas-infra-filebeat.yml
+++ b/playbooks/maas-infra-filebeat.yml
@@ -18,6 +18,10 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: hosts
+
   tags:
     - maas-infra-filebeat
 

--- a/playbooks/maas-infra-galera.yml
+++ b/playbooks/maas-infra-galera.yml
@@ -18,6 +18,10 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: galera_all
+
   tags:
     - maas-infra-galera
 

--- a/playbooks/maas-infra-lb-ssl.yml
+++ b/playbooks/maas-infra-lb-ssl.yml
@@ -18,6 +18,10 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: utility_all
+
   tags:
     - maas-infra-lb-ssl
 

--- a/playbooks/maas-infra-memcached.yml
+++ b/playbooks/maas-infra-memcached.yml
@@ -18,6 +18,9 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: memcached_all
 
   tasks:
     - name: Copy over pip constraints

--- a/playbooks/maas-infra-rabbitmq.yml
+++ b/playbooks/maas-infra-rabbitmq.yml
@@ -18,6 +18,9 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: rabbitmq_all
 
   tasks:
     - name: Install rabbitmq pip packages

--- a/playbooks/maas-infra-rsyslogd.yml
+++ b/playbooks/maas-infra-rsyslogd.yml
@@ -18,6 +18,10 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: rsyslog_all
+
   tags:
     - maas-infra-rsyslog
 

--- a/playbooks/maas-openstack-cinder.yml
+++ b/playbooks/maas-openstack-cinder.yml
@@ -19,6 +19,9 @@
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
     - include: "common-tasks/maas_get_openrc.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: cinder_all
 
   tasks:
     - name: Copy over pip constraints

--- a/playbooks/maas-openstack-glance.yml
+++ b/playbooks/maas-openstack-glance.yml
@@ -19,6 +19,9 @@
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
     - include: "common-tasks/maas_get_openrc.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: glance_all
 
   tasks:
     - name: Copy over pip constraints

--- a/playbooks/maas-openstack-heat.yml
+++ b/playbooks/maas-openstack-heat.yml
@@ -19,6 +19,9 @@
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
     - include: "common-tasks/maas_get_openrc.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: heat_all
 
   tasks:
     - name: Copy over pip constraints

--- a/playbooks/maas-openstack-horizon.yml
+++ b/playbooks/maas-openstack-horizon.yml
@@ -19,6 +19,9 @@
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
     - include: "common-tasks/maas_get_openrc.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: horizon
 
   tags:
     - maas-openstack-horizon

--- a/playbooks/maas-openstack-keystone.yml
+++ b/playbooks/maas-openstack-keystone.yml
@@ -19,6 +19,9 @@
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
     - include: "common-tasks/maas_get_openrc.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: keystone_all
 
   tasks:
     - name: Copy over pip constraints

--- a/playbooks/maas-openstack-magnum.yml
+++ b/playbooks/maas-openstack-magnum.yml
@@ -19,6 +19,9 @@
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
     - include: "common-tasks/maas_get_openrc.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: magnum
 
   tasks:
     - name: Copy over pip constraints

--- a/playbooks/maas-openstack-neutron.yml
+++ b/playbooks/maas-openstack-neutron.yml
@@ -19,6 +19,9 @@
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
     - include: "common-tasks/maas_get_openrc.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: neutron_all
 
   tasks:
     - name: Copy over pip constraints

--- a/playbooks/maas-openstack-nova.yml
+++ b/playbooks/maas-openstack-nova.yml
@@ -19,6 +19,9 @@
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
     - include: "common-tasks/maas_get_openrc.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: nova_all
 
   tasks:
     - name: Copy over pip constraints

--- a/playbooks/maas-openstack-swift.yml
+++ b/playbooks/maas-openstack-swift.yml
@@ -19,6 +19,9 @@
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
     - include: "common-tasks/maas_get_openrc.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: swift_all
 
   tasks:
     - name: Copy over pip constraints


### PR DESCRIPTION
Added step to detect and limit container storage checks to only contianer
hosts. This ensures we're not attempting to deploy container checks on
non-container hosts.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>