### PR TITLE
Consistent naming for check labels

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -313,7 +313,7 @@ where the job reference tag is equal to the string "testing".
 Legacy Ceph monitoring
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Early versions of RPC-O have a specific Ceph deployment that deployed
+Early versions of RPC-O have a specific Ceph deployment style that deployed
 all of the Ceph components in containers in a very RPC-O specific way.
 To monitor these environments the RPC-MaaS checks need to descend into the
 containers and run the various plugins from within the environment which is

--- a/playbooks/templates/rax-maas/ceph_cluster_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_cluster_stats.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "ceph_cluster_stats" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
 {% if maas_rpc_legacy_ceph | bool %}
 {%   set _ = ceph_args.extend(["--container-name " + container_name]) %}
@@ -18,9 +18,9 @@ details     :
     args    : {{ ceph_args }}
 alarms      :
     ceph_health_err :
-        label                   : ceph_health_err--{{ ansible_hostname }}
+        label                   : ceph_health_err--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('ceph_health_err--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('ceph_health_err--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cluster_health"] == 0) {
@@ -28,9 +28,9 @@ alarms      :
             }
 
     ceph_health_warn :
-        label                   : ceph_health_warn--{{ ansible_hostname }}
+        label                   : ceph_health_warn--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('ceph_health_warn--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('ceph_health_warn--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cluster_health"] == 1) {

--- a/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
@@ -1,10 +1,10 @@
 {% set label = "ceph_mon_stats" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
 {% if maas_rpc_legacy_ceph | bool %}
 {%   set _ = ceph_args.extend(["--container-name " + container_name]) %}
 {% endif %}
-{% set _ = ceph_args.extend(["mon", "--host " + ansible_hostname]) %}
+{% set _ = ceph_args.extend(["mon", "--host " + inventory_hostname]) %}
 {% set _ceph_args = ceph_args | join(' ') | string %}
 {% set ceph_args = _ceph_args.split() %}
 
@@ -18,9 +18,9 @@ details     :
     args    : {{ ceph_args }}
 alarms      :
     mon_health_err :
-        label                   : mon_health_err--{{ ansible_hostname }}
+        label                   : mon_health_err--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('mon_health_err--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('mon_health_err--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["mon_health"] == 0) {
@@ -28,9 +28,9 @@ alarms      :
             }
 
     mon_health_warn :
-        label                   : mon_health_warn--{{ ansible_hostname }}
+        label                   : mon_health_warn--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('mon_health_err--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('mon_health_err--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["mon_health"] == 1) {

--- a/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "ceph_osd_stats" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
 {% if maas_rpc_legacy_ceph | bool %}
 {%   set _ = ceph_args.extend(["--container-name " + container_name]) %}
@@ -19,9 +19,9 @@ details     :
 alarms      :
 {% for osd_id in ceph_osd_host['osd_ids'] %}
     ceph_warn_osd.{{ osd_id }} :
-        label                   : ceph_warn_osd.{{ osd_id }}--{{ ansible_hostname }}
+        label                   : ceph_warn_osd.{{ osd_id }}--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('ceph_warn_osd.'+osd_id|string+'--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('ceph_warn_osd.'+osd_id|string+'--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["osd.{{ osd_id }}_up"] == 0) {

--- a/playbooks/templates/rax-maas/checks_base.yaml.j2
+++ b/playbooks/templates/rax-maas/checks_base.yaml.j2
@@ -1,5 +1,5 @@
 ---
-{% set label_name = item.label+'--'+ansible_hostname %}
+{% set label_name = item.label+'--'+inventory_hostname %}
 label: "{{ label_name }}"
 period: "{{ maas_check_period_override[item.label] | default(maas_check_period) }}"
 timeout: "{{ maas_check_timeout_override[item.label] | default(maas_check_timeout) }}"

--- a/playbooks/templates/rax-maas/cinder_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_api_local_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "cinder_api_local_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/cinder_api_local_check.py", "{{ ansible_host }}"]
 alarms      :
     cinder_api_local_status :
-        label                   : cinder_api_local_status--{{ ansible_hostname }}
+        label                   : cinder_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('cinder_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('cinder_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cinder_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/cinder_backup_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_backup_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "cinder_backup_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/cinder_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     cinder_backup_status :
-        label                   : cinder_backup_status--{{ ansible_hostname }}
+        label                   : cinder_backup_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('cinder_backup_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('cinder_backup_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cinder-backup_status"] != 1) {

--- a/playbooks/templates/rax-maas/cinder_scheduler_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_scheduler_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "cinder_scheduler_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/cinder_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     cinder_scheduler_status :
-        label                   : cinder_scheduler_status--{{ ansible_hostname }}
+        label                   : cinder_scheduler_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('cinder_scheduler_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('cinder_scheduler_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cinder-scheduler_status"] != 1) {

--- a/playbooks/templates/rax-maas/cinder_vg_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_vg_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "cinder_vg_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/vg_check.py", "{{ cinder_backends[item.key]['volume_group'] }}"]
 alarms      :
     cinder_vg_space_status :
-        label                   : cinder_vg_space_status--{{ ansible_hostname }}
+        label                   : cinder_vg_space_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('cinder_vg_space_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('cinder_vg_space_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["{{ cinder_backends[item.key]['volume_group'] }}_vg_used_space"], metric["{{ cinder_backends[item.key]['volume_group'] }}_vg_total_space"]) > {{ maas_cinder_volumes_vg_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/cinder_volume_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_volume_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "cinder_volume_"+item.key+"_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/cinder_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     cinder_volume_{{ item.key }}_status :
-        label                   : cinder_volume_{{ item.key }}_status--{{ ansible_hostname }}
+        label                   : cinder_volume_{{ item.key }}_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('cinder_volume_'+item.key+'_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('cinder_volume_'+item.key+'_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["cinder-volume-{{ item.key}}_status"] != 1) {

--- a/playbooks/templates/rax-maas/conntrack_count.yaml.j2
+++ b/playbooks/templates/rax-maas/conntrack_count.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "conntrack_count" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/conntrack_count.py"]
 alarms      :
     conntrack_count_status :
-        label                   : conntrack_count_status--{{ ansible_hostname }}
+        label                   : conntrack_count_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('conntrack_count_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('conntrack_count_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["nf_conntrack_count"] , metric["nf_conntrack_max"]) > {{ maas_nf_conntrack_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/container_storage_checks.yaml.j2
+++ b/playbooks/templates/rax-maas/container_storage_checks.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "container_storage_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/container_storage_check.py", "--thresh", "{{ maas_percent_used_critical_threshold }}"]
 alarms      :
     container_storage_percent_used_critical:
-        label                   : container_storage_percent_used--{{ ansible_hostname }}
+        label                   : container_storage_percent_used--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('container_storage_percent_used_critical--' + ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('container_storage_percent_used_critical--' + inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["container_storage_percent_used_critical"] != 1) {

--- a/playbooks/templates/rax-maas/cpu_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cpu_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "cpu_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type              : agent.cpu
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"

--- a/playbooks/templates/rax-maas/disk_utilisation.yaml.j2
+++ b/playbooks/templates/rax-maas/disk_utilisation.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "disk_utilisation" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -11,9 +11,9 @@ details     :
 alarms      :
 {% for device in maas_disk_util_devices %}
     percentage_disk_utilisation_{{ device }}:
-        label                   : percentage_disk_utilisation_{{ device }}--{{ ansible_hostname }}
+        label                   : percentage_disk_utilisation_{{ device }}--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('percentage_disk_utilisation_'+device+'--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('percentage_disk_utilisation_'+device+'--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["disk_utilisation_{{ device }}"] > {{ maas_disk_utilisation_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/elasticsearch_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/elasticsearch_process_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "elasticsearch_process_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -11,12 +11,12 @@ details     :
 alarms      :
 {% for process in elasticsearch_process_names %}
     {{ process }}_process_status:
-        label                   : {{ process }}_process_status--{{ ansible_hostname }}
+        label                   : {{ process }}_process_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ ((process+'_process_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ process }}_process_status"] != 1 ) {
-                return new AlarmStatus(CRITICAL, "Elasticsearch process {{ process }} not running on {{ ansible_hostname }}");
+                return new AlarmStatus(CRITICAL, "Elasticsearch process {{ process }} not running on {{ inventory_hostname }}");
             }
 {% endfor %}

--- a/playbooks/templates/rax-maas/filebeat_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/filebeat_process_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "filebeat_process_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -11,12 +11,12 @@ details     :
 alarms      :
 {% for process in filebeat_process_names %}
     {{ process }}_process_status:
-        label                   : {{ process }}_process_status--{{ ansible_hostname }}
+        label                   : {{ process }}_process_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : "{{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
+        disabled                : "{{ ((process+'_process_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ process }}_process_status"] != 1 ) {
-                return new AlarmStatus(CRITICAL, "Filebeat process {{ process }} not running on {{ ansible_hostname }}");
+                return new AlarmStatus(CRITICAL, "Filebeat process {{ process }} not running on {{ inventory_hostname }}");
             }
 {% endfor %}

--- a/playbooks/templates/rax-maas/filesystem.yaml.j2
+++ b/playbooks/templates/rax-maas/filesystem.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "filesystem_"+item.filesystem %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.filesystem
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -9,9 +9,9 @@ details     :
     target  : "{{ item.filesystem }}"
 alarms      :
     filesystem_{{ item.filesystem }}_check :
-        label                   : "Disk space used on {{ item.filesystem }}--{{ ansible_hostname }}"
+        label                   : "Disk space used on {{ item.filesystem }}--{{ inventory_hostname }}"
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('Disk space used on '+item.filesystem+'--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('Disk space used on '+item.filesystem+'--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric['used'], metric['total']) >= {{ item.critical_threshold }}) {

--- a/playbooks/templates/rax-maas/galera_check.yaml.j2
+++ b/playbooks/templates/rax-maas/galera_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "galera_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,27 +10,27 @@ details     :
     args    : ["{{ maas_plugin_dir }}/galera_check.py", "-H", "{{ ansible_host }}"]
 alarms      :
     wsrep_cluster_size :
-        label                   : wsrep_cluster_size--{{ ansible_hostname }}
+        label                   : wsrep_cluster_size--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('wsrep_cluster_size--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('wsrep_cluster_size--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["wsrep_cluster_size"] < {{ groups["galera"] | length }}) {
                 return new AlarmStatus(CRITICAL, "Galera cluster size less than expected");
             }
     wsrep_local_state :
-        label                   : wsrep_local_state--{{ ansible_hostname }}
+        label                   : wsrep_local_state--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('wsrep_local_state--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('wsrep_local_state--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["wsrep_local_state_comment"] != "Synced" ) {
                 return new AlarmStatus(CRITICAL, "Galera cluster node not synced");
             }
     percentage_used_mysql_connections :
-        label                   : percentage_used_mysql_connections--{{ ansible_hostname }}
+        label                   : percentage_used_mysql_connections--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('percentage_used_mysql_connections--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('percentage_used_mysql_connections--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["mysql_current_connections"], metric["mysql_max_configured_connections"]) > {{ maas_mysql_connection_critical_threshold }} ) {
@@ -40,9 +40,9 @@ alarms      :
                 return new AlarmStatus(WARNING, "Mysql connectons has exceeded {{ maas_mysql_connection_warning_threshold }}% of configured maximum");
             }
     open_file_size_limit_reached :
-        label                   : open_file_size_limit_reached--{{ ansible_hostname }}
+        label                   : open_file_size_limit_reached--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('open_file_size_limit_reached--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('open_file_size_limit_reached--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["num_of_open_files"], metric["open_files_limit"]) > {{ maas_mysql_open_files_percentage_critical_threshold }}) {
@@ -52,9 +52,9 @@ alarms      :
                 return new AlarmStatus(WARNING, "Number of open files has exceeded {{ maas_mysql_open_files_percentage_warning_threshold }}% of open file limit");
             }
     innodb_row_lock_time_avg :
-        label                   : innodb_row_lock_time_avg--{{ ansible_hostname }}
+        label                   : innodb_row_lock_time_avg--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('innodb_row_lock_time_avg--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('innodb_row_lock_time_avg--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["innodb_row_lock_time_avg"] > {{ maas_innodb_row_lock_time_avg_critical_threshold }}) {
@@ -64,9 +64,9 @@ alarms      :
                 return new AlarmStatus(WARNING, "InnoDB row lock time average has exceeded {{ maas_innodb_row_lock_time_avg_warning_threshold }} milliseconds");
             }
     innodb_deadlocks :
-        label                   : innodb_deadlocks--{{ ansible_hostname }}
+        label                   : innodb_deadlocks--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('innodb_deadlocks--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('innodb_deadlocks--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["innodb_deadlocks"]) > {{ maas_innodb_deadlocks_rate_warning_threshold }}) {
@@ -76,9 +76,9 @@ alarms      :
                 return new AlarmStatus(CRITICAL, "InnoDB has experienced a deadlock rate greater than {{ maas_innodb_deadlocks_rate_critical_threshold }} per {{ maas_check_period }} seconds");
             }
     access_denied_errors :
-        label                   : access_denied_errors--{{ ansible_hostname }}
+        label                   : access_denied_errors--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('access_denied_errors--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('access_denied_errors--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["access_denied_errors"]) > {{ maas_mysql_access_denied_errors_rate_warning_threshold }}) {
@@ -88,9 +88,9 @@ alarms      :
                 return new AlarmStatus(CRITICAL, "Access denied errors rate is greater than {{ maas_mysql_access_denied_errors_rate_critical_threshold }} per maas_check_period_override[label] | default(maas_check_period) seconds");
             }
     aborted_clients :
-        label                   : aborted_clients--{{ ansible_hostname }}
+        label                   : aborted_clients--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('aborted_clients--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('aborted_clients--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["aborted_clients"]) > {{ maas_mysql_aborted_clients_rate_warning_threshold }}) {
@@ -100,9 +100,9 @@ alarms      :
                 return new AlarmStatus(CRITICAL, "Aborted clients rate is greater than {{ maas_mysql_aborted_clients_rate_critical_threshold }} per maas_check_period_override[label] | default(maas_check_period) seconds");
             }
     aborted_connects :
-        label                   : aborted_connects--{{ ansible_hostname }}
+        label                   : aborted_connects--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('aborted_connects--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('aborted_connects--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["aborted_connects"]) > {{ maas_mysql_aborted_connects_rate_warning_threshold }}) {

--- a/playbooks/templates/rax-maas/glance_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/glance_api_local_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "glance_api_local_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/glance_api_local_check.py", "{{ ansible_host }}"]
 alarms      :
     glance_api_local_status :
-        label                   : glance_api_local_status--{{ ansible_hostname }}
+        label                   : glance_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('glance_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('glance_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["glance_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/glance_registry_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/glance_registry_local_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "glance_registry_local_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/glance_registry_local_check.py", "{{ ansible_host }}"]
 alarms      :
     glance_registry_local_status :
-        label                   : glance_registry_local_status--{{ ansible_hostname }}
+        label                   : glance_registry_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('glance_registry_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('glance_registry_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["glance_registry_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/heat_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/heat_api_local_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "heat_api_local_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/heat_api_local_check.py", "{{ ansible_host }}"]
 alarms      :
     heat_api_local_status :
-        label                   : heat_api_local_status--{{ ansible_hostname }}
+        label                   : heat_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('heat_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('heat_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["heat_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/heat_cfn_api_check.yaml.j2
+++ b/playbooks/templates/rax-maas/heat_cfn_api_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "heat_cfn_api_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/service_api_local_check.py", "heat_cfn", "{{ ansible_host }}", "8000"]
 alarms      :
     heat_cfn_api_local_status :
-        label                   : heat_cfn_api_local_status--{{ ansible_hostname }}
+        label                   : heat_cfn_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('heat_cfn_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('heat_cfn_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["heat_cfn_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/heat_cw_api_check.yaml.j2
+++ b/playbooks/templates/rax-maas/heat_cw_api_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "heat_cw_api_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/service_api_local_check.py", "heat_cw", "{{ ansible_host }}", "8003"]
 alarms      :
     heat_cw_api_local_status :
-        label                   : heat_cw_api_local_status--{{ ansible_hostname }}
+        label                   : heat_cw_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('heat_cw_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('heat_cw_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["heat_cw_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/holland_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/holland_local_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "holland_local_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}holland_local_check.py", "{{ container_name }}", "{{ holland_venv_bin + '/holland' }}"]
 alarms      :
      holland_backup_status:
-        label                   : holland_backup_status--{{ ansible_hostname }}
+        label                   : holland_backup_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('holland_backup_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('holland_backup_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["holland_backup_status"] != 1) {

--- a/playbooks/templates/rax-maas/horizon_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/horizon_local_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "horizon_local_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/horizon_check.py", "{{ ansible_host }}", "{{ maas_horizon_site_name }}"]
 alarms      :
     horizon_local_status :
-        label                   : "horizon_local_status--{{ ansible_hostname }}"
+        label                   : "horizon_local_status--{{ inventory_hostname }}"
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('horizon_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('horizon_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["horizon_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/hp-check.yaml.j2
+++ b/playbooks/templates/rax-maas/hp-check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "hp-check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"

--- a/playbooks/templates/rax-maas/keystone_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/keystone_api_local_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "keystone_api_local_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/keystone_api_local_check.py", "{{ ansible_host }}"]
 alarms      :
     keystone_api_local_status :
-        label                   : keystone_api_local_status--{{ ansible_hostname }}
+        label                   : keystone_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('keystone_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('keystone_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["keystone_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/magnum_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/magnum_api_local_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "magnum_api_local_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/magnum_api_local_check.py", "{{ ansible_host }}"]
 alarms      :
     magnum_api_local_status :
-        label                   : magnum_api_local_status--{{ ansible_hostname }}
+        label                   : magnum_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('magnum_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('magnum_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["magnum_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/magnum_conductor_check.yaml.j2
+++ b/playbooks/templates/rax-maas/magnum_conductor_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "magnum_conductor_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/magnum_service_check.py", "{{ ansible_host }}"]
 alarms      :
     magnum_conductor_status :
-        label                   : magnum_conductor_status--{{ ansible_hostname }}
+        label                   : magnum_conductor_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('magnum_conductor_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('magnum_conductor_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["magnum-conductor_status"] != 1) {

--- a/playbooks/templates/rax-maas/memcached_status.yaml.j2
+++ b/playbooks/templates/rax-maas/memcached_status.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "memcached_status" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,18 +10,18 @@ details     :
     args    : ["{{ maas_plugin_dir }}/memcached_status.py", "{{ ansible_host }}"]
 alarms      :
     memcache_api_local_status :
-        label                   : memcache_api_local_status--{{ ansible_hostname }}
+        label                   : memcache_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('memcache_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('memcache_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["memcache_api_local_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "memcache unavailable");
             }
     memcache_curr_connections :
-        label                   : memcache_curr_connections--{{ ansible_hostname }}
+        label                   : memcache_curr_connections--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('memcache_curr_connections--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('memcache_curr_connections--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["memcache_curr_connections"] > {{ ((memcached_connections | default(1024) *0.9) | round | int) }}) {

--- a/playbooks/templates/rax-maas/memory_check.yaml.j2
+++ b/playbooks/templates/rax-maas/memory_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "memory_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type              : agent.memory
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"

--- a/playbooks/templates/rax-maas/network_throughput.yaml.j2
+++ b/playbooks/templates/rax-maas/network_throughput.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "network_throughput_"+item.0.name %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 {% set max_speed = item.0.max_speed | default(0, boolean=true) %}
 {% set rx_warn = (max_speed | int * item.0.rx_pct_warn | float / 100) | int %}
 {% set rx_crit = (max_speed | int * item.0.rx_pct_crit | float / 100) | int %}

--- a/playbooks/templates/rax-maas/neutron_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_api_local_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "neutron_api_local_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/neutron_api_local_check.py", "{{ ansible_host }}"]
 alarms      :
     neutron_api_local_status :
-        label                   : neutron_api_local_status--{{ ansible_hostname }}
+        label                   : neutron_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('neutron_api_local_status--'+ansible_hostname )| match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('neutron_api_local_status--'+inventory_hostname )| match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/neutron_dhcp_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_dhcp_agent_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "neutron_dhcp_agent_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_dhcp_agent_status :
-        label                   : neutron_dhcp_agent_status--{{ ansible_hostname }}
+        label                   : neutron_dhcp_agent_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('neutron_dhcp_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('neutron_dhcp_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-dhcp-agent_status"] != 1) {

--- a/playbooks/templates/rax-maas/neutron_l3_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_l3_agent_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "neutron_l3_agent_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_l3_agent_status :
-        label                   : neutron_l3_agent_status--{{ ansible_hostname }}
+        label                   : neutron_l3_agent_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('neutron_l3_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('neutron_l3_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-l3-agent_status"] != 1) {

--- a/playbooks/templates/rax-maas/neutron_linuxbridge_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_linuxbridge_agent_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "neutron_linuxbridge_agent_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_linuxbridge_agent_status :
-        label                   : neutron_linuxbridge_agent_status--{{ ansible_hostname }}
+        label                   : neutron_linuxbridge_agent_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('neutron_linuxbridge_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('neutron_linuxbridge_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-linuxbridge-agent_status"] != 1) {

--- a/playbooks/templates/rax-maas/neutron_metadata_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_metadata_agent_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "neutron_metadata_agent_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_metadata_agent_status :
-        label                   : neutron_metadata_agent_status--{{ ansible_hostname }}
+        label                   : neutron_metadata_agent_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('neutron_metadata_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('neutron_metadata_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-metadata-agent_status"] != 1) {

--- a/playbooks/templates/rax-maas/neutron_metering_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_metering_agent_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "neutron_metering_agent_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_metering_agent_status :
-        label                   : neutron_metering_agent_status--{{ ansible_hostname }}
+        label                   : neutron_metering_agent_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('neutron_metering_agent_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('neutron_metering_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["neutron-metering-agent_status"] != 1) {

--- a/playbooks/templates/rax-maas/nova_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_api_local_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "nova_api_local_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/nova_api_local_check.py", "{{ ansible_host }}"]
 alarms      :
     nova_api_local_status :
-        label                   : nova_api_local_status--{{ ansible_hostname }}
+        label                   : nova_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('nova_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/nova_api_metadata_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_api_metadata_local_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "nova_api_metadata_local_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/nova_api_metadata_local_check.py", "{{ ansible_host }}"]
 alarms      :
     nova_api_metadata_local_status :
-        label                   : nova_api_metadata_local_status--{{ ansible_hostname }}
+        label                   : nova_api_metadata_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('nova_api_metadata_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_api_metadata_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
 
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/nova_cert_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_cert_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "nova_cert_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_cert_status :
-        label                   : nova_cert_status--{{ ansible_hostname }}
+        label                   : nova_cert_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('nova_cert_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_cert_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-cert_status"] != 1) {

--- a/playbooks/templates/rax-maas/nova_cloud_stats_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_cloud_stats_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "nova_cloud_stats_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -11,9 +11,9 @@ details     :
 
 alarms      :
     nova_cloud_memory_status :
-        label                   : nova_cloud_memory_status--{{ ansible_hostname }}
+        label                   : nova_cloud_memory_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('nova_cloud_memory_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_cloud_memory_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["cloud_resource_used_memory"], metric["cloud_resource_total_memory"]) > {{ maas_cloud_resource_critical_memory }}) {
@@ -23,9 +23,9 @@ alarms      :
                 return new AlarmStatus(WARNING, "Total cloud memory usage exceeds warning threshold of {{ maas_cloud_resource_warning_memory }}%");
             }
     nova_cloud_disk_status :
-        label                   : nova_cloud_disk_status--{{ ansible_hostname }}
+        label                   : nova_cloud_disk_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('nova_cloud_disk_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_cloud_disk_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["cloud_resource_used_disk_space"], metric["cloud_resource_total_disk_space"]) > {{ maas_cloud_resource_critical_disk_space }}) {
@@ -35,9 +35,9 @@ alarms      :
                 return new AlarmStatus(WARNING, "Total cloud disk_space usage exceeds warning threshold of {{ maas_cloud_resource_warning_disk_space }}%");
             }
     nova_cloud_vcpu_status :
-        label                   : nova_cloud_vcpu_status--{{ ansible_hostname }}
+        label                   : nova_cloud_vcpu_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('nova_cloud_vcpu_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_cloud_vcpu_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["cloud_resource_used_vcpus"], metric["cloud_resource_total_vcpus"]) > {{ maas_cloud_resource_critical_vcpus }}) {

--- a/playbooks/templates/rax-maas/nova_compute_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_compute_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "nova_compute_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_compute_status :
-        label                   : nova_compute_status--{{ ansible_hostname }}
+        label                   : nova_compute_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('nova_compute_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_compute_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-compute_status"] != 1) {

--- a/playbooks/templates/rax-maas/nova_conductor_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_conductor_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "nova_conductor_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_conductor_status :
-        label                   : nova_conductor_status--{{ ansible_hostname }}
+        label                   : nova_conductor_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('nova_conductor_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_conductor_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-conductor_status"] != 1) {

--- a/playbooks/templates/rax-maas/nova_console_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_console_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "nova_console_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 {% if nova_console_type == 'spice' %}
 {% set console_service_name = 'nova_spice' %}
 {% set nova_console_base_url = 'spice_auto.html' %}
@@ -17,9 +17,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/service_api_local_check.py", "{{ console_service_name }}", "{{ ansible_host }}", "{{ nova_console_port }}", "--path", "{{ nova_console_base_url }}"]
 alarms      :
     nova_{{ console_service_name }}_api_local_status :
-        label                   : nova_{{ console_service_name}}_api_local_status--{{ ansible_hostname }}
+        label                   : nova_{{ console_service_name}}_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('nova_{{ console_service_name}}_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_{{ console_service_name}}_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ console_service_name }}_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/nova_consoleauth_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_consoleauth_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "nova_consoleauth_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_consoleauth_status :
-        label                   : nova_consoleauth_status--{{ ansible_hostname }}
+        label                   : nova_consoleauth_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('nova_consoleauth_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_consoleauth_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-consoleauth_status"] != 1) {

--- a/playbooks/templates/rax-maas/nova_scheduler_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_scheduler_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "nova_scheduler_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_scheduler_status :
-        label                   : nova_scheduler_status--{{ ansible_hostname }}
+        label                   : nova_scheduler_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('nova_scheduler_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_scheduler_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["nova-scheduler_status"] != 1) {

--- a/playbooks/templates/rax-maas/openmanage-memory.yaml.j2
+++ b/playbooks/templates/rax-maas/openmanage-memory.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "openmanage-memory" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -12,7 +12,7 @@ alarms      :
     openmanage-memory_status :
         label                   : openmanage-memory--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
-        disabled                : {{ (('openmanage-memory--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('openmanage-memory--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_memory_status"] != 1) {

--- a/playbooks/templates/rax-maas/openmanage-processors.yaml.j2
+++ b/playbooks/templates/rax-maas/openmanage-processors.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "openmanage-processors" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -12,7 +12,7 @@ alarms      :
     openmanage-processors :
         label                   : openmanage-processors--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
-        disabled                : {{ (('openmanage-processors--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('openmanage-processors--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_processors_status"] != 1) {

--- a/playbooks/templates/rax-maas/openmanage-vdisk.yaml.j2
+++ b/playbooks/templates/rax-maas/openmanage-vdisk.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "openmanage-vdisk" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -12,7 +12,7 @@ alarms      :
     openmanage-vdisk :
         label                   : openmanage-vdisk--{{ inventory_hostname|quote }}
         notification_plan_id    : {{ maas_notification_plan }}
-        disabled                : {{ (('openmanage-vdisk--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('openmanage-vdisk--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["hardware_vdisk_status"] != 1) {

--- a/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
+++ b/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "rabbitmq_status" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/rabbitmq_status.py", "-H", "{{ ansible_host }}", "-n", "{{ ansible_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}"]
 alarms      :
     rabbitmq_disk_free_alarm_status :
-        label                   : rabbitmq_disk_free_alarm_status--{{ ansible_hostname }}
+        label                   : rabbitmq_disk_free_alarm_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('rabbitmq_disk_free_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('rabbitmq_disk_free_alarm_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_disk_free_alarm_status"] != 1) {
@@ -20,9 +20,9 @@ alarms      :
             }
 
     rabbitmq_mem_alarm_status :
-        label                   : rabbitmq_mem_alarm_status--{{ ansible_hostname }}
+        label                   : rabbitmq_mem_alarm_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('rabbitmq_mem_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('rabbitmq_mem_alarm_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_mem_alarm_status"] != 1) {
@@ -30,9 +30,9 @@ alarms      :
             }
 
     rabbitmq_max_channels_per_conn :
-        label                   : rabbitmq_max_channels_per_conn--{{ ansible_hostname }}
+        label                   : rabbitmq_max_channels_per_conn--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('rabbitmq_max_channels_per_conn--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('rabbitmq_max_channels_per_conn--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_max_channels_per_conn"] > {{ maas_rabbitmq_max_channels_per_con_threshold }}) {
@@ -40,9 +40,9 @@ alarms      :
             }
 
     rabbitmq_fd_used_alarm_status :
-        label                   : rabbitmq_fd_used_alarm_status-{{ ansible_hostname }}
+        label                   : rabbitmq_fd_used_alarm_status-{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('rabbitmq_fd_used_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('rabbitmq_fd_used_alarm_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["rabbitmq_fd_used"],metric["rabbitmq_fd_total"]) >= {{ maas_rabbitmq_fd_used_threshold }}) {
@@ -50,9 +50,9 @@ alarms      :
             }
 
     rabbitmq_proc_used_alarm_status :
-        label                   : rabbitmq_proc_used_alarm_status--{{ ansible_hostname }}
+        label                   : rabbitmq_proc_used_alarm_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('rabbitmq_proc_used_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('rabbitmq_proc_used_alarm_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["rabbitmq_proc_used"],metric["rabbitmq_proc_total"]) >= {{ maas_rabbitmq_proc_used_threshold }}) {
@@ -60,27 +60,27 @@ alarms      :
             }
 
     rabbitmq_socket_used_alarm_status :
-        label                   : rabbitmq_socket_used_alarm_status--{{ ansible_hostname }}
+        label                   : rabbitmq_socket_used_alarm_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('rabbitmq_socket_used_alarm_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('rabbitmq_socket_used_alarm_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["rabbitmq_sockets_used"],metric["rabbitmq_sockets_total"]) >= {{ maas_rabbitmq_socket_used_threshold }}) {
                 return new AlarmStatus(CRITICAL, "RabbitMQ sockets is reaching configured limit. Currently above {{ maas_rabbitmq_socket_used_threshold }} % used");
             }
     rabbitmq_msgs_excl_notifications :
-        label                   : rabbitmq_msgs_excl_notifications--{{ ansible_hostname }}
+        label                   : rabbitmq_msgs_excl_notifications--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('rabbitmq_msgs_excl_notifications--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('rabbitmq_msgs_excl_notifications--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_msgs_excl_notifications"] > {{ maas_rabbitmq_queued_messages_excluding_notifications_threshold }} ) {
                 return new AlarmStatus(CRITICAL, "RabbitMQ sum of queued messages excluding notifications queues is reaching configured limit. Currently above {{ maas_rabbitmq_queued_messages_excluding_notifications_threshold }}");
             }
     rabbitmq_qgrowth_excl_notifications :
-        label                   : rabbitmq_qgrowth_excl_notifications--{{ ansible_hostname }}
+        label                   : rabbitmq_qgrowth_excl_notifications--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('rabbitmq_qgrowth_excl_notifications--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('rabbitmq_qgrowth_excl_notifications--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["rabbitmq_msgs_excl_notifications"]) > {{ maas_rabbitmq_queue_growth_rate_threshold / maas_check_period}}) {
@@ -88,9 +88,9 @@ alarms      :
             }
 
     rabbitmq_queues_without_consumers :
-        label                   : rabbitmq_queues_without_consumers--{{ ansible_hostname }}
+        label                   : rabbitmq_queues_without_consumers--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('rabbitmq_queues_without_consumers--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('rabbitmq_queues_without_consumers--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_queues_without_consumers"] > {{ maas_rabbitmq_queues_without_consumers_limit }}) {

--- a/playbooks/templates/rax-maas/rsyslogd_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/rsyslogd_process_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "rsyslogd_process_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -11,12 +11,12 @@ details     :
 alarms      :
 {% for process in rsyslogd_process_names %}
     {{ process }}_process_status:
-        label                   : {{ process }}_process_status--{{ ansible_hostname }}
+        label                   : {{ process }}_process_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ ((process+'_process_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ process }}_process_status"] != 1 ) {
-                return new AlarmStatus(CRITICAL, "Rsyslogd process {{ process }} not running on {{ ansible_hostname }}.");
+                return new AlarmStatus(CRITICAL, "Rsyslogd process {{ process }} not running on {{ inventory_hostname }}.");
             }
 {% endfor %}

--- a/playbooks/templates/rax-maas/swift_account_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_account_process_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_account_process_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -11,12 +11,12 @@ details     :
 alarms      :
 {% for process in maas_swift_account_process_names %}
     {{ process }}_process_status:
-        label                   : {{ process }}_process_status--{{ ansible_hostname }}
+        label                   : {{ process }}_process_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : "{{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
+        disabled                : "{{ ((process+'_process_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ process }}_process_status"] != 1 ) {
-                return new AlarmStatus(CRITICAL, "Swift process {{ process }} not running on {{ ansible_hostname }}");
+                return new AlarmStatus(CRITICAL, "Swift process {{ process }} not running on {{ inventory_hostname }}");
             }
 {% endfor %}

--- a/playbooks/templates/rax-maas/swift_account_replication_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_account_replication_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_account_replication_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,27 +10,27 @@ details     :
     args    : ["{{ maas_plugin_dir }}/swift-recon.py", "--ring-type", "account", "replication"]
 alarms      :
     swift_account_replication_failure_check :
-        label                   : swift_account_replication_failure_check--{{ ansible_hostname }}
+        label                   : swift_account_replication_failure_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_account_replication_failure_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_account_replication_failure_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_failed"] > {{ maas_swift_account_replication_failure_percentage_threshold }}) {
                 return new AlarmStatus(CRITICAL, "Swift Account Replication Failure Percentage Above Threshold");
             }
     swift_account_replication_rate_check :
-        label                   : swift_account_replication_rate_check--{{ ansible_hostname }}
+        label                   : swift_account_replication_rate_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_account_replication_rate_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_account_replication_rate_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["time_avg"]) > {{ maas_swift_account_replication_growth_rate_threshold / maas_check_period}}) {
                 return new AlarmStatus(CRITICAL, "Swift Account Replication time growth rate is above configured threshold. Currently above {{ maas_swift_account_replication_growth_rate_threshold }}");
             }
     swift_account_replication_avg_time_check :
-        label                   : swift_account_replication_avg_time_check--{{ ansible_hostname }}
+        label                   : swift_account_replication_avg_time_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_account_replication_avg_time_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_account_replication_avg_time_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_avg"] > {{ maas_swift_account_replication_avg_time_threshold }}) {

--- a/playbooks/templates/rax-maas/swift_account_server_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_account_server_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_account_server_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/service_api_local_check.py", "swift_account_server", "--path", "/healthcheck", "{{ storage_address }}", "6002"]
 alarms      :
     swift_account_server_api_local_status :
-        label                   : swift_account_server_api_local_status--{{ ansible_hostname }}
+        label                   : swift_account_server_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_account_server_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_account_server_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_account_server_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/swift_async_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_async_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_async_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/swift-recon.py", "async-pendings"]
 alarms      :
     swift_async_failure_check :
-        label                   : swift_async_failure_check--{{ ansible_hostname }}
+        label                   : swift_async_failure_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_async_failure_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_async_failure_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["async_failed"] > {{ maas_swift_async_pending_failure_percentage_threshold }}) {
@@ -20,9 +20,9 @@ alarms      :
             }
 
     swift_async_avg_check :
-        label                   : swift_async_avg_check--{{ ansible_hostname }}
+        label                   : swift_async_avg_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_async_avg_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_async_avg_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["async_avg"] > {{ maas_swift_async_pending_average_threshold }}) {

--- a/playbooks/templates/rax-maas/swift_container_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_container_process_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_container_process_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -11,12 +11,12 @@ details     :
 alarms      :
 {% for process in maas_swift_container_process_names %}
     {{ process }}_process_status:
-        label                   : {{ process }}_process_status--{{ ansible_hostname }}
+        label                   : {{ process }}_process_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : "{{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
+        disabled                : "{{ ((process+'_process_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ process }}_process_status"] != 1 ) {
-                return new AlarmStatus(CRITICAL, "Swift process {{ process }} not running on {{ ansible_hostname }}");
+                return new AlarmStatus(CRITICAL, "Swift process {{ process }} not running on {{ inventory_hostname }}");
             }
 {% endfor %}

--- a/playbooks/templates/rax-maas/swift_container_replication_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_container_replication_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_container_replication_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,27 +10,27 @@ details     :
     args    : ["{{ maas_plugin_dir }}/swift-recon.py", "--ring-type", "container", "replication"]
 alarms      :
     swift_container_replication_failure_check :
-        label                   : swift_container_replication_failure_check--{{ ansible_hostname }}
+        label                   : swift_container_replication_failure_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_container_replication_failure_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_container_replication_failure_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_failed"] > {{ maas_swift_container_replication_failure_percentage_threshold }}) {
                 return new AlarmStatus(CRITICAL, "Swift Container Replication Failure Percentage Above Threshold");
             }
     swift_container_replication_rate_check :
-        label                   : swift_container_replication_rate_check--{{ ansible_hostname }}
+        label                   : swift_container_replication_rate_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_container_replication_rate_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_container_replication_rate_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["time_avg"]) > {{ maas_swift_container_replication_growth_rate_threshold / maas_check_period}}) {
                 return new AlarmStatus(CRITICAL, "Swift Container Replication time growth rate is above configured threshold. Currently above {{ maas_swift_container_replication_growth_rate_threshold }}");
             }
     swift_container_replication_avg_time_check :
-        label                   : swift_container_replication_avg_time_check--{{ ansible_hostname }}
+        label                   : swift_container_replication_avg_time_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_container_replication_avg_time_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_container_replication_avg_time_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_avg"] > {{ maas_swift_container_replication_avg_time_threshold }}) {

--- a/playbooks/templates/rax-maas/swift_container_server_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_container_server_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_container_server_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/service_api_local_check.py", "swift_container_server", "--path", "/healthcheck", "{{ storage_address }}", "6001"]
 alarms      :
     swift_container_server_api_local_status :
-        label                   : swift_container_server_api_local_status--{{ ansible_hostname }}
+        label                   : swift_container_server_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_container_server_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_container_server_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_container_server_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/swift_md5_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_md5_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_md5_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/swift-recon.py", "md5"]
 alarms      :
     swift_ring_md5_check :
-        label                   : swift_ring_md5_check--{{ ansible_hostname }}
+        label                   : swift_ring_md5_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_ring_md5_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_ring_md5_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["ring_errors"] > 0) {
@@ -20,9 +20,9 @@ alarms      :
             }
 
     swift_conf_md5_check :
-        label                   : swift_conf_md5_check--{{ ansible_hostname }}
+        label                   : swift_conf_md5_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_conf_md5_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_conf_md5_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_conf_errors"] > 0) {

--- a/playbooks/templates/rax-maas/swift_object_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_object_process_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_object_process_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -11,12 +11,12 @@ details     :
 alarms      :
 {% for process in maas_swift_object_process_names %}
     {{ process }}_process_status:
-        label                   : {{ process }}_process_status--{{ ansible_hostname }}
+        label                   : {{ process }}_process_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : "{{ ((process+'_process_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
+        disabled                : "{{ ((process+'_process_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ process }}_process_status"] != 1 ) {
-                return new AlarmStatus(CRITICAL, "Swift process {{ process }} not running on {{ ansible_hostname }}");
+                return new AlarmStatus(CRITICAL, "Swift process {{ process }} not running on {{ inventory_hostname }}");
             }
 {% endfor %}

--- a/playbooks/templates/rax-maas/swift_object_replication_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_object_replication_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_object_replication_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,27 +10,27 @@ details     :
     args    : ["{{ maas_plugin_dir }}/swift-recon.py", "--ring-type", "object", "replication"]
 alarms      :
     swift_object_replication_failure_check :
-        label                   : swift_object_replication_failure_check--{{ ansible_hostname }}
+        label                   : swift_object_replication_failure_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_object_replication_failure_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_object_replication_failure_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_failed"] > {{ maas_swift_object_replication_failure_percentage_threshold }}) {
                 return new AlarmStatus(CRITICAL, "Swift Object Replication Failure Percentage Above Threshold");
             }
     swift_object_replication_rate_check :
-        label                   : swift_object_replication_rate_check--{{ ansible_hostname }}
+        label                   : swift_object_replication_rate_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_object_replication_rate_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_object_replication_rate_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["time_avg"]) > {{ maas_swift_object_replication_growth_rate_threshold / maas_check_period}}) {
                 return new AlarmStatus(CRITICAL, "Swift Object Replication time growth rate is above configured threshold. Currently above {{ maas_swift_object_replication_growth_rate_threshold }}");
             }
     swift_object_replication_avg_time_check :
-        label                   : swift_object_replication_avg_time_check--{{ ansible_hostname }}
+        label                   : swift_object_replication_avg_time_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_object_replication_avg_time_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_object_replication_avg_time_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_avg"] > {{ maas_swift_object_replication_avg_time_threshold }}) {

--- a/playbooks/templates/rax-maas/swift_object_server_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_object_server_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_object_server_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/service_api_local_check.py", "swift_object_server", "--path", "/healthcheck", "{{ storage_address }}", "6000"]
 alarms      :
     swift_object_server_api_local_status :
-        label                   : swift_object_server_api_local_status--{{ ansible_hostname }}
+        label                   : swift_object_server_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_object_server_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_object_server_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_object_server_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/swift_proxy_server_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_proxy_server_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_proxy_server_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/service_api_local_check.py", "swift_proxy_server", "--path", "/healthcheck", "{{ ansible_host }}", "8080"]
 alarms      :
     swift_proxy_server_api_local_status :
-        label                   : swift_proxy_server_api_local_status--{{ ansible_hostname }}
+        label                   : swift_proxy_server_api_local_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_proxy_server_api_local_status--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_proxy_server_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["swift_proxy_server_api_local_status"] != 1) {

--- a/playbooks/templates/rax-maas/swift_quarantine_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_quarantine_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_quarantine_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/swift-recon.py", "quarantine"]
 alarms      :
     swift_quarantine_object_failed :
-        label                   : swift_quarantine_object_failed--{{ ansible_hostname }}
+        label                   : swift_quarantine_object_failed--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_quarantine_object_failed--'+ansible_hostname )| match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_quarantine_object_failed--'+inventory_hostname )| match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["objects_failed"] > {{ maas_swift_object_quarantine_failed_percentage_threshold }}) {
@@ -20,9 +20,9 @@ alarms      :
             }
 
     swift_quarantine_object_avg :
-        label                   : swift_quarantine_object_avg--{{ ansible_hostname }}
+        label                   : swift_quarantine_object_avg--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_quarantine_object_avg--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_quarantine_object_avg--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["objects_avg"] > {{ maas_swift_object_quarantine_average_threshold }}) {
@@ -30,9 +30,9 @@ alarms      :
             }
 
     swift_quarantine_account_failed :
-        label                   : swift_quarantine_account_failed--{{ ansible_hostname }}
+        label                   : swift_quarantine_account_failed--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_quarantine_account_failed--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_quarantine_account_failed--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["accounts_failed"] > {{ maas_swift_account_quarantine_failed_percentage_threshold }}) {
@@ -40,9 +40,9 @@ alarms      :
             }
 
     swift_quarantine_account_avg :
-        label                   : swift_quarantine_account_avg--{{ ansible_hostname }}
+        label                   : swift_quarantine_account_avg--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_quarantine_account_avg--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_quarantine_account_avg--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["accounts_avg"] > {{ maas_swift_account_quarantine_average_threshold }}) {
@@ -50,9 +50,9 @@ alarms      :
             }
 
     swift_quarantine_container_failed :
-        label                   : swift_quarantine_container_failed--{{ ansible_hostname }}
+        label                   : swift_quarantine_container_failed--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_quarantine_container_failed--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_quarantine_container_failed--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["containers_failed"] > {{ maas_swift_container_quarantine_failed_percentage_threshold }}) {
@@ -60,9 +60,9 @@ alarms      :
             }
 
     swift_quarantine_container_avg :
-        label                   : swift_quarantine_container_avg--{{ ansible_hostname }}
+        label                   : swift_quarantine_container_avg--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_quarantine_container_avg--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_quarantine_container_avg--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["containers_avg"] > {{ maas_swift_container_quarantine_average_threshold }}) {

--- a/playbooks/templates/rax-maas/swift_time_sync_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_time_sync_check.yaml.j2
@@ -1,5 +1,5 @@
 {% set label = "swift_time_sync_check" %}
-{% set check_name = label+'--'+ansible_hostname %}
+{% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -10,9 +10,9 @@ details     :
     args    : ["{{ maas_plugin_dir }}/swift-recon.py", "time"]
 alarms      :
     swift_time_sync_check :
-        label                   : swift_time_sync_check--{{ ansible_hostname }}
+        label                   : swift_time_sync_check--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan }}"
-        disabled                : {{ (('swift_time_sync_check--'+ansible_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('swift_time_sync_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["time_sync_time_differ"] > 30) {


### PR DESCRIPTION
Our checks were very inconsistent in how labels were created. This
change ensures all labels are consistently named using the
`inventory_hostname`.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>