### PR TITLE
Thread the telegraf entrypoint

### DIFF
--- a/playbooks/files/plugins/container_storage_check.py
+++ b/playbooks/files/plugins/container_storage_check.py
@@ -52,6 +52,9 @@ def container_check(thresh):
     containers = lxc.list_containers()
     for container in containers:
         c = lxc.Container(container)
+        if c.init_pid == -1:
+            return True
+
         with Chroot('/proc/%s/root' % int(c.init_pid)):
             for partition in psutil.disk_partitions():
                 percent_used = disk_usage(part=partition)

--- a/playbooks/templates/run_plugin_in_venv.sh.j2
+++ b/playbooks/templates/run_plugin_in_venv.sh.j2
@@ -7,6 +7,4 @@ fi
 # NOTE(cloudnull): Hard coded because this was never addressed upstream
 export OS_API_INSECURE=True
 
-source {{ maas_venv_bin }}/activate
-
-python2.7 "$@"
+{{ maas_venv_bin }}/python "$@"

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -78,7 +78,7 @@ maas_cloud_resource_mem_allocation_ratio: 1.0
 #
 # Default horizon site name
 #
-maas_horizon_site_name: "openstack dashboard"
+maas_horizon_site_name: "openstack"
 
 #
 # Swift object access check


### PR DESCRIPTION
Running all plugins from MaaS in a single pass is slow, this chnage
implements threading allowing the collection of the plugins to happen
much faster.

Three bugs were discovered:
  * Should a container be stopped the pid returned for the container is
    "-1" which will fail a lookup, a change has been added to condition has
    been added to check for a negative pid and skip when needed.
  * The horizon dashboard variable had a space in it causing the lookup
    to fail. This removes the extra bits and corrects the plugin
    failure.
  * The venv wrapper used to source the virtual env and then run the a
    python utility while this mostly works it breaks a shell environment
    should the check fail to run. Calling the virtual environment python
    directly resolves this issue.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>