### PR TITLE
Added telegraf and influx metric collection

### DIFF
--- a/playbooks/files/maas_telegraf_format.py
+++ b/playbooks/files/maas_telegraf_format.py
@@ -15,7 +15,6 @@
 
 import multiprocessing
 import os
-import subprocess
 
 import yaml
 
@@ -47,20 +46,7 @@ class Runner:
 
             detail_args.insert(0, RUN_VENV)
             detail_args.insert(2, '--telegraf-output')
-            with open(os.devnull, 'w') as null:
-                process = subprocess.Popen(
-                    ' '.join(detail_args),
-                    stdout=subprocess.PIPE,
-                    stderr=null,
-                    executable='/bin/bash',
-                    shell=True
-                )
-
-            output, error = process.communicate()
-            if process.returncode in [0]:
-                RETURN_QUEUE.put(output.strip())
-            else:
-                print(error, output, ' '.join(detail_args))
+            RETURN_QUEUE.put(' '.join(detail_args).strip())
 
             self.queue.task_done()
 
@@ -97,13 +83,17 @@ def main():
     finally:
         r.terminate()
 
+    q_items = list()
     while True:
         try:
             q_item = RETURN_QUEUE.get(timeout=1)
         except Exception:
             break
         else:
-            print(q_item)
+            q_items.append(q_item)
+
+    # Print a sorted list of commands
+    print('\n'.join(sorted(q_items)))
 
 
 if __name__ == '__main__':

--- a/playbooks/files/plugins/container_storage_check.py
+++ b/playbooks/files/plugins/container_storage_check.py
@@ -87,7 +87,6 @@ def main():
         status_err(str(e))
     else:
         status_ok()
-    finally:
         metric_bool(
             'container_storage_percent_used_critical',
             _container_check

--- a/playbooks/files/plugins/maas_common.py
+++ b/playbooks/files/plugins/maas_common.py
@@ -579,7 +579,7 @@ METRICS = list()
 TELEGRAF_METRICS = {
     'variables': dict(),
     'meta': {
-        'rpc_maas': True
+        'rpc_maas': True  # This should use some form of a job number
     }
 }
 
@@ -587,9 +587,8 @@ TELEGRAF_METRICS = {
 def metric(name, metric_type, value, unit=None):
     global METRICS
     global TELEGRAF_METRICS
-    TELEGRAF_METRICS['measurement_name'] = '_'.join(name.split('_')[:3])
-    meta = TELEGRAF_METRICS['meta']
-    meta[name] = metric_type
+    measurement_name = '_'.join(name.split('_')[:3]).replace('-', '_')
+    TELEGRAF_METRICS['measurement_name'] = measurement_name
 
     if len(METRICS) > 49:
         status_err('Maximum of 50 metrics per check')

--- a/playbooks/files/tigkstack/deploy_go.sh
+++ b/playbooks/files/tigkstack/deploy_go.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+pushd /opt
+  wget -P /opt/ https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz
+  tar  -xzf /opt/go1.8.3.linux-amd64.tar.gz -C /opt/
+popd
+
+pushd /usr/local/bin
+  find /opt/go/bin/ -type f -exec ln -sf {} \;
+popd
+
+if ! grep -qw 'GOROOT="/opt/go"' /etc/environment; then
+  echo 'GOROOT="/opt/go"' | tee -a /etc/environment
+fi

--- a/playbooks/files/tigkstack/deploy_influxdbrelay.sh
+++ b/playbooks/files/tigkstack/deploy_influxdbrelay.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+rm -rf /opt/influxdb-relay;
+
+mkdir /opt/influxdb-relay;
+
+export GOPATH=/opt/influxdb-relay/;
+export GOROOT=/opt/go;
+
+go get -u github.com/influxdata/influxdb-relay

--- a/playbooks/maas-tigkstack-all.yml
+++ b/playbooks/maas-tigkstack-all.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- include: maas-tigkstack-influxdb.yml
+  tags:
+    - maas-tigkstack
+
+- include: maas-tigkstack-telegraf.yml
+  tags:
+    - maas-tigkstack

--- a/playbooks/maas-tigkstack-influxdb.yml
+++ b/playbooks/maas-tigkstack-influxdb.yml
@@ -1,0 +1,113 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Deploy influxdb
+  hosts: log_hosts
+  gather_facts: true
+  pre_tasks:
+    - name: Check init system
+      command: cat /proc/1/comm
+      changed_when: false
+      register: _pid1_name
+      tags:
+        - always
+
+    - name: Set the name of pid1
+      set_fact:
+        pid1_name: "{{ _pid1_name.stdout }}"
+      tags:
+        - always
+
+    - name: Add influxdata apt-keys
+      apt_key:
+        url: "https://repos.influxdata.com/influxdb.key"
+        state: "present"
+
+    - name: Add influxdata repo
+      apt_repository:
+        repo: "deb https://repos.influxdata.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+        state: "present"
+
+    - name: Install packages
+      apt:
+        pkg: "{{ item }}"
+        state: "latest"
+      with_items:
+        - git
+        - influxdb
+
+    - name: Drop influxdb config file
+      template:
+        src: templates/tigkstack/influxdb.conf.j2
+        dest: /etc/influxdb/influxdb.conf
+
+    - name: Enable and restart influxdb
+      service:
+        name: "influxdb"
+        enabled: true
+        state: restarted
+
+    - name: Wait for influxdb to be ready
+      wait_for:
+        host: "{{ ansible_host }}"
+        port: "{{ influxdb_port }}"
+        delay: 1
+
+    - name: Create metrics DB
+      shell: >
+        influx -username {{ influxdb_db_root_name }}
+        -password {{ influxdb_db_root_password }}
+        -execute "{{ item }}"
+      with_items:
+        - "CREATE DATABASE {{ influxdb_db_name }}"
+        - "CREATE RETENTION POLICY {{ influxdb_db_retention_policy }} ON {{ influxdb_db_name }} DURATION {{ influxdb_db_retention }} REPLICATION {{ influxdb_db_replication }}"
+        - "CREATE USER {{ influxdb_db_metric_user }} WITH PASSWORD '{{ influxdb_db_metric_password }}'"
+        - "GRANT ALL ON {{ influxdb_db_name }} TO {{ influxdb_db_metric_user }}"
+
+    - name: Install GOLang
+      script: files/tigkstack/deploy_go.sh
+
+    - name: Download and install influx-relay
+      script: files/tigkstack/deploy_influxdbrelay.sh
+
+    - name: Drop influx relay toml file
+      template:
+        src: templates/tigkstack/relay.toml.j2
+        dest: /opt/influxdb-relay/relay.toml
+
+    - name: Drop Influx Relay upstart
+      template:
+        src: templates/tigkstack/influxdbrelay.conf.j2
+        dest: /etc/init/influxdbrelay.conf
+      when:
+        - pid1_name == "init"
+
+    - name: Drop Influx Relay service file
+      template:
+        src: templates/tigkstack/influxdbrelay.service.j2
+        dest: /etc/systemd/system/influxdbrelay.service
+      when:
+        - pid1_name == "systemd"
+
+    - name: Enable and restart influxdb
+      service:
+        name: "influxdbrelay"
+        state: restarted
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas-tigkstack.yml
+  tags:
+    - maas-tigkstack-influxdb

--- a/playbooks/maas-tigkstack-telegraf.yml
+++ b/playbooks/maas-tigkstack-telegraf.yml
@@ -1,0 +1,80 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Deploy telegraf
+  hosts: "hosts:all_containers"
+  gather_facts: true
+  tasks:
+    - name: Add influxdata apt-keys
+      apt_key:
+        url: "https://repos.influxdata.com/influxdb.key"
+        state: "present"
+
+    - name: Add influxdata repo
+      apt_repository:
+        repo: "deb https://repos.influxdata.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+        state: "present"
+        update_cache: yes
+
+    - name: Install telegraf
+      apt:
+        pkg: "telegraf"
+        state: "latest"
+
+    - name: Create telegraf plugin dir
+      file:
+        path: "/opt/telegraf"
+        state: directory
+        mode: "0755"
+
+    - name: Return Commands for metric
+      command: "/usr/lib/rackspace-monitoring-agent/plugins/maas_telegraf_format.py"
+      changed_when: false
+      register: telegraf_maas_commands
+      when:
+        - inventory_hostname in groups['hosts']
+
+    - name: Set the telegraf maas commands
+      set_fact:
+        telegraf_commands: "{{ telegraf_maas_commands.stdout_lines }}"
+      when:
+        - inventory_hostname in groups['hosts']
+
+    - name: Drop telegraf config file
+      template:
+        src: templates/tigkstack/telegraf.conf.j2
+        dest: /etc/telegraf/telegraf.conf
+      register: telegraf_config
+
+    - name: Set telegraf defaults
+      copy:
+        content: |
+          USER="root"
+          GROUP="root"
+        dest: /etc/default/telegraf
+
+    - name: Enable and restart telegraf
+      service:
+        name: "telegraf"
+        enabled: true
+        state: restarted
+      when:
+        - telegraf_config | changed
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas-tigkstack.yml
+  tags:
+    - maas-tigkstack-telegraf

--- a/playbooks/templates/tigkstack/grafana.ini.j2
+++ b/playbooks/templates/tigkstack/grafana.ini.j2
@@ -1,0 +1,65 @@
+[paths]
+
+[server]
+http_port = {{ grafana_port }}
+{% if grafana_root_url is defined %}
+root_url = {{ grafana_root_url }}
+{% endif %}
+
+[database]
+type = mysql
+host = {{ galera_address }}:3306
+name = {{ grafana_db_name }}
+user = {{ grafana_db_user }}
+password = {{ grafana_db_password }}
+
+[session]
+
+[analytics]
+check_for_updates = true
+
+[security]
+admin_user = admin
+admin_password = {{ grafana_admin_password }}
+
+[snapshots]
+
+[users]
+allow_sign_up = false
+allow_org_create = false
+
+[auth.anonymous]
+enabled = true
+org_name = OpenStack
+org_role = Viewer
+
+[auth.github]
+
+[auth.google]
+
+[auth.proxy]
+
+[auth.basic]
+
+[auth.ldap]
+
+[smtp]
+
+[emails]
+
+[log]
+
+[log.console]
+
+[log.file]
+
+[log.syslog]
+
+[event_publisher]
+
+[dashboards.json]
+
+[metrics]
+
+[grafana_net]
+url = https://grafana.net

--- a/playbooks/templates/tigkstack/influxdb.conf.j2
+++ b/playbooks/templates/tigkstack/influxdb.conf.j2
@@ -1,0 +1,80 @@
+reporting-disabled = false
+
+[logging]
+  level = "info"
+
+[meta]
+  dir = "/var/lib/influxdb/meta"
+  retention-autocreate = true
+  logging-enabled = true
+  pprof-enabled = false
+  lease-duration = "1m0s"
+
+[data]
+  enabled = true
+  dir = "/var/lib/influxdb/data"
+  wal-dir = "/var/lib/influxdb/wal"
+  wal-logging-enabled = true
+  query-log-enabled = false
+  cache-max-memory-size = 679477248
+  cache-snapshot-memory-size = 28311552
+  cache-snapshot-write-cold-duration = "1h0m0s"
+  compact-full-write-cold-duration = "24h0m0s"
+  max-points-per-block = 0
+  data-logging-enabled = false
+
+[cluster]
+  shard-writer-timeout = "8s" # The time within which a remote shard must respond to a write request.
+  write-timeout = "30s" # The time within which a write request must complete on the cluster.
+  max-concurrent-queries = 0 # The maximum number of concurrent queries that can run. 0 to disable.
+  query-timeout = "0s" # The time within a query must complete before being killed automatically. 0s to disable.
+  max-select-point = 0 # The maximum number of points to scan in a query. 0 to disable.
+  max-select-series = 0 # The maximum number of series to select in a query. 0 to disable.
+  max-select-buckets = 0 # The maximum number of buckets to select in an aggregate query. 0 to disable.
+
+[retention]
+  enabled = true
+  check-interval = "32m"
+
+[shard-precreation]
+  enabled = true
+  check-interval = "16m"
+  advance-period = "32m"
+
+[monitor]
+  store-enabled = true # Whether to record statistics internally.
+  store-database = "_internal" # The destination database for recorded statistics
+  store-interval = "16s" # The interval at which to record statistics
+
+[admin]
+  enabled = true
+  bind-address = ":{{ influxdb_admin_port }}"
+  https-enabled = false
+  https-certificate = "/etc/ssl/influxdb.pem"
+
+[http]
+  enabled = true
+  bind-address = ":{{ influxdb_port }}"
+  auth-enabled = false
+  log-enabled = false
+  write-tracing = false
+  pprof-enabled = false
+  https-enabled = false
+  https-certificate = "/etc/ssl/influxdb.pem"
+  max-row-limit = 10240
+
+[[graphite]]
+  enabled = false
+
+[[collectd]]
+  enabled = false
+
+[[opentsdb]]
+  enabled = false
+
+[[udp]]
+  enabled = false
+
+[continuous_queries]
+  log-enabled = false
+  enabled = true

--- a/playbooks/templates/tigkstack/influxdbrelay.conf.j2
+++ b/playbooks/templates/tigkstack/influxdbrelay.conf.j2
@@ -1,0 +1,6 @@
+description "Influxdb Relay"
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+exec /opt/influxdb-relay/bin/influxdb-relay -config /opt/influxdb-relay/relay.toml

--- a/playbooks/templates/tigkstack/influxdbrelay.service.j2
+++ b/playbooks/templates/tigkstack/influxdbrelay.service.j2
@@ -1,0 +1,31 @@
+# If you modify this, please also make sure to edit init.sh
+
+[Unit]
+Description=Influx relay adds a basic high availability layer to InfluxDB.
+After=network-online.target
+
+[Service]
+User=influxdb
+Group=influxdb
+LimitNOFILE=65536
+ExecStart=/opt/influxdb-relay/bin/influxdb-relay -config /opt/influxdb-relay/relay.toml
+KillMode=control-group
+Restart=on-failure
+
+# Give a reasonable amount of time for the server to start up/shut down
+TimeoutSec=300
+Restart=on-failure
+RestartSec=150
+
+# This creates a specific slice which all services will operate from
+#  The accounting options give us the ability to see resource usage through
+#  the `systemd-cgtop` command.
+Slice=influxdbrelay.slice
+CPUAccounting=true
+BlockIOAccounting=true
+MemoryAccounting=false
+TasksAccounting=true
+
+[Install]
+WantedBy=multi-user.target
+Alias=influxd.service

--- a/playbooks/templates/tigkstack/relay.toml.j2
+++ b/playbooks/templates/tigkstack/relay.toml.j2
@@ -1,0 +1,10 @@
+[[http]]
+name = "example-http"
+bind-addr = '0.0.0.0:{{ influxdb_relay_port  }}'
+output = [
+{% set i =1%}
+{%for host_name in groups['log_hosts'] %}
+    { name="local{{ i }}", location = "http://{{ hostvars[host_name]['ansible_host'] }}:{{ influxdb_port }}/write"},
+{%set i = i + 1%}
+{%endfor%}
+]

--- a/playbooks/templates/tigkstack/telegraf.conf.j2
+++ b/playbooks/templates/tigkstack/telegraf.conf.j2
@@ -1,0 +1,96 @@
+[global_tags]
+{% if 'all_containers' in groups and inventory_hostname in groups['all_containers'] %}
+  node_type = "container"
+{% else %}
+  node_type = "physical_host"
+{% endif %}
+  job_reference = "{{ maas_job_reference }}"
+
+{% set interval = (telegraf_interval | int) + 10 %}
+
+[agent]
+  interval = "{{ interval }}s"
+  round_interval = false
+  metric_batch_size = 1024
+  metric_buffer_limit = 10240
+  collection_jitter = "8s"
+  flush_interval = "{{ interval * 1.5 | round }}s"
+  flush_jitter = "8s"
+  debug = false
+  quiet = true
+  hostname = "{{ inventory_hostname }}"
+  omit_hostname = false
+
+{%   set influx_targets = [] %}
+{%   for item in groups['log_hosts'] %}
+{%     set target = influxdb_protocol + '://' + hostvars[item]['ansible_host'] + ':' + influxdb_port | string %}
+{%     set _ = influx_targets.extend([target]) %}
+{%   endfor %}
+{%   set all_influx_targets = influx_telegraf_targets | union(influx_targets) %}
+
+[[outputs.influxdb]]
+{% if all_influx_targets | length > 1 %}
+  urls = [{{ all_influx_targets | map('quote') | join(', ') }}]
+{% else %}
+  urls = ["{{ all_influx_targets[0] }}"]
+{% endif %}
+  database = "{{ influxdb_db_name }}"
+  precision = "s"
+  write_consistency = "any"
+  timeout = "30s"
+
+{% if telegraf_outputs_prometheus_client is defined %}
+[[outputs.prometheus_client]]
+  listen = ":{{ telegraf_outputs_prometheus_client_listen }}"
+  expiration_interval = "{{ telegraf_outputs_prometheus_client_expiration_interval }}s"
+{% endif %}
+
+[[inputs.processes]]
+
+[[inputs.system]]
+
+[[inputs.conntrack]]
+  files = ["ip_conntrack_count","ip_conntrack_max",
+            "nf_conntrack_count","nf_conntrack_max"]
+  dirs = ["/proc/sys/net/ipv4/netfilter","/proc/sys/net/netfilter"]
+
+{% if 'swift_proxy' in groups and inventory_hostname in groups['swift_proxy'] %}
+[[inputs.statsd]]
+  service_address = ":8125"
+  metric_separator = "."
+  templates = [
+    "*.swift.proxy-server.*.*.*.* host.measurement.measurement.measurement.method.returncode.field*",
+    "*.swift.proxy-server.*.policy.*.*.*.* host.measurement.measurement.measurement.measurement.measurement.method.returncode.field*",
+  ]
+{% endif %}
+
+{% if 'all_containers' in groups and inventory_hostname in groups['all_containers'] %}
+[[inputs.net]]
+
+{% else %}
+[[inputs.exec]]
+  commands = [{{ telegraf_commands | map('quote') | join(', ') }}]
+  timeout = "{{ telegraf_commands | length * 1.5 | round }}s"
+  data_format = "influx"
+
+[[inputs.cpu]]
+  percpu = true
+  totalcpu = true
+  fielddrop = ["time_*"]
+
+[[inputs.net]]
+
+[[inputs.netstat]]
+
+[[inputs.disk]]
+  ignore_fs = ["tmpfs", "devtmpfs"]
+
+[[inputs.diskio]]
+
+[[inputs.kernel]]
+
+[[inputs.mem]]
+
+[[inputs.swap]]
+
+{% endif %}

--- a/playbooks/vars/maas-tigkstack.yml
+++ b/playbooks/vars/maas-tigkstack.yml
@@ -1,0 +1,47 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Grafana vars
+grafana_port: 8089
+grafana_db_name: grafana
+grafana_db_user: grafana
+
+# InfluxDB vars
+influxdb_admin_port: 8083
+influxdb_port: 8086
+influxdb_db_name: telegraf
+influxdb_db_retention: 90d
+influxdb_db_retention_policy: rpc_maas
+influxdb_db_replication: 1
+influxdb_db_root_name: root
+influxdb_db_metric_user: rpc_maas
+
+# Telegraf vars
+telegraf_interval: 30
+
+## Prometheus Client Outputs Plugin
+telegraf_outputs_prometheus_client: false
+telegraf_outputs_prometheus_client_listen: 9126
+telegraf_outputs_prometheus_client_expiration_interval: 60
+
+# Kapacitor Vars
+kapacitor_port: 9092
+
+# Influxdb Relay vars
+influxdb_relay_port: 9096
+
+influxdb_protocol: http
+
+influx_telegraf_targets: []

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -14,6 +14,12 @@
 # limitations under the License.
 
 #
+# Set the maas job reference. This is used by telegraf to add tags to a given set of metrics.
+#   This makes querying metrics easy when aggregating metrics to a single influxdb cluster.
+#
+maas_job_reference: "testing"
+
+#
 # Set the pip package state, defaults to latest.
 #
 maas_pip_package_state: "latest"

--- a/tests/inventory
+++ b/tests/inventory
@@ -54,6 +54,12 @@ openstack1
 [utility_all:children]
 utility
 
+[log_hosts]
+infra1
+
+[log_hosts_all:children]
+log_hosts
+
 
 #### OPENSTACK START HERE
 

--- a/tests/rpc-maas-overrides.yml
+++ b/tests/rpc-maas-overrides.yml
@@ -125,3 +125,10 @@ neutron_venv_tag: "testing"
 nova_venv_tag: "testing"
 sahara_venv_tag: "testing"
 swift_venv_tag: "testing"
+
+
+# Set vars for tigk stack
+influxdb_db_root_password: SuperSecrete
+influxdb_db_metric_password: SuperDuperSecrete
+grafana_db_password: secrete
+grafana_admin_password: SuperSecrete

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -51,3 +51,7 @@
 
 # Ensure all plugins are functional
 - include: "../playbooks/maas-verify.yml"
+
+# Run the tigk stack playbooks
+- include: "../playbooks/maas-tigkstack-all.yml"
+


### PR DESCRIPTION
Two new playbooks have been added to deploy telegraf and influxdb into
an environmeent and begin collecting metrics locally using the same
plugins powering the rax-maas check system.

In the course of adding this collection capability I discovered the
plugin `process_check_container.py` was throwing an error should a given
container lookup fail. To correct this I've added an exception handler.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>