### PR TITLE
Excluding empty queues from consumer check

### DIFF
--- a/playbooks/templates/plugins/rabbitmq_status.py
+++ b/playbooks/templates/plugins/rabbitmq_status.py
@@ -193,7 +193,7 @@ def _get_consumer_metrics(session, metrics, host, port):
         queue_response = _get_rabbit_json(session, CONSUMERS_QUEUES_URL %
                                           (host, port, URI_ENCODED))
         for queue in queue_response:
-            if queue['consumers'] == 0:
+            if queue['consumers'] == 0 and queue['messages'] > 0:
                 queues_without_consumers += 1
 
     metrics['queues_without_consumers'] = {

--- a/playbooks/templates/rabbitmq_status.yaml.j2
+++ b/playbooks/templates/rabbitmq_status.yaml.j2
@@ -87,7 +87,7 @@ alarms      :
                 return new AlarmStatus(CRITICAL, "RabbitMQ Queue growth rate is above configured threshold. Currently above {{ maas_rabbitmq_queue_growth_rate_threshold }}");
             }
 
-    rabbitmq_queus_without_consumers :
+    rabbitmq_queues_without_consumers :
         label                   : rabbitmq_queues_without_consumers--{{ ansible_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
         disabled                : {{ (('rabbitmq_queues_without_consumers--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}


### PR DESCRIPTION
Queues having no consumers subscribed and don't
contain any messages are excluded from the
consumer check.
This is done to reduce alerts on non critical conditions.