### PR TITLE
Add support for MaaS Poller

### DIFF
--- a/playbooks/common-tasks/maas-poller-ubuntu-install.yml
+++ b/playbooks/common-tasks/maas-poller-ubuntu-install.yml
@@ -1,0 +1,42 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Add MaaS apt keys
+  apt_key:
+    id: "{{ maas_keys.hash_id | default(omit) }}"
+    keyserver: "{{ maas_keys.keyserver | default(omit) }}"
+    url: "{{ maas_keys.url | default(omit) }}"
+    state: "{{ maas_keys.state }}"
+  register: add_repo_keys
+  until: add_repo_keys | success
+  retries: 3
+  delay: 2
+
+- name: Add maas repo
+  apt_repository:
+    repo: "{{ maas_poller_repos.repo }}"
+    state: "{{ maas_poller_repos.state }}"
+    update_cache: yes
+  register: add_repos
+  until: add_repos | success
+  retries: 5
+  delay: 2
+
+- name: Ensure container packages are installed
+  apt:
+    pkg: "{{ maas_poller_distro_packages | join(' ') }}"
+    state: "{{ maas_package_state }}"
+    update_cache: yes
+    cache_valid_time: 600

--- a/playbooks/files/rackspace-monitoring-poller-enabled
+++ b/playbooks/files/rackspace-monitoring-poller-enabled
@@ -1,0 +1,8 @@
+# Configuration of the rackspace-monitoring-poller service
+
+ENABLED=true
+
+CONFIG_FILE=/etc/rackspace-monitoring-poller.cfg
+
+# Allows for passing additional options to the 'server' command
+POLLER_SERVE_OPTS="-l /var/log/rackspace-monitoring-poller.log"

--- a/playbooks/files/rax-maas/plugins/maas_poller_fd_count.py
+++ b/playbooks/files/rax-maas/plugins/maas_poller_fd_count.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2015, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import psutil
+
+from maas_common import metric
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+
+
+def _get_poller_proc(name="rackspace-monitoring-poller"):
+    """Return the process relating to the running poller
+
+    This reports an appropriate status if either zero or
+    more than one pollers are found.
+
+    Returns None when more than one poller is found.
+    """
+    procs = filter(lambda proc: proc.name() == name, psutil.process_iter())
+
+    metric_name = "maas_poller"
+
+    poller_count = len(procs)
+    if poller_count > 1:
+        status_err("Found %d %s instances" % (poller_count, name),
+                   m_name=metric_name)
+    elif poller_count == 0:
+        status_err("No %s found" % name,
+                   m_name=metric_name)
+    else:
+        status_ok(m_name=metric_name)
+
+    return procs[0] if poller_count == 1 else None
+
+
+def get_poller_fd_details():
+    """Generate metrics for the poller's file descriptor usage"""
+    proc = _get_poller_proc()
+    if proc is None:
+        return
+
+    metric("maas_poller_fd_count", "uint32", proc.num_fds())
+
+    # rlimit returns soft and hard limits, but only use hard
+    _, hard_limit = proc.rlimit(psutil.RLIMIT_NOFILE)
+    metric("maas_poller_fd_max", "uint32", hard_limit)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Check poller file descriptor usage")
+
+    parser.add_argument("--telegraf-output",
+                        action="store_true",
+                        default=False,
+                        help="Set the output format to telegraf")
+
+    args = parser.parse_args()
+
+    with print_output(print_telegraf=args.telegraf_output):
+        get_poller_fd_details()

--- a/playbooks/maas-agent-setup.yml
+++ b/playbooks/maas-agent-setup.yml
@@ -120,6 +120,7 @@
     - include: handlers/main.yml
   vars_files:
     - vars/main.yml
+    - vars/maas-auth.yml
     - vars/maas-agent.yml
   tags:
     - maas-agent-setup

--- a/playbooks/maas-host-all.yml
+++ b/playbooks/maas-host-all.yml
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: maas-host-private-checks.yml
+  tags:
+    - maas-host
+
 - include: maas-host-cdm.yml
   tags:
     - maas-host

--- a/playbooks/maas-host-private-checks.yml
+++ b/playbooks/maas-host-private-checks.yml
@@ -1,0 +1,53 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in witing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Gather facts
+  hosts: hosts
+  gather_facts: "{{ gather_facts | default(true) }}"
+  pre_tasks:
+    - include: "common-tasks/maas_excluded_regex.yml"
+  tags:
+    - maas-poller-setup
+
+- name: Install private network monitoring checks
+  hosts: hosts
+  gather_facts: false
+
+  tasks:
+    - name: Install private ping and SSH checks
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
+      template:
+        src: "templates/rax-maas/{{ item.name }}.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/{{ item.name }}.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      with_items:
+        - { name: "private_ping_check" }
+        - { name: "private_ssh_check" }
+      notify:
+        - Restart rax-maas
+
+  handlers:
+    - include: handlers/main.yml
+  vars_files:
+    - vars/main.yml
+    - vars/maas-poller.yml
+  tags:
+    - maas-poller-setup
+
+- include: maas-restart.yml

--- a/playbooks/maas-openstack-cinder.yml
+++ b/playbooks/maas-openstack-cinder.yml
@@ -77,6 +77,21 @@
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
+      notify:
+        - Restart rax-maas
+
+    - name: Install cinder private lb checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_cinder.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_cinder.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
       notify:
         - Restart rax-maas
 

--- a/playbooks/maas-openstack-glance.yml
+++ b/playbooks/maas-openstack-glance.yml
@@ -77,6 +77,21 @@
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
+      notify:
+        - Restart rax-maas
+
+    - name: Install glance private lb checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_glance.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_glance.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
       notify:
         - Restart rax-maas
 

--- a/playbooks/maas-openstack-heat.yml
+++ b/playbooks/maas-openstack-heat.yml
@@ -77,6 +77,21 @@
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
+      notify:
+        - Restart rax-maas
+
+    - name: Install heat api private lb checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_heat_api.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_heat_api.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
       notify:
         - Restart rax-maas
 
@@ -113,6 +128,21 @@
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
+      notify:
+        - Restart rax-maas
+
+    - name: Install heat api cfn private lb checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_heat_cfn.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_heat_cfn.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
       notify:
         - Restart rax-maas
 
@@ -139,7 +169,7 @@
       notify:
         - Restart rax-maas
 
-    - name: Install heat lb cloudwatch checks
+    - name: Install heat cloudwatch lb checks
       template:
         src: "templates/rax-maas/lb_api_check_heat_cloudwatch.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/lb_api_check_heat_cloudwatch.yaml"
@@ -149,6 +179,21 @@
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
+      notify:
+        - Restart rax-maas
+
+    - name: Install heat cloudwatch private lb checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_heat_cloudwatch.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_heat_cloudwatch.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
       notify:
         - Restart rax-maas
 

--- a/playbooks/maas-openstack-horizon.yml
+++ b/playbooks/maas-openstack-horizon.yml
@@ -41,7 +41,7 @@
       notify:
         - Restart rax-maas
 
-    - name: Install horizon lb checks
+    - name: install horizon lb checks
       template:
         src: "templates/rax-maas/lb_api_check_horizon.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/lb_api_check_horizon.yaml"
@@ -51,6 +51,21 @@
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
+      notify:
+        - Restart rax-maas
+
+    - name: install horizon private lb checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_horizon.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_horizon.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
       notify:
         - Restart rax-maas
 
@@ -65,6 +80,7 @@
       when:
         - maas_ssl_check | bool
         - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
       notify:
         - Restart rax-maas
 

--- a/playbooks/maas-openstack-ironic.yml
+++ b/playbooks/maas-openstack-ironic.yml
@@ -77,6 +77,21 @@
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
+      notify:
+        - Restart rax-maas
+
+    - name: Install ironic api private lb checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_ironic_api.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_ironic_api.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
       notify:
         - Restart rax-maas
 

--- a/playbooks/maas-openstack-keystone.yml
+++ b/playbooks/maas-openstack-keystone.yml
@@ -104,6 +104,21 @@
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
+      notify:
+        - Restart rax-maas
+
+    - name: Install keystone private lb checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_keystone.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_keystone.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
       notify:
         - Restart rax-maas
 

--- a/playbooks/maas-openstack-neutron.yml
+++ b/playbooks/maas-openstack-neutron.yml
@@ -77,6 +77,21 @@
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
+      notify:
+        - Restart rax-maas
+
+    - name: Install neutron private lb checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_neutron.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_neutron.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
       notify:
         - Restart rax-maas
 

--- a/playbooks/maas-openstack-nova.yml
+++ b/playbooks/maas-openstack-nova.yml
@@ -111,6 +111,21 @@
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
+      notify:
+        - Restart rax-maas
+
+    - name: Install nova private lb checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_nova.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_nova.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
       notify:
         - Restart rax-maas
 

--- a/playbooks/maas-openstack-swift.yml
+++ b/playbooks/maas-openstack-swift.yml
@@ -238,7 +238,7 @@
       register: mon_user
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
-        - maas_remote_check | bool
+        - (maas_private_monitoring_enabled | bool) or (maas_remote_check | bool)
         - maas_swift_accesscheck_enabled | bool
         - inventory_hostname in groups['swift_proxy'][0]
 
@@ -249,7 +249,7 @@
         dest: "/tmp/index.html"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
-        - maas_remote_check | bool
+        - (maas_private_monitoring_enabled | bool) or (maas_remote_check | bool)
         - maas_swift_accesscheck_enabled | bool
         - inventory_hostname in groups['swift_proxy'][0]
 
@@ -271,7 +271,7 @@
       changed_when: false
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
-        - maas_remote_check | bool
+        - (maas_private_monitoring_enabled | bool) or (maas_remote_check | bool)
         - maas_swift_accesscheck_enabled | bool
         - inventory_hostname in groups['swift_proxy'][0]
 
@@ -288,7 +288,7 @@
       changed_when: false
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
-        - maas_remote_check | bool
+        - (maas_private_monitoring_enabled | bool) or (maas_remote_check | bool)
         - maas_swift_accesscheck_enabled | bool
         - inventory_hostname in groups['swift_proxy'][0]
 
@@ -299,7 +299,7 @@
         maas_swift_access_url_key: "{{ swift_url_key.stdout }}"
       when:
         - maas_swift_access_url_key is undefined
-        - maas_remote_check | bool
+        - (maas_private_monitoring_enabled | bool) or (maas_remote_check | bool)
         - maas_swift_accesscheck_enabled | bool
         - inventory_hostname in groups['swift_proxy'][0]
 
@@ -401,6 +401,7 @@
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
       notify:
         - Restart rax-maas
 
@@ -414,6 +415,36 @@
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
+        - maas_swift_accesscheck_enabled | bool
+        - not maas_private_monitoring_enabled
+      notify:
+        - Restart rax-maas
+
+    - name: Install swift private lb health checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_swift_healthcheck.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_swift_healthcheck.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
+      notify:
+        - Restart rax-maas
+
+    - name: Install swift private lb access checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_swift_access.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_swift_access.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
         - maas_swift_accesscheck_enabled | bool
       notify:
         - Restart rax-maas

--- a/playbooks/maas-poller-all.yml
+++ b/playbooks/maas-poller-all.yml
@@ -13,36 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: maas-agent-all.yml
+- include: maas-poller-install.yml
   tags:
-    - maas
+    - maas-poller
 
-- include: maas-poller-all.yml
+- include: maas-poller-setup.yml
   tags:
-    - maas
-
-- include: maas-ceph-all.yml
-  tags:
-    - maas
-
-- include: maas-host-all.yml
-  tags:
-    - maas
-
-- include: maas-infra-all.yml
-  tags:
-    - maas
-
-- include: maas-container-all.yml
-  tags:
-    - maas
-
-- include: maas-openstack-all.yml
-  tags:
-    - maas
-
-# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
-#                  will be globally unified.
-- include: maas-restart.yml
-  vars:
-    maas_force_restart: true
+    - maas-poller

--- a/playbooks/maas-poller-install.yml
+++ b/playbooks/maas-poller-install.yml
@@ -1,0 +1,48 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in witing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Gather facts
+  hosts: shared-infra_hosts
+  gather_facts: "{{ gather_facts | default(true) }}"
+  tags:
+    - maas-poller-install
+
+- name: Install MaaS Poller
+  hosts: shared-infra_hosts
+  gather_facts: false
+  pre_tasks:
+    - name: Gather variables for each operating system
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
+      include_vars: "{{ item }}"
+      with_first_found:
+        - files:
+            - "vars/maas-poller-{{ ansible_distribution | lower }}.yml"
+            - "vars/maas-poller-{{ ansible_os_family | lower }}.yml"
+          skip: false
+
+    - name: Include distro install tasks
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
+        - ansible_distribution | lower == 'ubuntu'
+      include: "common-tasks/maas-poller-ubuntu-install.yml"
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas-poller-{{ ansible_distribution | lower }}.yml
+  tags:
+    - maas-poller-install

--- a/playbooks/maas-poller-setup.yml
+++ b/playbooks/maas-poller-setup.yml
@@ -48,6 +48,59 @@
         owner: root
         group: root
 
+    - name: Install check for poller's file descriptor usage
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
+      template:
+        src: "templates/rax-maas/maas_poller_fd_count.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/maas_poller_fd_count--{{ inventory_hostname }}.yaml"
+        mode: 0644
+        owner: root
+        group: root
+
+    # NOTE: This step is currently handled directly in the systemd
+    # service config file.
+    - name: Increase MaaS poller file descriptor limit on 14.04
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
+        - ansible_distribution_version == "14.04"
+      lineinfile:
+        name: /etc/init/rackspace-monitoring-poller.conf
+        regexp: "^limit nofile 16384 16384"
+        insertbefore: "^pre-start script"
+        line: "limit nofile 16384 16384"
+
+    - name: Add poller config in systemd unit file on 16.04
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
+        - ansible_distribution_version == "16.04"
+      lineinfile:
+        name: /lib/systemd/system/rackspace-monitoring-poller.systemd.service
+        insertafter: '^\[Service\]'
+        line: "EnvironmentFile=/etc/default/rackspace-monitoring-poller"
+
+    - name: Use poller config in systemd unit file on 16.04
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
+        - ansible_distribution_version == "16.04"
+      lineinfile:
+        name: /lib/systemd/system/rackspace-monitoring-poller.systemd.service
+        regexp: "^ExecStart="
+        insertafter: "^[Service]"
+        line: "ExecStart=/usr/bin/rackspace-monitoring-poller serve --config $CONFIG_FILE $POLLER_SERVE_OPTS"
+
+    - name: Reload systemd unit configurations on 16.04
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
+        - ansible_distribution_version == "16.04"
+      command: "systemctl daemon-reload"
+      changed_when: False
+
     # NOTE: With the way the poller is currently named, we can't
     # start it up one way for both Trusty and Xenial. The systemd
     # setup requires the full "systemd.service" at the end.
@@ -76,5 +129,6 @@
   vars_files:
     - vars/main.yml
     - vars/maas-poller.yml
+    - vars/maas-host.yml
   tags:
     - maas-poller-setup

--- a/playbooks/maas-poller-setup.yml
+++ b/playbooks/maas-poller-setup.yml
@@ -1,0 +1,80 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in witing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Gather facts
+  hosts: shared-infra_hosts
+  gather_facts: "{{ gather_facts | default(true) }}"
+  pre_tasks:
+    - include: "common-tasks/maas_excluded_regex.yml"
+  tags:
+    - maas-poller-setup
+
+- name: Setup MaaS Poller
+  hosts: shared-infra_hosts
+  gather_facts: false
+
+  tasks:
+    - name: Generate MaaS poller config
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
+      template:
+        src: "templates/rax-maas/rackspace-monitoring-poller.cfg"
+        dest: /etc/rackspace-monitoring-poller.cfg
+        mode: 0600
+        owner: root
+        group: root
+
+    - name: Enable MaaS poller via config
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
+      copy:
+        src: files/rackspace-monitoring-poller-enabled
+        dest: /etc/default/rackspace-monitoring-poller
+        mode: 0600
+        owner: root
+        group: root
+
+    # NOTE: With the way the poller is currently named, we can't
+    # start it up one way for both Trusty and Xenial. The systemd
+    # setup requires the full "systemd.service" at the end.
+    - name: Start MaaS poller (systemd)
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
+        - ansible_distribution_version == "16.04"
+      service:
+        name: rackspace-monitoring-poller.systemd.service
+        state: started
+        enabled: yes
+
+    - name: Start MaaS poller (upstart)
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
+        - ansible_distribution_version == "14.04"
+      service:
+        name: rackspace-monitoring-poller
+        state: started
+        enabled: yes
+
+  handlers:
+    - include: handlers/main.yml
+  vars_files:
+    - vars/main.yml
+    - vars/maas-poller.yml
+  tags:
+    - maas-poller-setup

--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -31,7 +31,7 @@
         - maas_private_monitoring_enabled | bool
         - maas_restart_independent | default(true) | bool or
           maas_force_restart | default(false) | bool
-        - ansible_distribution == "16.04"
+        - ansible_distribution_version == "16.04"
 
     - name: Restart rackspace-monitoring-poller (upstart)
       service:
@@ -47,7 +47,7 @@
         - maas_private_monitoring_enabled | bool
         - maas_restart_independent | default(true) | bool or
           maas_force_restart | default(false) | bool
-        - ansible_distribution == "14.04"
+        - ansible_distribution_version == "14.04"
 
     - name: Restart rackspace-monitoring-agent
       service:

--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -17,14 +17,51 @@
   hosts: "{{ maas_restart_on_host_override | default('maas_restart_on_host') }}"
   gather_facts: false
   tasks:
+    - name: Restart rackspace-monitoring-poller (systemd)
+      service:
+        name: rackspace-monitoring-poller.systemd.service
+        state: restarted
+        sleep: 10
+      register: _maas_poller_restart
+      until: _maas_poller_restart | success
+      retries: 3
+      delay: 2
+      when:
+        - physical_host in groups['shared-infra_hosts']
+        - maas_private_monitoring_enabled | bool
+        - maas_restart_independent | default(true) | bool or
+          maas_force_restart | default(false) | bool
+        - ansible_distribution == "16.04"
+
+    - name: Restart rackspace-monitoring-poller (upstart)
+      service:
+        name: rackspace-monitoring-poller
+        state: restarted
+        sleep: 10
+      register: _maas_poller_restart
+      until: _maas_poller_restart | success
+      retries: 3
+      delay: 2
+      when:
+        - physical_host in groups['shared-infra_hosts']
+        - maas_private_monitoring_enabled | bool
+        - maas_restart_independent | default(true) | bool or
+          maas_force_restart | default(false) | bool
+        - ansible_distribution == "14.04"
+
     - name: Restart rackspace-monitoring-agent
       service:
         name: rackspace-monitoring-agent
         state: restarted
-      register: _maas_restart
-      until: _maas_restart | success
+      register: _maas_agent_restart
+      until: _maas_agent_restart | success
       retries: 3
       delay: 2
       when: >
         maas_restart_independent | default(true) | bool or
         maas_force_restart | default(false) | bool
+
+  vars_files:
+    - vars/main.yml
+  tags:
+    - maas-restart

--- a/playbooks/templates/rax-maas/maas_poller_fd_count.yaml.j2
+++ b/playbooks/templates/rax-maas/maas_poller_fd_count.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "maas_poller_fd_count" %}
+{% set check_name = label+'--'+ansible_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}/maas_poller_fd_count.py"]
+alarms      :
+    maas_poller_fd_count_status :
+        label                   : maas_poller_fd_count_status--{{ ansible_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan }}"
+        disabled                : {{ (('maas_poller_fd_count_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (percentage(metric["maas_poller_fd_count"] , metric["maas_poller_fd_max"]) > {{ maas_poller_fd_critical_threshold }}) {
+                return new AlarmStatus(CRITICAL, "MaaS poller file descriptor usage is > {{ maas_poller_fd_critical_threshold }}% of maximum allowed.");
+            }
+            if (percentage(metric["maas_poller_fd_count"] , metric["maas_poller_fd_max"]) > {{ maas_poller_fd_warning_threshold }}) {
+                return new AlarmStatus(WARNING, "MaaS poller file descriptor usage is > {{ maas_poller_fd_warning_threshold }}% of maximum allowed.");
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_cinder.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_cinder.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_cinder" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ internal_vip_address }}"
+details           :
+    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8776"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_cinder     :
+        label               : private_lb_api_alarm_cinder
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_cinder' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '200' && metric['code'] != '300') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_glance.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_glance.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_glance" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ internal_vip_address }}"
+details           :
+    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:9292"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_glance     :
+        label               : private_lb_api_alarm_glance
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_glance' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '300') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_heat_api.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_heat_api.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_heat_api" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ internal_vip_address }}"
+details           :
+    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8004"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_heat_api   :
+        label               : private_lb_api_alarm_heat_api
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_heat_api' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '300') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_heat_cfn.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_heat_cfn.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_heat_cfn" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ internal_vip_address }}"
+details           :
+    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8000"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_heat_cfn   :
+        label               : private_lb_api_alarm_heat_cfn
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_heat_cfn' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '300') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_heat_cloudwatch.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_heat_cloudwatch.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_heat_cloudwatch" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ internal_vip_address }}"
+details           :
+    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8003"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_heat_cloudwatch :
+        label               : private_lb_api_alarm_heat_cloudwatch
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_heat_cloudwatch' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '300') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_horizon.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_horizon.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_horizon" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ internal_vip_address }}"
+details           :
+    url           : "{{ maas_horizon_scheme | default(maas_scheme)}}://{{ internal_vip_address }}:443/auth/login/"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_horizon     :
+        label               : private_lb_api_alarm_horizon
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_horizon' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '200') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_ironic_api.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_ironic_api.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_ironic_api" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (inventory_hostname != groups['ironic_api'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ internal_vip_address }}"
+details           :
+    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:6385"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_ironic_api   :
+        label               : private_lb_api_alarm_ironic_api
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_ironic_api' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '200') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_keystone.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_keystone.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_keystone" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ internal_vip_address }}"
+details           :
+    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:5000"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_keystone   :
+        label               : private_lb_api_alarm_keystone
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_keystone' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '300') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_neutron.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_neutron.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_neutron" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ internal_vip_address }}"
+details           :
+    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:9696/"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_neutron    :
+        label               : private_lb_api_alarm_neutron
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_neutron' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '200') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_nova.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_nova.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_nova" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ internal_vip_address }}"
+details           :
+    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8774"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_nova       :
+        label               : private_lb_api_alarm_nova
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_nova' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '200') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_swift_access.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_swift_access.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_swift_access" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ internal_vip_address }}"
+details           :
+    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8080/v1/{{ hostvars[groups['swift_proxy'][0]]['maas_swift_access_url_key'] }}/{{ maas_swift_accesscheck_container }}/index.html"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_swift_access:
+        label               : private_lb_api_alarm_swift_access
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_swift_access' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '200') {
+                return new AlarmStatus(CRITICAL, 'Data unavailable.');
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_swift_healthcheck.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_swift_healthcheck.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_swift_healthcheck" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ internal_vip_address }}"
+details           :
+    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8080/healthcheck"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_swift_healthcheck:
+        label               : private_lb_api_alarm_swift_healthcheck
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_swift_healthcheck' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '200') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/templates/rax-maas/private_ping_check.yaml.j2
+++ b/playbooks/templates/rax-maas/private_ping_check.yaml.j2
@@ -1,0 +1,26 @@
+{% set label = "private_ping_check" %}
+{% set check_name = label+'--'+inventory_hostname %}
+type              : remote.ping
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[check_name] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[check_name] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_hostname   : "{{ ansible_default_ipv4.address }}"
+details           :
+  count           : {{ private_ping_check_count }}
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+metadata          :
+  event-type-override: "ping"
+alarms            :
+  Packet_loss               :
+        label               : packet_loss--{{ inventory_hostname|quote }}
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ (('private_ping_check--'+inventory_hostname | quote) | match(
+        maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount=3
+            if (metric['available'] > 80) {
+                return new AlarmStatus(OK, 'Ping responds as expected');
+            }
+            return new AlarmStatus(CRITICAL, 'Packet loss has occurred');

--- a/playbooks/templates/rax-maas/private_ssh_check.yaml.j2
+++ b/playbooks/templates/rax-maas/private_ssh_check.yaml.j2
@@ -1,0 +1,27 @@
+{% set label = "private_ssh_check" %}
+{% set check_name = label+'--'+inventory_hostname %}
+type              : remote.tcp
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[check_name] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[check_name] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_hostname   : "{{ ansible_default_ipv4.address }}"
+details           :
+  port            : {{ private_ssh_port }}
+  banner_match    : "SSH"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+metadata          :
+  event-type-override: "ssh"
+alarms            :
+  Banner_Match              :
+        label               : banner_match--{{ inventory_hostname|quote }}
+        notification_plan_id: "{{ maas_notification_plan }}"
+        disabled            : {{ (('private_ssh_check--'+inventory_hostname | quote) | match(
+        maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount=3
+            if (metric['banner_match'] == "") {
+                return new AlarmStatus(CRITICAL, 'Banner not found. Expected: SSH');
+            }
+            return new AlarmStatus(OK, 'SSH service responds as expected.');

--- a/playbooks/templates/rax-maas/rackspace-monitoring-poller.cfg
+++ b/playbooks/templates/rax-maas/rackspace-monitoring-poller.cfg
@@ -1,0 +1,3 @@
+monitoring_token {{ maas_agent_token }}
+monitoring_id {{ maas_entity_name }}
+monitoring_private_zones {{ maas_private_monitoring_zone }}

--- a/playbooks/vars/maas-agent.yml
+++ b/playbooks/vars/maas-agent.yml
@@ -30,18 +30,6 @@ maas_pip_packages:
   - requests
   - waxeye
 
-maas_username: "admin"
-
-maas_api_key: null
-
-maas_auth_url: "https://identity.api.rackspacecloud.com/v2.0"
-
-maas_auth_method: "token"
-
-maas_auth_token: "{{ lookup('env', 'MAAS_AUTH_TOKEN') | default(null) }}"
-
-maas_api_url: "{{ lookup('env', 'MAAS_API_URL') | default(null) }}"
-
 ## PIP for maas
 # Path to pip download/installation script.
 maas_pip_upstream_url: https://bootstrap.pypa.io/get-pip.py

--- a/playbooks/vars/maas-auth.yml
+++ b/playbooks/vars/maas-auth.yml
@@ -1,0 +1,11 @@
+maas_username: "admin"
+
+maas_api_key: null
+
+maas_auth_url: "https://identity.api.rackspacecloud.com/v2.0"
+
+maas_auth_method: "token"
+
+maas_auth_token: "{{ lookup('env', 'MAAS_AUTH_TOKEN') | default(null) }}"
+
+maas_api_url: "{{ lookup('env', 'MAAS_API_URL') | default(null) }}"

--- a/playbooks/vars/maas-host.yml
+++ b/playbooks/vars/maas-host.yml
@@ -74,6 +74,9 @@ maas_cpu_idle_percent_avg_critical_threshold: 1.0
 maas_nf_conntrack_warning_threshold: 80
 maas_nf_conntrack_critical_threshold: 90
 
+maas_poller_fd_warning_threshold: 80
+maas_poller_fd_critical_threshold: 90
+
 maas_network_checks_list:
   - name: "{{ ansible_default_ipv4.interface }}"
     max_speed: null

--- a/playbooks/vars/maas-poller-ubuntu.yml
+++ b/playbooks/vars/maas-poller-ubuntu.yml
@@ -13,36 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: maas-agent-all.yml
-  tags:
-    - maas
+maas_keys:
+  url: "https://monitoring.api.rackspacecloud.com/pki/agent/linux.asc"
+  state: "present"
 
-- include: maas-poller-all.yml
-  tags:
-    - maas
+maas_poller_repos:
+  repo: "deb [arch=amd64] http://stable.poller.packages.cloudmonitoring.rackspace.com/debian cloudmonitoring main"
+  state: "present"
 
-- include: maas-ceph-all.yml
-  tags:
-    - maas
-
-- include: maas-host-all.yml
-  tags:
-    - maas
-
-- include: maas-infra-all.yml
-  tags:
-    - maas
-
-- include: maas-container-all.yml
-  tags:
-    - maas
-
-- include: maas-openstack-all.yml
-  tags:
-    - maas
-
-# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
-#                  will be globally unified.
-- include: maas-restart.yml
-  vars:
-    maas_force_restart: true
+maas_poller_distro_packages:
+  - rackspace-monitoring-poller

--- a/playbooks/vars/maas-poller.yml
+++ b/playbooks/vars/maas-poller.yml
@@ -13,36 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: maas-agent-all.yml
-  tags:
-    - maas
+#
+# private_ping_check_count: Number of times to try ping check in private
+#                           network monitoring case. Must be integer
+#                           1-15 inclusive.
+private_ping_check_count: 6
 
-- include: maas-poller-all.yml
-  tags:
-    - maas
-
-- include: maas-ceph-all.yml
-  tags:
-    - maas
-
-- include: maas-host-all.yml
-  tags:
-    - maas
-
-- include: maas-infra-all.yml
-  tags:
-    - maas
-
-- include: maas-container-all.yml
-  tags:
-    - maas
-
-- include: maas-openstack-all.yml
-  tags:
-    - maas
-
-# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
-#                  will be globally unified.
-- include: maas-restart.yml
-  vars:
-    maas_force_restart: true
+#
+# private_ssh_port: The port number to use for SSH connections.
+private_ssh_port: 22

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -184,6 +184,19 @@ maas_monitoring_zones:
   - mzhkg
 
 #
+# maas_private_monitoring_enabled: This flag indicates if the
+#                                  rackspace-monitoring-poller will be
+#                                  installed and configured.
+#
+maas_private_monitoring_enabled: false
+
+#
+# maas_private_monitoring_zone: Specifies the private zone for use with
+#                               rackspace-monitoring-poller.
+#
+maas_private_monitoring_zone:
+
+#
 # host_check: This flag indicates if the host-related hardware monitoring checks and alarms should
 #             be deployed.
 #

--- a/releasenotes/notes/add-maas-poller-cd3406a6cc5efa86.yaml
+++ b/releasenotes/notes/add-maas-poller-cd3406a6cc5efa86.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Add support for the rackspace-monitoring-poller, which enables the
+    monitoring of private networks. This introduces a private version of the
+    set of API checks that are made against each of the OpenStack services,
+    all with the prefix ``private_lb_api_check``.
+
+    In order to have the poller installed and setup, the
+    ``maas_private_monitoring_enabled`` variable needs to be set to ``True``,
+    and a value for ``maas_private_monitoring_zone`` must be set.

--- a/releasenotes/notes/increase-poller-file-descriptor-limit-c67ad6f4d25bacbc.yaml
+++ b/releasenotes/notes/increase-poller-file-descriptor-limit-c67ad6f4d25bacbc.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Set the file descriptor limit for rackspace-monitoring-poller to 16384.
+    This change ensures that regardless of which platform the poller is
+    running on, the file descriptor limit will be set to 16384.
+
+    Additionally, this change adds a check on rackspace-monitoring-poller's
+    file descriptor usage, prefixed with ``maas_poller_fd_count``, which
+    creates a warning alert at 80% capacity and a critical alert at 90%
+    capacity of the 16384 limit.


### PR DESCRIPTION
This change adds `rackspace-monitoring-poller` in a similar fashion to how `rackspace-monitoring-agent` is added, and sets up the appropriate configuration files as well as moves the `lb_api_check*` check templates to use the appropriate values for being run against the private poller.

Fixes rcbops/rpc-openstack#2184