### PR TITLE
UG-634 Add vars file for verification dependencies

### DIFF
--- a/playbooks/maas-verify.yml
+++ b/playbooks/maas-verify.yml
@@ -46,6 +46,25 @@
         - rpc-maas-tool.py
         - alarmparser.py
 
+    - name: Copy over pip constraints
+      copy:
+        src: "files/pip-constraints.txt"
+        dest: "/tmp/pip-constraints.txt"
+
+    - name: Install verify pip packages to venv
+      pip:
+        name: "{{ maas_verify_pip_packages | join(' ') }}"
+        state: "{{ maas_pip_package_state }}"
+        extra_args: >-
+          --isolated
+          --constraint /tmp/pip-constraints.txt
+          {{ pip_install_options | default('') }}
+        virtualenv: "{{ maas_venv }}"
+      register: install_pip_packages
+      until: install_pip_packages|success
+      retries: 5
+      delay: 2
+
     - name: "Allow MAAS time to run checks before verifying they're created"
       pause:
         minutes: 2
@@ -93,3 +112,4 @@
     workspace_logs: "{{ lookup('env', 'WORKING_DIR') | default('/tmp', true) }}/../../logs"
   vars_files:
     - vars/main.yml
+    - vars/maas-verify.yml

--- a/playbooks/vars/maas-verify.yml
+++ b/playbooks/vars/maas-verify.yml
@@ -1,0 +1,20 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# pip installable packages for verifying maas deployment
+#
+maas_verify_pip_packages:
+  - futures

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,7 +17,6 @@ reno>=1.8.0 # Apache-2.0
 sphinxmark>=0.1.14 # Apache-2.0
 
 # MaaS specific
-futures
 rackspace_monitoring
 waxeye
 pyrax


### PR DESCRIPTION
Deploying rpc-maas on a multi-node fails on the verification stage,
because we're not explicitly installing the futures module on all
hosts.  It appears to be getting pulled in implicitly on some hosts
via other modules and therefore isn't failing across the board.

This commit simply creates a new vars file for the verification stage,
and updates maas-verify.yml to install this new pip package set.

Lastly, we remove futures from test-requirements.txt since it is now
installed via the maas-verify.yml playbook.