### PR TITLE
[LA-314] change log_hosts to influx_hosts

### DIFF
--- a/doc/source/static-inventory.rst
+++ b/doc/source/static-inventory.rst
@@ -426,3 +426,18 @@ section.
     swift_proxy
     swift_cont
     swift_obj
+
+
+influx_hosts
+~~~~~~~~~~~~
+
+If you have node(s) running ``influx``, add the node(s) into the "influx_hosts"
+section.
+
+.. code-block:: ini
+
+    [influx_hosts]
+    influx1
+
+    [influx_all:children]
+    influx_hosts

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -248,9 +248,42 @@ Deploying the TIGK Stack
 
 If ``the maas-tigkstack-all.yml`` Playbook is run **telegraf** will be
 installed throughout the deployment and **influxdb** will be installed
-within the *log_host*. Enabling this service will immediately being
+within the *influx_hosts*. Enabling this service will immediately being
 collecting metrics within the deployment using the existing MaaS plugins
 and enabled checks.
+
+If you're deploying InfluxDB within OpenStack-Ansible you will need to create
+a configuration entry for the *influx_hosts* in either the
+``openstack_user_config.yml`` or an isolated ``conf.d`` file.
+
+Example configuration file:
+
+.. code-block:: yaml
+
+    influx_hosts:
+      aio1:
+        ip: 172.29.236.100
+
+You can also pin the influx_hosts to an existing host group by adding an
+environment file (``env.d``). In the following example *influx_hosts* is
+being linked to the *log_hosts* group within OpenStack-Ansible.
+
+.. code-block:: yaml
+
+    component_skel:
+      influx:
+        belongs_to:
+          - influx_all
+          - influx_hosts
+
+    container_skel:
+      influx_container:
+        belongs_to:
+          - log_containers
+        contains:
+          - influx
+        properties:
+          is_metal: true
 
 
 Collecting metrics for time series analysis

--- a/playbooks/maas-tigkstack-influxdb.yml
+++ b/playbooks/maas-tigkstack-influxdb.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Deploy influxdb
-  hosts: log_hosts
+  hosts: influx_hosts
   gather_facts: true
   pre_tasks:
     - name: Gather variables for each operating system
@@ -24,6 +24,7 @@
             - "vars/maas-{{ ansible_distribution | lower }}.yml"
             - "vars/maas-{{ ansible_os_family | lower }}.yml"
           skip: true
+
   tasks:
     - name: Check init system
       command: cat /proc/1/comm

--- a/playbooks/templates/tigkstack/relay.toml.j2
+++ b/playbooks/templates/tigkstack/relay.toml.j2
@@ -3,8 +3,8 @@ name = "example-http"
 bind-addr = '0.0.0.0:{{ influxdb_relay_port  }}'
 output = [
 {% set i =1%}
-{%for host_name in groups['log_hosts'] %}
+{% for host_name in groups['influx_hosts'] | default([]) %}
     { name="local{{ i }}", location = "http://{{ hostvars[host_name]['ansible_host'] | default(hostvars[host_name]['ansible_ssh_host']) }}:{{ influxdb_port }}/write"},
-{%set i = i + 1%}
-{%endfor%}
+{% set i = i + 1%}
+{% endfor%}
 ]

--- a/playbooks/templates/tigkstack/telegraf.conf.j2
+++ b/playbooks/templates/tigkstack/telegraf.conf.j2
@@ -22,7 +22,7 @@
   omit_hostname = false
 
 {%   set influx_targets = [] %}
-{%   for item in groups['log_hosts'] %}
+{%   for item in groups['influx_hosts'] | default([]) %}
 {%     set target = influxdb_protocol + '://' + hostvars[item]['ansible_host'] | default(hostvars[item]['ansible_ssh_host']) + ':' + influxdb_port | string %}
 {%     set _ = influx_targets.extend([target]) %}
 {%   endfor %}


### PR DESCRIPTION
This change creates a specific group for influxdb deployments. This
change is being done so that we dont assume the log hosts will be used
for metric collection.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>