### PR TITLE
Allow cache status to remain 'Not Configured' when ssds are utilized

### DIFF
--- a/playbooks/files/rax-maas/plugins/hp_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/hp_monitoring.py
@@ -61,7 +61,7 @@ def get_controller_status():
 
 def get_controller_cache_status():
     return check_command(('hpssacli', 'ctrl', 'all', 'show', 'status'),
-                         'Cache Status', 'OK')
+                         'Cache Status', ('OK', 'Not Configured'))
 
 
 def get_controller_battery_status():


### PR DESCRIPTION
For customers that use SSD in their arrays, the cache is not enabled and will have a status of 'Not Configured'. This inclusion should still catch failures of the cache as they will show up as disabled.