### PR TITLE
Exclude notifications queues under condition

### DIFF
--- a/playbooks/templates/rax-maas/plugins/rabbitmq_status.py
+++ b/playbooks/templates/rax-maas/plugins/rabbitmq_status.py
@@ -23,6 +23,7 @@ from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
 from maas_common import status_ok
+import re
 import requests
 
 OVERVIEW_URL = "http://%s:%s/api/overview"
@@ -168,7 +169,9 @@ def _get_node_metrics(session, metrics, host, port, name):
 def _get_queue_metrics(session, metrics, host, port):
     response = _get_rabbit_json(session, QUEUES_URL % (host, port))
     notification_messages = sum([q['messages'] for q in response
-                                if q['name'].startswith('notifications.')])
+                                if re.match('/^(versioned_)?notifications\.',
+                                            q['name']) and
+                                q['consumers'] > 0])
 
     metrics['notification_messages'] = {
         'value': notification_messages,


### PR DESCRIPTION
The notifications queues can only be execluded from monitoring
if one or more consumer is present on the queue.
If the queues are excluded from monitoring but no consumer is present,
it will lead to instabilities of RabbitMQ, ultimately stopping
operations due to system limitations (memory/disk).
The notification_driver need to be properly set to noop if the
messages generation for the notification queues should be suppressed.
Additionally the new versioned_notifications queue is included in this
check.

Closes-Bug: #286