### PR TITLE
Override raxmon ssl verification for non-transparent web proxy

### DIFF
--- a/playbooks/library/raxmon.py
+++ b/playbooks/library/raxmon.py
@@ -164,9 +164,6 @@ def main():
 
     # Provide the ability to enable or disable SSL certificate verification
     # with raxmon
-    CA_CERT_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                           'data/cacert.pem')
-    libcloud.security.CA_CERTS_PATH.append(CA_CERT_PATH)
     cfg = ConfigParser.RawConfigParser()
     cfg.read(module.params['raxmon_cfg'])
     verify_ssl = cfg.get('ssl', 'verify')

--- a/playbooks/library/raxmon.py
+++ b/playbooks/library/raxmon.py
@@ -160,6 +160,21 @@ def main():
     # importing the correct libraries
     from rackspace_monitoring.providers import get_driver
     from rackspace_monitoring.types import Provider
+    import libcloud.security
+
+    # Provide the ability to enable or disable SSL certificate verification
+    # with raxmon
+    CA_CERT_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                           'data/cacert.pem')
+    libcloud.security.CA_CERTS_PATH.append(CA_CERT_PATH)
+    cfg = ConfigParser.RawConfigParser()
+    cfg.read(module.params['raxmon_cfg'])
+    verify_ssl = cfg.get('ssl', 'verify')
+    if verify_ssl == 'true':
+        verify_ssl = True
+    else:
+        verify_ssl = False
+    libcloud.security.VERIFY_SSL_CERT = verify_ssl
 
     conn = _get_conn(get_driver, Provider, module.params['raxmon_cfg'])
 

--- a/playbooks/templates/rax-maas/raxrc.j2
+++ b/playbooks/templates/rax-maas/raxrc.j2
@@ -13,4 +13,4 @@ token={{ maas_auth_token }}
 {% endif %}
 
 [ssl]
-verify=true
+verify={{ maas_raxmon_ssl_verify }}

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -59,6 +59,7 @@ maas_openstack_nova_pip_packages:
 
 maas_openstack_swift_pip_packages:
   - python-openstackclient
+  - python-swiftclient
 
 #
 # The Cinder backup monitor can be turned on or off based on provided config.

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -199,3 +199,9 @@ maas_keystone_user: maas
 #
 #
 maas_agent_upgrade: true
+
+#
+# maas_raxmon_ssl_verify: Allow enabling or disabling raxmon ssl verification
+#
+#
+maas_raxmon_ssl_verify: true


### PR DESCRIPTION
The hardcoded nature of raxmon SSL verification can be problematic if a customer is using a non-transparent web proxy, which will fail verification checks. This allows an override for verification allowing the playbooks to properly set an entities agentID.