### PR TITLE
UG-634 Install python-swiftclient on swift hosts

### DIFF
--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -59,6 +59,7 @@ maas_openstack_nova_pip_packages:
 
 maas_openstack_swift_pip_packages:
   - python-openstackclient
+  - python-swiftclient
 
 #
 # The Cinder backup monitor can be turned on or off based on provided config.


### PR DESCRIPTION
Currently, deploying rpc-maas on a multi-node deplay fails when
attempting to upload a file with the swift client as this role
currently does not install python-swiftclient.

This commit simply adds python-swiftclient to the
maas_openstack_swift_pip_packages variable.