### PR TITLE
use known measurement names

### DIFF
--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -166,7 +166,7 @@ def main(args):
     if args.subparser_name == 'mon':
         kwargs['host'] = args.host
     get_statistics[args.subparser_name](**kwargs)
-    maas_common.status_ok()
+    maas_common.status_ok(m_name='maas_ceph')
 
 
 if __name__ == '__main__':

--- a/playbooks/files/rax-maas/plugins/cinder_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/cinder_api_local_check.py
@@ -63,9 +63,12 @@ def check(auth_ref, args):
             exc.HTTPError,
             exc.Timeout) as e:
         is_up = False
+        metric_bool('client_success', False, m_name='maas_cinder')
     except Exception as e:
-        status_err(str(e))
+        metric_bool('client_success', False, m_name='maas_cinder')
+        status_err(str(e), m_name='maas_cinder')
     else:
+        metric_bool('client_success', True, m_name='maas_cinder')
         # gather some metrics
         vol_statuses = [v['status'] for v in vol.json()['volumes']]
         vol_status_count = collections.Counter(vol_statuses)
@@ -75,8 +78,8 @@ def check(auth_ref, args):
         snap_status_count = collections.Counter(snap_statuses)
         total_snaps = len(snap.json()['snapshots'])
 
-    status_ok()
-    metric_bool('cinder_api_local_status', is_up)
+    status_ok(m_name='maas_cinder')
+    metric_bool('cinder_api_local_status', is_up, m_name='maas_cinder')
     # only want to send other metrics if api is up
     if is_up:
         metric('cinder_api_local_response_time',

--- a/playbooks/files/rax-maas/plugins/cinder_service_check.py
+++ b/playbooks/files/rax-maas/plugins/cinder_service_check.py
@@ -54,10 +54,17 @@ def check(auth_ref, args):
     except (exc.ConnectionError,
             exc.HTTPError,
             exc.Timeout) as e:
-        status_err(str(e))
+        metric_bool('client_success', False, m_name='maas_cinder')
+        status_err(str(e), m_name='maas_cinder')
 
     if not r.ok:
-        status_err('Could not get response from Cinder API')
+        metric_bool('client_success', False, m_name='maas_cinder')
+        status_err(
+            'Could not get response from Cinder API',
+            m_name='cinder'
+        )
+    else:
+        metric_bool('client_success', True, m_name='maas_cinder')
 
     services = r.json()['services']
 
@@ -69,9 +76,12 @@ def check(auth_ref, args):
                         service['host'] == args.host)]
 
     if len(services) == 0:
-        status_err('No host(s) found in the service list')
+        status_err(
+            'No host(s) found in the service list',
+            m_name='maas_cinder'
+        )
 
-    status_ok()
+    status_ok(m_name='maas_cinder')
 
     if args.host:
 

--- a/playbooks/files/rax-maas/plugins/conntrack_count.py
+++ b/playbooks/files/rax-maas/plugins/conntrack_count.py
@@ -54,9 +54,9 @@ def main():
     try:
         metrics = get_metrics()
     except maas_common.MaaSException as e:
-        maas_common.status_err(str(e))
+        maas_common.status_err(str(e), m_name='maas_conntrack')
     else:
-        maas_common.status_ok()
+        maas_common.status_ok(m_name='maas_conntrack')
         for name, data in metrics.viewitems():
             maas_common.metric(name, 'uint32', data['value'])
 

--- a/playbooks/files/rax-maas/plugins/container_storage_check.py
+++ b/playbooks/files/rax-maas/plugins/container_storage_check.py
@@ -84,12 +84,16 @@ def main():
     try:
         _container_check = container_check(thresh=args.thresh)
     except Exception as e:
-        status_err(str(e))
-    else:
-        status_ok()
         metric_bool(
             'container_storage_percent_used_critical',
-            _container_check
+            _container_check, m_name='maas_container'
+        )
+        status_err(str(e), m_name='maas_container')
+    else:
+        status_ok(m_name='maas_container')
+        metric_bool(
+            'container_storage_percent_used_critical',
+            _container_check, m_name='maas_container'
         )
 
 

--- a/playbooks/files/rax-maas/plugins/disk_utilisation.py
+++ b/playbooks/files/rax-maas/plugins/disk_utilisation.py
@@ -43,8 +43,8 @@ if __name__ == '__main__':
         try:
             utils = utilisation(5)
         except Exception as e:
-            status_err(e)
+            status_err(e, m_name='maas_disk_utilisation')
         else:
-            status_ok()
+            status_ok(m_name='maas_disk_utilisation')
             for util in utils:
                 metric('disk_utilisation_%s' % util[0], 'double', util[1], '%')

--- a/playbooks/files/rax-maas/plugins/elasticsearch.py
+++ b/playbooks/files/rax-maas/plugins/elasticsearch.py
@@ -72,7 +72,8 @@ def most_recent_index():
     indices = find_indices()
 
     if not indices:
-        status_err('There are no elasticsearch indices to search')
+        status_err('There are no elasticsearch indices to search',
+                   m_name='maas_elasticsearch')
 
     return indices[-1]
 
@@ -89,7 +90,7 @@ def get_json(url, data):
     try:
         r = requests.get(url, data=data)
     except exceptions as e:
-        status_err(str(e))
+        status_err(str(e), m_name='maas_elasticsearch')
 
     return r.json()
 
@@ -133,7 +134,7 @@ def main():
     num_errors = get_number_of('ERROR', latest)
     num_warnings = get_number_of('WARN*', latest)
 
-    status_ok()
+    status_ok(m_name='maas_galera')
     metric('NUMBER_OF_LOG_ERRORS', 'uint32', num_errors)
     metric('NUMBER_OF_LOG_WARNINGS', 'uint32', num_warnings)
 

--- a/playbooks/files/rax-maas/plugins/glance_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/glance_api_local_check.py
@@ -46,10 +46,13 @@ def check(auth_ref, args):
         is_up = True
     except exc.HTTPException:
         is_up = False
+        metric_bool('client_success', False, m_name='maas_glance')
     # Any other exception presumably isn't an API error
     except Exception as e:
-        status_err(str(e))
+        metric_bool('client_success', False, m_name='maas_glance')
+        status_err(str(e), m_name='maas_glance')
     else:
+        metric_bool('client_success', True, m_name='maas_glance')
         # time something arbitrary
         start = time.time()
         glance.images.list(search_opts={'all_tenants': 1})
@@ -59,8 +62,8 @@ def check(auth_ref, args):
         images = glance.images.list(search_opts={'all_tenants': 1})
         status_count = collections.Counter([s.status for s in images])
 
-    status_ok()
-    metric_bool('glance_api_local_status', is_up)
+    status_ok(m_name='maas_glance')
+    metric_bool('glance_api_local_status', is_up, m_name='maas_glance')
 
     # only want to send other metrics if api is up
     if is_up:

--- a/playbooks/files/rax-maas/plugins/glance_registry_local_check.py
+++ b/playbooks/files/rax-maas/plugins/glance_registry_local_check.py
@@ -47,11 +47,14 @@ def check(auth_ref, args):
         is_up = r.ok
     except (exc.ConnectionError, exc.HTTPError, exc.Timeout):
         is_up = False
+        metric_bool('client_success', False, m_name='maas_glance')
     except Exception as e:
-        status_err(str(e))
+        metric_bool('client_success', False, m_name='maas_glance')
+        status_err(str(e), m_name='maas_glance')
 
-    status_ok()
-    metric_bool('glance_registry_local_status', is_up)
+    status_ok(m_name='maas_glance')
+    metric_bool('client_success', True, m_name='maas_glance')
+    metric_bool('glance_registry_local_status', is_up, m_name='maas_glance')
     # only want to send other metrics if api is up
     if is_up:
         milliseconds = r.elapsed.total_seconds() * 1000

--- a/playbooks/files/rax-maas/plugins/heat_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/heat_api_local_check.py
@@ -45,18 +45,21 @@ def check(auth_ref, args):
         is_up = True
     except exc.HTTPException as e:
         is_up = False
+        metric_bool('client_success', False, m_name='maas_heat')
     # Any other exception presumably isn't an API error
     except Exception as e:
-        status_err(str(e))
+        metric_bool('client_success', False, m_name='maas_heat')
+        status_err(str(e), m_name='maas_heat')
     else:
+        metric_bool('client_success', True, m_name='maas_heat')
         # time something arbitrary
         start = time.time()
         heat.build_info.build_info()
         end = time.time()
         milliseconds = (end - start) * 1000
 
-    status_ok()
-    metric_bool('heat_api_local_status', is_up)
+    status_ok(m_name='maas_heat')
+    metric_bool('heat_api_local_status', is_up, m_name='maas_heat')
     if is_up:
         # only want to send other metrics if api is up
         metric('heat_api_local_response_time',

--- a/playbooks/files/rax-maas/plugins/holland_local_check.py
+++ b/playbooks/files/rax-maas/plugins/holland_local_check.py
@@ -66,7 +66,8 @@ def container_holland_lb_check(container, binary, backupset):
                                        (container, binary))
 
     if retcode > 0:
-            status_err('Could not list holland backupsets: %s' % (err))
+            status_err('Could not list holland backupsets: %s' % (err),
+                       m_name='maas_holland')
 
     for line in output.split():
         if backupset + '/' in line:
@@ -102,12 +103,12 @@ def main():
 
     if len([backup for backup in backupsets
             if yesterday or today in backup[0]]) > 0:
-        status_ok()
-        metric_bool('holland_backup_status', True)
+        status_ok(m_name='maas_holland')
+        metric_bool('holland_backup_status', True, m_name='maas_holland')
     else:
+        metric_bool('holland_backup_status', False, m_name='maas_holland')
         status_err('Could not find Holland backup from %s or %s'
-                   % (yesterday, today))
-        metric_bool('holland_backup_status', False)
+                   % (yesterday, today), m_name='maas_holland')
 
     # Print metric about last backup
     print_metrics('holland_backup_size', float(backupsets[-1][1]) / 1024)

--- a/playbooks/files/rax-maas/plugins/horizon_check.py
+++ b/playbooks/files/rax-maas/plugins/horizon_check.py
@@ -58,11 +58,14 @@ def check(args):
             exc.HTTPError,
             exc.Timeout) as e:
         is_up = False
+        metric_bool('client_success', False, m_name='maas_horizon')
     else:
         if not (r.ok and
                 re.search(args.site_name_regexp, r.content, re.IGNORECASE)):
-            status_err('could not load login page')
-
+            metric_bool('client_success', False, m_name='maas_horizon')
+            status_err('could not load login page', m_name='maas_horizon')
+        else:
+            metric_bool('client_success', True, m_name='maas_horizon')
         splash_status_code = r.status_code
         splash_milliseconds = r.elapsed.total_seconds() * 1000
 
@@ -89,16 +92,16 @@ def check(args):
         except (exc.ConnectionError,
                 exc.HTTPError,
                 exc.Timeout) as e:
-            status_err('While logging in: %s' % e)
+            status_err('While logging in: %s' % e, m_name='maas_horizon')
 
         if not (l.ok and re.search('overview', l.content, re.IGNORECASE)):
-            status_err('could not log in')
+            status_err('could not log in', m_name='maas_horizon')
 
         login_status_code = l.status_code
         login_milliseconds = l.elapsed.total_seconds() * 1000
 
-    status_ok()
-    metric_bool('horizon_local_status', is_up)
+    status_ok(m_name='maas_horizon')
+    metric_bool('horizon_local_status', is_up, m_name='maas_horizon')
 
     if is_up:
         metric('splash_status_code', 'uint32', splash_status_code, 'http_code')

--- a/playbooks/files/rax-maas/plugins/hp_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/hp_monitoring.py
@@ -79,9 +79,9 @@ def main():
     status['hardware_controller_battery_status'] = \
         get_controller_battery_status()
 
-    maas_common.status_ok()
+    maas_common.status_ok(m_name='maas_hwvendor')
     for name, value in status.viewitems():
-        maas_common.metric_bool(name, value)
+        maas_common.metric_bool(name, value, m_name='maas_hwvendor')
 
 
 if __name__ == '__main__':

--- a/playbooks/files/rax-maas/plugins/keystone_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/keystone_api_local_check.py
@@ -44,10 +44,13 @@ def check(args, auth_details):
         is_up = True
     except (exc.HttpServerError, exc.ClientException):
         is_up = False
+        metric_bool('client_success', False, m_name='maas_keystone')
     # Any other exception presumably isn't an API error
     except Exception as e:
-        status_err(str(e))
+        metric_bool('client_success', False, m_name='maas_keystone')
+        status_err(str(e), m_name='maas_keystone')
     else:
+        metric_bool('client_success', True, m_name='maas_keystone')
         # time something arbitrary
         start = time.time()
         keystone.services.list()
@@ -62,8 +65,8 @@ def check(args, auth_details):
             project_count = len(keystone.projects.list())
             user_count = len(keystone.users.list(domain='Default'))
 
-    status_ok()
-    metric_bool('keystone_api_local_status', is_up)
+    status_ok(m_name='maas_keystone')
+    metric_bool('keystone_api_local_status', is_up, m_name='maas_keystone')
     # only want to send other metrics if api is up
     if is_up:
         metric('keystone_api_local_response_time',

--- a/playbooks/files/rax-maas/plugins/maas_common.py
+++ b/playbooks/files/rax-maas/plugins/maas_common.py
@@ -58,7 +58,8 @@ try:
 
 except ImportError:
     def get_cinder_client(*args, **kwargs):
-        status_err('Cannot import cinderclient')
+        metric_bool('client_success', False, m_name='maas_cinder')
+        status_err('Cannot import cinderclient', m_name='maas_cinder')
 else:
 
     def get_cinder_client(previous_tries=0):
@@ -88,7 +89,8 @@ else:
         except (c_exc.Unauthorized, c_exc.AuthorizationFailure) as e:
             cinder = get_cinder_client(previous_tries + 1)
         except Exception as e:
-            status_err(str(e))
+            metric_bool('client_success', False, m_name='maas_cinder')
+            status_err(str(e), m_name='maas_cinder')
 
         return cinder
 
@@ -97,7 +99,8 @@ try:
     from glanceclient import exc as g_exc
 except ImportError:
     def get_glance_client(*args, **kwargs):
-        status_err('Cannot import glanceclient')
+        metric_bool('client_success', False, m_name='maas_glance')
+        status_err('Cannot import glanceclient', m_name='maas_glance')
 else:
     def get_glance_client(token=None, endpoint=None, previous_tries=0):
         if previous_tries > 3:
@@ -138,7 +141,8 @@ else:
         except g_exc.HTTPException:
             raise
         except Exception as e:
-            status_err(str(e))
+            metric_bool('client_success', False, m_name='maas_glance')
+            status_err(str(e), m_name='maas_glance')
 
         return glance
 
@@ -147,7 +151,8 @@ try:
     from novaclient.client import exceptions as nova_exc
 except ImportError:
     def get_nova_client(*args, **kwargs):
-        status_err('Cannot import novaclient')
+        metric_bool('client_success', False, m_name='maas_nova')
+        status_err('Cannot import novaclient', m_name='maas_nova')
 else:
     def get_nova_client(auth_token=None, bypass_url=None, previous_tries=0):
         if previous_tries > 3:
@@ -197,7 +202,8 @@ else:
         except nova_exc.ClientException:
             raise
         except Exception as e:
-            status_err(str(e))
+            metric_bool('client_success', False, m_name='maas_nova')
+            status_err(str(e), m_name='maas_nova')
 
         return nova
 
@@ -208,10 +214,12 @@ try:
     from keystoneclient.v3 import client as k3_client
 except ImportError:
     def keystone_auth(*args, **kwargs):
-        status_err('Cannot import keystoneclient')
+        metric_bool('client_success', False, m_name='maas_keystone')
+        status_err('Cannot import keystoneclient', m_name='maas_keystone')
 
     def get_keystone_client(*args, **kwargs):
-        status_err('Cannot import keystoneclient')
+        metric_bool('client_success', False, m_name='maas_keystone')
+        status_err('Cannot import keystoneclient', m_name='maas_keystone')
 else:
     def keystone_auth(auth_details):
         keystone = None
@@ -250,7 +258,8 @@ else:
                     region_name=auth_details['OS_REGION_NAME']
                 )
         except Exception as e:
-            status_err(str(e))
+            metric_bool('client_success', False, m_name='maas_keystone')
+            status_err(str(e), m_name='maas_keystone')
         else:
             if keystone:
                 return keystone.auth_ref
@@ -296,10 +305,12 @@ else:
             keystone = get_keystone_client(auth_ref,
                                            endpoint,
                                            previous_tries + 1)
-        except (k_exc.HttpServerError, k_exc.ClientException):
-            raise
+        except (k_exc.HttpServerError, k_exc.ClientException) as e:
+            metric_bool('client_success', False, m_name='maas_keystone')
+            status_err(str(e), m_name='maas_keystone')
         except Exception as e:
-            status_err(str(e))
+            metric_bool('client_success', False, m_name='maas_keystone')
+            status_err(str(e), m_name='maas_keystone')
 
         return keystone
 
@@ -309,7 +320,8 @@ try:
     from neutronclient.neutron import client as n_client
 except ImportError:
     def get_neutron_client(*args, **kwargs):
-        status_err('Cannot import neutronclient')
+        metric_bool('client_success', False, m_name='maas_neutron')
+        status_err('Cannot import neutronclient', m_name='maas_neutron')
 else:
     def get_neutron_client(token=None, endpoint_url=None, previous_tries=0):
         if previous_tries > 3:
@@ -359,7 +371,8 @@ else:
         except n_exc.NeutronClientException as e:
             raise
         except Exception as e:
-            status_err(str(e))
+            metric_bool('client_success', False, m_name='maas_neutron')
+            status_err(str(e), m_name='maas_neutron')
 
         return neutron
 
@@ -369,7 +382,8 @@ try:
     from heatclient import exc as h_exc
 except ImportError:
     def get_heat_client(*args, **kwargs):
-        status_err('Cannot import heatclient')
+        metric_bool('client_success', False, m_name='maas_heat')
+        status_err('Cannot import heatclient', m_name='maas_heat')
 else:
     def get_heat_client(token=None, endpoint=None, previous_tries=0):
         if previous_tries > 3:
@@ -404,7 +418,8 @@ else:
         except h_exc.HTTPException:
             raise
         except Exception as e:
-            status_err(str(e))
+            metric_bool('client_success', False, m_name='maas_heat')
+            status_err(str(e), m_name='maas_heat')
 
         return heat
 
@@ -414,7 +429,8 @@ try:
     from magnumclient.common.apiclient import exceptions as magnum_exc
 except ImportError:
     def get_magnum_client(*args, **kwargs):
-        status_err('Cannot import magnumclient')
+        metric_bool('client_success', False, m_name='maas_magnum')
+        status_err('Cannot import magnumclient', m_name='maas_magnum')
 else:
     def get_magnum_client(token=None, endpoint=None, previous_tries=0):
         if previous_tries > 3:
@@ -449,7 +465,8 @@ else:
         except magnum_exc.HttpError:
             raise
         except Exception as e:
-            status_err(str(e))
+            metric_bool('client_success', False, m_name='maas_magnum')
+            status_err(str(e), m_name='maas_magnum')
 
         return magnum
 
@@ -511,7 +528,7 @@ def get_auth_from_file():
     except IOError as e:
         if e.errno == errno.ENOENT:
             return None
-        status_err(e)
+        status_err(str(e), m_name='maas_keystone')
 
 
 def get_auth_details(openrc_file=OPENRC):
@@ -532,14 +549,14 @@ def get_auth_details(openrc_file=OPENRC):
                     auth_details[k] = v
     except IOError as e:
         if e.errno != errno.ENOENT:
-            status_err(e)
+            status_err(str(e), m_name='maas_keystone')
         # no openrc file, so we try the environment
         for key in auth_details.keys():
             auth_details[key] = os.environ.get(key)
 
     for key in auth_details.keys():
         if auth_details[key] is None:
-            status_err('%s not set' % key)
+            status_err('%s not set' % key, m_name='maas_keystone')
 
     return auth_details
 
@@ -578,6 +595,28 @@ def force_reauth():
 
 
 STATUS = ''
+METRICS = list()
+TELEGRAF_ENABLED = False
+TELEGRAF_METRICS = {
+    'variables': dict(),
+    'meta': {
+        'rpc_maas': True  # This should use some form of a job number
+    }
+}
+
+
+def _telegraf_metric_name(name=None, m_name=None):
+    global TELEGRAF_METRICS
+    if 'measurement_name' in TELEGRAF_METRICS:
+        return
+    elif m_name:
+        pass
+    elif name and not m_name:
+        m_name = '_'.join(name.split('_')[:3]).replace('-', '_')
+    elif not name and not m_name:
+        raise SystemExit('A name or m_name option must be provided')
+
+    TELEGRAF_METRICS['measurement_name'] = m_name
 
 
 def status(status, message, force_print=False):
@@ -594,7 +633,8 @@ def status(status, message, force_print=False):
         print(STATUS)
 
 
-def status_err(message=None, force_print=False, exception=None):
+def status_err(message=None, force_print=False, exception=None, m_name=None):
+    _telegraf_metric_name(m_name=m_name)
     if exception:
         # a status message cannot exceed 256 characters
         # 'error ' plus up to 250 from the end of the exception
@@ -602,44 +642,39 @@ def status_err(message=None, force_print=False, exception=None):
     status('error', message, force_print=force_print)
     if exception:
         raise exception
-    sys.exit(1)
+    if TELEGRAF_ENABLED:
+        sys.exit(0)
+    else:
+        sys.exit(1)
 
 
-def status_ok(message=None, force_print=False):
+def status_ok(message=None, force_print=False, m_name=None):
     status('okay', message, force_print=force_print)
+    _telegraf_metric_name(m_name=m_name)
 
 
-METRICS = list()
-TELEGRAF_METRICS = {
-    'variables': dict(),
-    'meta': {
-        'rpc_maas': True  # This should use some form of a job number
-    }
-}
-
-
-def metric(name, metric_type, value, unit=None):
+def metric(name, metric_type, value, unit=None, m_name=None):
     global METRICS
     global TELEGRAF_METRICS
-    measurement_name = '_'.join(name.split('_')[:3]).replace('-', '_')
-    TELEGRAF_METRICS['measurement_name'] = measurement_name
+    if 'measurement_name' not in TELEGRAF_METRICS:
+        _telegraf_metric_name(name=name, m_name=m_name)
 
     if len(METRICS) > 49:
-        status_err('Maximum of 50 metrics per check')
+        status_err('Maximum of 50 metrics per check', m_name='maas')
 
     metric_line = 'metric %s %s %s' % (name, metric_type, value)
     if unit is not None:
         metric_line = ' '.join((metric_line, unit))
 
     metric_line = metric_line.replace('\n', '\\n')
+    METRICS.append(metric_line)
     variables = TELEGRAF_METRICS['variables']
     variables[name] = value
-    METRICS.append(metric_line)
 
 
-def metric_bool(name, success):
+def metric_bool(name, success, m_name=None):
     value = success and 1 or 0
-    metric(name, 'uint32', value)
+    metric(name, 'uint32', value, m_name=m_name)
 
 
 try:
@@ -653,6 +688,9 @@ except IOError as e:
 
 @contextlib.contextmanager
 def print_output(print_telegraf=False):
+    if print_telegraf:
+        global TELEGRAF_ENABLED
+        TELEGRAF_ENABLED = True
     try:
         yield
     except SystemExit as e:
@@ -666,7 +704,8 @@ def print_output(print_telegraf=False):
     except Exception as e:
         logging.exception('The plugin %s has failed with an unhandled '
                           'exception', sys.argv[0])
-        status_err(traceback.format_exc(), force_print=True, exception=e)
+        status_err(traceback.format_exc(), force_print=True, exception=e,
+                   m_name='maas')
     else:
         if print_telegraf:
             TELEGRAF_METRICS['message'] = STATUS

--- a/playbooks/files/rax-maas/plugins/magnum_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/magnum_api_local_check.py
@@ -40,18 +40,21 @@ def check(auth_ref, args):
         api_is_up = True
     except exc.HttpError as e:
         api_is_up = False
+        metric_bool('client_success', False, m_name='maas_magnum')
     # Any other exception presumably isn't an API error
     except Exception as e:
-        status_err(str(e))
+        metric_bool('client_success', False, m_name='maas_magnum')
+        status_err(str(e), m_name='maas_magnum')
     else:
+        metric_bool('client_success', True, m_name='maas_magnum')
         # time something arbitrary
         start = time.time()
         magnum.cluster_templates.list()
         end = time.time()
         milliseconds = (end - start) * 1000
 
-    status_ok()
-    metric_bool('magnum_api_local_status', api_is_up)
+    status_ok(m_name='maas_magnum')
+    metric_bool('magnum_api_local_status', api_is_up, m_name='maas_magnum')
     if api_is_up:
         # only want to send other metrics if api is up
         metric('magnum_api_local_response_time',

--- a/playbooks/files/rax-maas/plugins/magnum_service_check.py
+++ b/playbooks/files/rax-maas/plugins/magnum_service_check.py
@@ -38,14 +38,17 @@ def check(auth_ref, args):
         api_is_up = True
     except exc.HttpError as e:
         api_is_up = False
+        metric_bool('client_success', False, m_name='maas_magnum')
     # Any other exception presumably isn't an API error
     except Exception as e:
-        status_err(str(e))
+        metric_bool('client_success', False, m_name='maas_magnum')
+        status_err(str(e), m_name='maas_magnum')
     else:
+        metric_bool('client_success', True, m_name='maas_magnum')
         services = magnum.mservices.list()
 
-    status_ok()
-    metric_bool('magnum_api_local_status', api_is_up)
+    status_ok(m_name='maas_magnum')
+    metric_bool('magnum_api_local_status', api_is_up, m_name='maas_magnum')
     if api_is_up:
         for service in services:
             metric_bool('_'.join([service.binary, 'status']),

--- a/playbooks/files/rax-maas/plugins/memcached_status.py
+++ b/playbooks/files/rax-maas/plugins/memcached_status.py
@@ -58,15 +58,17 @@ def main(args):
         current_version = stats['version']
     except (TypeError, IndexError):
         is_up = False
+        metric_bool('client_success', False, m_name='maas_memcached')
     else:
         is_up = True
+        metric_bool('client_success', True, m_name='maas_memcached')
         if current_version not in VERSIONS:
             status_err('This plugin has only been tested with version %s '
                        'of memcached, and you are using version %s'
-                       % (VERSIONS, current_version))
+                       % (VERSIONS, current_version), m_name='maas_memcached')
 
-    status_ok()
-    metric_bool('memcache_api_local_status', is_up)
+    status_ok(m_name='maas_memcached')
+    metric_bool('memcache_api_local_status', is_up, m_name='maas_memcached')
     if is_up:
         for m, u in MEMCACHE_METRICS.iteritems():
             metric('memcache_%s' % m, 'uint64', stats[m], u)

--- a/playbooks/files/rax-maas/plugins/neutron_service_check.py
+++ b/playbooks/files/rax-maas/plugins/neutron_service_check.py
@@ -31,9 +31,12 @@ def check(args):
 
     # not gathering api status metric here so catch any exception
     except Exception as e:
-        status_err(str(e))
+        metric_bool('client_success', False, m_name='maas_neutron')
+        status_err(str(e), m_name='maas_neutron')
+    else:
+        metric_bool('client_success', True, m_name='maas_neutron')
 
-    # gather nova service states
+    # gather neutron service states
     if args.host:
         agents = neutron.list_agents(host=args.host)['agents']
     elif args.fqdn:
@@ -42,10 +45,14 @@ def check(args):
         agents = neutron.list_agents()['agents']
 
     if len(agents) == 0:
-        status_err("No host(s) found in the agents list")
+        metric_bool('agents_found', False, m_name='maas_neutron')
+        status_err("No host(s) found in the agents list",
+                   m_name='maas_neutron')
+    else:
+        metric_bool('agents_found', True, m_name='maas_neutron')
 
     # return all the things
-    status_ok()
+    status_ok(m_name='maas_neutron')
     for agent in agents:
         agent_is_up = True
         if agent['admin_state_up'] and not agent['alive']:
@@ -60,7 +67,7 @@ def check(args):
                                          agent['id'],
                                          agent['host'])
 
-        metric_bool(name, agent_is_up)
+        metric_bool(name, agent_is_up, m_name='maas_neutron')
 
 
 def main(args):

--- a/playbooks/files/rax-maas/plugins/nova_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/nova_api_local_check.py
@@ -50,10 +50,13 @@ def check(auth_ref, args):
         is_up = True
     except exc.ClientException:
         is_up = False
+        metric_bool('client_success', False, m_name='maas_nova')
     # Any other exception presumably isn't an API error
     except Exception as e:
-        status_err(str(e))
+        metric_bool('client_success', False, m_name='maas_nova')
+        status_err(str(e), m_name='maas_nova')
     else:
+        metric_bool('client_success', True, m_name='maas_nova')
         # time something arbitrary
         start = time.time()
         nova.services.list()
@@ -64,8 +67,8 @@ def check(auth_ref, args):
         # gather some metrics
         status_count = collections.Counter([s.status for s in servers])
 
-    status_ok()
-    metric_bool('nova_api_local_status', is_up)
+    status_ok(m_name='maas_nova')
+    metric_bool('nova_api_local_status', is_up, m_name='maas_nova')
     # only want to send other metrics if api is up
     if is_up:
         metric('nova_api_local_response_time',

--- a/playbooks/files/rax-maas/plugins/nova_api_metadata_local_check.py
+++ b/playbooks/files/rax-maas/plugins/nova_api_metadata_local_check.py
@@ -43,11 +43,15 @@ def check(args):
             is_up = False
     except (exc.ConnectionError, exc.HTTPError, exc.Timeout) as e:
         is_up = False
+        metric_bool('client_success', False, m_name='maas_nova')
     except Exception as e:
-        status_err(str(e))
+        metric_bool('client_success', False, m_name='maas_nova')
+        status_err(str(e), m_name='maas_nova')
+    else:
+        metric_bool('client_success', True, m_name='maas_nova')
 
-    status_ok()
-    metric_bool('nova_api_metadata_local_status', is_up)
+    status_ok(m_name='maas_nova')
+    metric_bool('nova_api_metadata_local_status', is_up, m_name='maas_nova')
     # only want to send other metrics if api is up
     if is_up:
         metric('nova_api_metadata_local_response_time',

--- a/playbooks/files/rax-maas/plugins/nova_cloud_stats.py
+++ b/playbooks/files/rax-maas/plugins/nova_cloud_stats.py
@@ -22,6 +22,7 @@ from maas_common import get_auth_ref
 from maas_common import get_keystone_client
 from maas_common import get_nova_client
 from maas_common import metric
+from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
 from maas_common import status_ok
@@ -76,8 +77,10 @@ def check(auth_ref, args):
             nova = get_nova_client()
 
     except Exception as e:
-        status_err(str(e))
+        metric_bool('client_success', False, m_name='maas_nova')
+        status_err(str(e), m_name='maas_nova')
     else:
+        metric_bool('client_success', True, m_name='maas_nova')
         # get some cloud stats
         stats = nova.hypervisor_stats.statistics()
         cloud_stats = collections.defaultdict(dict)
@@ -94,7 +97,7 @@ def check(auth_ref, args):
             cloud_stats[metric_name]['type'] = \
                 vals['type']
 
-    status_ok()
+    status_ok(m_name='maas_nova')
     for metric_name in cloud_stats.iterkeys():
         metric('cloud_resource_%s' % metric_name,
                cloud_stats[metric_name]['type'],

--- a/playbooks/files/rax-maas/plugins/nova_service_check.py
+++ b/playbooks/files/rax-maas/plugins/nova_service_check.py
@@ -40,7 +40,10 @@ def check(auth_ref, args):
 
     # not gathering api status metric here so catch any exception
     except Exception as e:
-        status_err(str(e))
+        metric_bool('client_success', False, m_name='maas_nova')
+        status_err(str(e), m_name='maas_nova')
+    else:
+        metric_bool('client_success', True, m_name='maas_nova')
 
     # gather nova service states
     if args.host:
@@ -49,10 +52,10 @@ def check(auth_ref, args):
         services = nova.services.list()
 
     if len(services) == 0:
-        status_err("No host(s) found in the service list")
+        status_err("No host(s) found in the service list", m_name='maas_nova')
 
     # return all the things
-    status_ok()
+    status_ok(m_name='maas_nova')
     for service in services:
         service_is_up = True
 
@@ -64,7 +67,7 @@ def check(auth_ref, args):
         else:
             name = '%s_on_host_%s_status' % (service.binary, service.host)
 
-        metric_bool(name, service_is_up)
+        metric_bool(name, service_is_up, m_name='maas_nova')
 
 
 def main(args):

--- a/playbooks/files/rax-maas/plugins/process_check_host.py
+++ b/playbooks/files/rax-maas/plugins/process_check_host.py
@@ -81,10 +81,11 @@ def check_process_running(process_names):
 
     if not procs:
         # Unable to get a list of process names for the container or host.
-        status_err('Could not get a list of running processes')
+        status_err('Could not get a list of running processes',
+                   m_name='maas_process')
 
     # Since we've fetched a process list, report status_ok.
-    status_ok()
+    status_ok(m_name='maas_process')
 
     # Make a list of command lines from each PID. There's a chance that one or
     # more PIDs may have exited already and this causes a NoSuchProcess
@@ -106,14 +107,15 @@ def check_process_running(process_names):
     # they exist on the system.
     for process_name in process_names:
         matches = [x for x in cmdlines if process_name in x]
-        metric_bool('%s_process_status' % process_name, len(matches) > 0)
+        metric_bool('%s_process_status' % process_name, len(matches) > 0,
+                    m_name='maas_host')
 
 
 def main(args):
     """Main function."""
     if not args.processes:
         # The command line does not have any process names specified
-        status_err('No executable names supplied')
+        status_err('No executable names supplied', m_name='maas_process')
 
     check_process_running(process_names=args.processes)
 

--- a/playbooks/files/rax-maas/plugins/service_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/service_api_local_check.py
@@ -48,7 +48,7 @@ def check(args):
     s = requests.Session()
 
     s.headers.update(headers)
-
+    short_name = args.name.split('_')[0]
     if path and not path.startswith('/'):
         url = '/'.join((endpoint, path))
     else:
@@ -59,10 +59,14 @@ def check(args):
             exc.HTTPError,
             exc.Timeout):
         up = False
+        metric_bool('client_success', False,
+                    m_name='maas_{name}'.format(name=short_name))
     else:
         up = True
+        metric_bool('client_success', True,
+                    m_name='maas_{name}'.format(name=short_name))
 
-    status_ok()
+    status_ok(m_name='maas_{name}'.format(name=short_name))
     metric_bool('{name}_api_local_status'.format(name=args.name), up)
 
     if up and r.ok:

--- a/playbooks/files/rax-maas/plugins/swift-dispersion.py
+++ b/playbooks/files/rax-maas/plugins/swift-dispersion.py
@@ -88,7 +88,8 @@ def main():
     except OSError:
         # If the subprocess call returns anything other than exit code 0.
         # we should probably error out too.
-        maas_common.status_err('Could not access object dispersion report')
+        maas_common.status_err('Could not access object dispersion report',
+                               m_name='maas_swift')
 
     try:
         container_out = generate_report('container')
@@ -96,12 +97,14 @@ def main():
     except OSError:
         # If the subprocess call returns anything other than exit code 0.
         # we should probably error out too.
-        maas_common.status_err('Could not access container dispersion report')
+        maas_common.status_err('Could not access container dispersion report',
+                               m_name='maas_swift')
 
     if not (object_match and container_match):
-        maas_common.status_err('Could not parse dispersion report output')
+        maas_common.status_err('Could not parse dispersion report output',
+                               m_name='maas_swift')
 
-    maas_common.status_ok()
+    maas_common.status_ok(m_name='maas_swift')
     print_metrics('object', object_match)
     print_metrics('container', container_match)
 

--- a/playbooks/files/rax-maas/plugins/swift-recon.py
+++ b/playbooks/files/rax-maas/plugins/swift-recon.py
@@ -83,7 +83,8 @@ def recon_output(for_ring, options=None):
         containers_list = subprocess.check_output(get_container)
         container = containers_list.splitlines()[0]
     except (IndexError, subprocess.CalledProcessError):
-        status_err('no running swift proxy containers found')
+        status_err('no running swift proxy containers found',
+                   m_name='maas_swift')
 
     # kilo didn't have venvs so check if kilo
     if openstack_version == "11.2.17":
@@ -239,7 +240,8 @@ def swift_async():
     else:
         # If we didn't find a non-empty dict, error out
         maas_common.status_err(
-            'No data could be collected about pending async operations'
+            'No data could be collected about pending async operations',
+            m_name='maas_swift'
         )
     return {'async': stats}
 
@@ -314,9 +316,13 @@ def swift_md5():
         # If there was an error checking the md5sum, error out immediately
         if line.startswith('!!'):
             error_dict = error_re.search(line).groupdict()
-            maas_common.status_err('md5 mismatch for {0} on host {1}'.format(
-                checking_dict.get('check'), error_dict['address']
-            ))
+            maas_common.status_err(
+                'md5 mismatch for {0} on host {1}'.format(
+                    checking_dict.get('check'),
+                    error_dict['address']
+                ),
+                m_name='maas_swift'
+            )
         results_match = result_re.match(line)
         if results_match:
             check_name = checking_dict['check'].replace('.', '_')
@@ -442,7 +448,8 @@ def get_stats_from(args):
         stats = swift_quarantine()
     elif args.recon == 'replication':
         if args.ring not in {"account", "container", "object"}:
-            maas_common.status_err('no ring provided to check')
+            maas_common.status_err('no ring provided to check',
+                                   m_name='maas_swift')
         stats = swift_replication(args.ring)
     elif args.recon == 'time':
         stats = swift_time()
@@ -458,10 +465,10 @@ def main():
     try:
         stats = get_stats_from(args)
     except (ParseError, CommandNotRecognized) as e:
-        maas_common.status_err(str(e))
+        maas_common.status_err(str(e), m_name='maas_swift')
 
     if stats:
-        maas_common.status_ok()
+        maas_common.status_ok(m_name='maas_swift')
         print_nested_stats(stats)
 
 

--- a/playbooks/files/rax-maas/plugins/vg_check.py
+++ b/playbooks/files/rax-maas/plugins/vg_check.py
@@ -47,7 +47,7 @@ def parse_args():
 
 
 def print_metrics(sizes, vgname):
-    status_ok()
+    status_ok(m_name='maas_cinder')
     metric('%s_vg_total_space' % vgname, 'int64',
            sizes['totalsize'], 'Megabytes')
     metric('%s_vg_free_space' % vgname, 'int64',
@@ -63,11 +63,12 @@ def main():
     retcode, output, err = run_command(command)
 
     if retcode > 0:
-        status_err(err)
+        status_err(err, m_name='maas_cinder')
 
     if not output:
         status_err('No output received from vgs command. '
-                   'Cannot gather metrics.')
+                   'Cannot gather metrics.',
+                   m_name='maas_cinder')
 
     totalsize, free = [int(float(x)) for x in output.split()]
     used = totalsize - free

--- a/playbooks/templates/tigkstack/telegraf.conf.j2
+++ b/playbooks/templates/tigkstack/telegraf.conf.j2
@@ -6,15 +6,19 @@
 {% endif %}
   job_reference = "{{ maas_job_reference }}"
 
-{% set interval = (telegraf_interval | int) + 10 %}
+{%   set telegraf_commands = [] %}
+{%   set _ = telegraf_commands.extend(telegraf_maas_commands) %}
+
+{% set command_interval = telegraf_commands | length * 3 | round %}
+{% set interval = ((telegraf_interval | int) > command_interval) | ternary(telegraf_interval, command_interval) %}
 
 [agent]
-  interval = "{{ interval }}s"
+  interval = "{{ interval | round }}s"
   round_interval = false
   metric_batch_size = 1024
   metric_buffer_limit = 10240
   collection_jitter = "8s"
-  flush_interval = "{{ interval * 1.5 | round }}s"
+  flush_interval = "{{ interval + 10 | round }}s"
   flush_jitter = "8s"
   debug = false
   quiet = true
@@ -64,12 +68,9 @@
   ]
 {% endif %}
 
-{%   set telegraf_commands = [] %}
-{%   set _ = telegraf_commands.extend(telegraf_maas_commands) %}
-
 [[inputs.exec]]
   commands = [{{ telegraf_commands | map('quote') | join(', ') }}]
-  timeout = "{{ telegraf_commands | length * 1.5 | round }}s"
+  timeout = "10s"
   data_format = "influx"
 
 {% if 'all_containers' in groups and inventory_hostname in groups['all_containers'] | default([]) %}

--- a/playbooks/vars/maas-tigkstack.yml
+++ b/playbooks/vars/maas-tigkstack.yml
@@ -112,420 +112,420 @@ grafana_time_panel_options:
 grafana_panels:
   cinder:
     - queries:
-        - 'SELECT "cinder_api_local_response_time"  FROM "cinder_error_snaps" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder_api_local_response_time"  FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: api response time
       panel_options: "{{ grafana_time_panel_options }}"
     - queries:
-        - 'SELECT "cinder_api_local_status" FROM "cinder_error_snaps" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder_api_local_status" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: cinder api status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "cinder_available_snaps" FROM "cinder_error_snaps" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder_available_snaps" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: cinder available snaps
       panel_options: {}
     - queries:
-        - 'SELECT "cinder_available_volumes" FROM "cinder_error_snaps" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder_available_volumes" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: cinder available volumes
       panel_options: {}
     - queries:
-        - 'SELECT "cinder_error_snaps" FROM "cinder_error_snaps" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder_error_snaps" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: cinder error snaps
       panel_options: {}
     - queries:
-        - 'SELECT "cinder_error_volumes" FROM "cinder_error_snaps" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder_error_volumes" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: cinder error volumes
       panel_options: {}
     - queries:
-        - 'SELECT "cinder_in-use_snaps" FROM "cinder_error_snaps" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder_in-use_snaps" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: cinder in-use snaps
       panel_options: {}
     - queries:
-        - 'SELECT "cinder_in-use_volumes" FROM "cinder_error_snaps" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder_in-use_volumes" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: cinder in-use volumes
       panel_options: {}
     - queries:
-        - 'SELECT "total_cinder_snapshots" FROM "cinder_error_snaps" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "total_cinder_snapshots" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: cinder snapshots
       panel_options: {}
     - queries:
-        - 'SELECT "total_cinder_volumes" FROM "cinder_error_snaps" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "total_cinder_volumes" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: cinder total volumes
       panel_options: {}
     - queries:
-        - 'SELECT "cinder-scheduler_status" FROM "cinder_scheduler_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder-scheduler_status" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: cinder scheduler status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "cinder-backup_status" FROM "cinder_volume_lvm_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder-backup_status" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: cinder backup status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "cinder-volume-lvm_status" FROM "cinder_error_snaps" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder-volume-lvm_status" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: cinder volume-lvm_ status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "cinder-volumes_vg_free_space" FROM "cinder_volumes_vg_used" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "cinder-volumes_vg_total_space" FROM "cinder_volumes_vg_used" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "cinder-volumes_vg_used_space" FROM "cinder_volumes_vg_used" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder-volumes_vg_free_space" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder-volumes_vg_total_space" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "cinder-volumes_vg_used_space" FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: cinder volume-lvm_ status
       panel_options: {}
   "cinder availability":
     - queries:
-        - 'SELECT mean("cinder-volume-lvm_status") * 100 FROM "cinder_volume_lvm_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("cinder-volume-lvm_status") * 100 FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: cinder lvm availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("cinder-backup_status") * 100 FROM "cinder_volume_lvm_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("cinder-backup_status") * 100 FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: cinder backup availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("cinder-scheduler_status") * 100 FROM "cinder_scheduler_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("cinder-scheduler_status") * 100 FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: cinder lvm availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("cinder_api_local_status") * 100 FROM "cinder_scheduler_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("cinder_api_local_status") * 100 FROM "maas_cinder" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: cinder lvm availability
       panel_options: "{{ grafana_single_status_panel_options }}"
   galera:
     - queries:
-        - 'SELECT "aborted_clients" FROM "aborted_connects" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "aborted_connects" FROM "aborted_connects" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "aborted_clients" FROM "maas_galera" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "aborted_connects" FROM "maas_galera" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: galera aborted clients and connections
       panel_options: {}
     - queries:
-        - 'SELECT "access_denied_errors" FROM "aborted_connects" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "access_denied_errors" FROM "maas_galera" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: galera access denied errors
       panel_options: {}
     - queries:
-        - 'SELECT "innodb_deadlocks" FROM "aborted_connects" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "innodb_deadlocks" FROM "maas_galera" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: galera innodb deadlocks
       panel_options: {}
     - queries:
-        - 'SELECT "innodb_row_lock_time_avg" FROM "aborted_connects" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "innodb_row_lock_time_avg" FROM "maas_galera" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: galera innodb row lock time avg
       panel_options: {}
     - queries:
-        - 'SELECT "mysql_current_connections" FROM "aborted_connects" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "mysql_max_seen_connections" FROM "aborted_connects" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "mysql_current_connections" FROM "maas_galera" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "mysql_max_seen_connections" FROM "maas_galera" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: galera connections
       panel_options: {}
     - queries:
-        - 'SELECT "num_of_open_files" FROM "aborted_connects" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "num_of_open_files" FROM "maas_galera" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: galera open files
       panel_options: {}
     - queries:
-        - 'SELECT "queries_per_second" FROM "aborted_connects" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "queries_per_second" FROM "maas_galera" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: galera queries per second
       panel_options: {}
     - queries:
-        - 'SELECT /wsrep_.*_(bytes|size)/ FROM "aborted_connects" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT /wsrep_.*_(bytes|size)/ FROM "maas_galera" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: galera queries per second
       panel_options: {}
   glance:
     - queries:
-        - 'SELECT "glance_api_local_response_time"  FROM "glance_killed_images" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "glance_registry_local_response_time"  FROM "glance_registry_local" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "glance_api_local_response_time"  FROM "maas_glance" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "glance_registry_local_response_time"  FROM "maas_glance" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: api response time
       panel_options: "{{ grafana_time_panel_options }}"
     - queries:
-        - 'SELECT "glance_api_local_status"  FROM "glance_killed_images" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "glance_api_local_status"  FROM "maas_glance" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: glance images
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "glance_registry_local_status"  FROM "glance_registry_local" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "glance_registry_local_status"  FROM "maas_glance" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: glance images
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "glance_active_images", "glance_killed_images", "glance_queued_images"  FROM "glance_killed_images" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "glance_active_images", "glance_killed_images", "glance_queued_images"  FROM "maas_glance" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: glance images
       panel_options: {}
   "glance availability":
     - queries:
-        - 'SELECT mean("glance_api_local_status") * 100 FROM "glance_killed_images" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("glance_api_local_status") * 100 FROM "maas_glance" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: glance api availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("glance_registry_local_status") * 100 FROM "glance_registry_local" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("glance_registry_local_status") * 100 FROM "maas_glance" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: glance api availability
       panel_options: "{{ grafana_single_status_panel_options }}"
   heat:
     - queries:
-        - 'SELECT "heat_api_local_response_time"  FROM "heat_api_local" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "heat_cfn_api_local_response_time"  FROM "heat_cfn_api" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "heat_cw_api_local_response_time"  FROM "heat_cw_api" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "heat_api_local_response_time"  FROM "maas_heat" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "heat_cfn_api_local_response_time"  FROM "maas_heat" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "heat_cw_api_local_response_time"  FROM "maas_heat" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: api response time
       panel_options: "{{ grafana_time_panel_options }}"
     - queries:
-        - 'SELECT "heat_api_local_status"  FROM "heat_api_local" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "heat_api_local_status"  FROM "maas_heat" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: heat api status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "heat_cfn_api_local_status"  FROM "heat_cfn_api" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "heat_cfn_api_local_status"  FROM "maas_heat" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: heat cfn api status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "heat_cw_api_local_status"  FROM "heat_cw_api" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "heat_cw_api_local_status"  FROM "maas_heat" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: heat cw api status
       panel_options: "{{ grafana_status_panel_options }}"
   "heat availability":
     - queries:
-        - 'SELECT mean("heat_api_local_status") * 100 FROM "heat_api_local" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("heat_api_local_status") * 100 FROM "maas_heat" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: heat api availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("heat_cfn_api_local_status") * 100 FROM "heat_cfn_api" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("heat_cfn_api_local_status") * 100 FROM "maas_heat" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: heat cfn api availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("heat_cw_api_local_status") * 100 FROM "heat_cw_api" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("heat_cw_api_local_status") * 100 FROM "maas_heat" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: heat cw api availability
       panel_options: "{{ grafana_single_status_panel_options }}"
   neutron:
     - queries:
-        - 'SELECT "neutron_api_local_response_time"  FROM "neutron_subnets" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "neutron_api_local_response_time"  FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: api response time
       panel_options: "{{ grafana_time_panel_options }}"
     - queries:
-        - 'SELECT "neutron-dhcp-agent_status" FROM "neutron_linuxbridge_agent_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "neutron-dhcp-agent_status" FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: neutron dhcp agent status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "neutron-l3-agent_status" FROM "neutron_linuxbridge_agent_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "neutron-l3-agent_status" FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: neutron l3 agent status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "neutron-lbaasv2-agent_status" FROM "neutron_linuxbridge_agent_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "neutron-lbaasv2-agent_status" FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: neutron lbaasv2 agent status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "neutron-linuxbridge-agent_status" FROM "neutron_linuxbridge_agent_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "neutron-linuxbridge-agent_status" FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: neutron linuxbridge agent status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "neutron-metadata-agent_status" FROM "neutron_linuxbridge_agent_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "neutron-metadata-agent_status" FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: neutron metadata agent status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "neutron-metering-agent_status" FROM "neutron_linuxbridge_agent_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "neutron-metering-agent_status" FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: neutron metering agent status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "neutron_agents" FROM "neutron_subnets" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "neutron_agents" FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: neutron agents
       panel_options: {}
     - queries:
-        - 'SELECT "neutron_api_local_status" FROM "neutron_subnets" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "neutron_api_local_status" FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: neutron api status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "neutron_networks", "neutron_routers", "neutron_subnets" FROM "neutron_subnets" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "neutron_networks", "neutron_routers", "neutron_subnets" FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: neutron networks, routers, subnets
       panel_options: {}
   "neutron availability":
     - queries:
-        - 'SELECT mean("neutron-dhcp-agent_status") * 100 FROM "neutron_linuxbridge_agent_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("neutron-dhcp-agent_status") * 100 FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: neutron dhcp agent availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("neutron-l3-agent_status") * 100 FROM "neutron_linuxbridge_agent_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("neutron-l3-agent_status") * 100 FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: neutron l3 agent availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("neutron-lbaasv2-agent_status") * 100 FROM "neutron_linuxbridge_agent_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("neutron-lbaasv2-agent_status") * 100 FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: neutron lbaasv2 agent availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("neutron-linuxbridge-agent_status") * 100 FROM "neutron_linuxbridge_agent_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("neutron-linuxbridge-agent_status") * 100 FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: neutron linuxbridge agent availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("neutron-metadata-agent_status") * 100 FROM "neutron_linuxbridge_agent_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter  GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("neutron-metadata-agent_status") * 100 FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter  GROUP BY time($__interval) fill(null)'
       measurement: neutron metadata agent availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("neutron-metering-agent_status") * 100 FROM "neutron_linuxbridge_agent_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter  GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("neutron-metering-agent_status") * 100 FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter  GROUP BY time($__interval) fill(null)'
       measurement: neutron metering agent availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("neutron_api_local_status") * 100 FROM "neutron_subnets" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("neutron_api_local_status") * 100 FROM "maas_neutron" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: neutron api availability
       panel_options: "{{ grafana_single_status_panel_options }}"
   nova:
     - queries:
-        - 'SELECT "nova_api_metadata_local_response_time"  FROM "nova_api_metadata" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "nova_api_local_response_time" FROM "nova_instances_in" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "nova_api_metadata_local_response_time"  FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "nova_api_local_response_time" FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: api response time
       panel_options: "{{ grafana_time_panel_options }}"
     - queries:
-        - 'SELECT "nova_api_metadata_local_status" FROM "nova_api_metadata" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "nova_api_metadata_local_status" FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: nova api metadata status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "nova-compute_status" FROM "nova_compute_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "nova-compute_status" FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: nova compute status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "nova-conductor_status" FROM "nova_conductor_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "nova-conductor_status" FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: nova conductor status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "nova-consoleauth_status" FROM "nova_consoleauth_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "nova-consoleauth_status" FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: nova consoleauth status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "nova_api_local_status" FROM "nova_instances_in" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "nova_api_local_status" FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: nova api status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "nova_instances_in_state_ACTIVE, nova_instances_in_state_ERROR, nova_instances_in_state_STOPPED" FROM "nova_instances_in" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "nova_instances_in_state_ACTIVE, nova_instances_in_state_ERROR, nova_instances_in_state_STOPPED" FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: nova instance states
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "nova_novnc_api_local_status" FROM "nova_novnc_api" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "nova_novnc_api_local_status" FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: nova novnc status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "nova-scheduler_status" FROM "nova_scheduler_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "nova-scheduler_status" FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: nova novnc status
       panel_options: "{{ grafana_status_panel_options }}"
   "nova availability":
     - queries:
-        - 'SELECT mean("nova-scheduler_status") * 100 FROM "nova_scheduler_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("nova-scheduler_status") * 100 FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: nova scheduler availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("nova_novnc_api_local_status") * 100 FROM "nova_novnc_api" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("nova_novnc_api_local_status") * 100 FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: nova novnc availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("nova_api_metadata_local_status") * 100 FROM "nova_api_metadata" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("nova_api_metadata_local_status") * 100 FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: nova api metadata status
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("nova-compute_status") * 100 FROM "nova_compute_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("nova-compute_status") * 100 FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: nova compute status
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("nova-conductor_status") * 100 FROM "nova_conductor_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("nova-conductor_status") * 100 FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: nova conductor status
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("nova-consoleauth_status") * 100 FROM "nova_consoleauth_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("nova-consoleauth_status") * 100 FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: nova consoleauth status
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("nova_api_local_status") * 100 FROM "nova_instances_in" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("nova_api_local_status") * 100 FROM "maas_nova" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: nova api status
       panel_options: "{{ grafana_single_status_panel_options }}"
-  rsyslog:
-    - queries:
-        - 'SELECT "rsyslogd_process_status" FROM "rsyslogd_process_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-      measurement: rsyslog status
-      panel_options: "{{ grafana_status_panel_options }}"
-  "rsyslog availability":
-    - queries:
-        - 'SELECT mean("rsyslogd_process_status") * 100 FROM "rsyslogd_process_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
-      measurement: rsyslog availability
-      panel_options: "{{ grafana_single_status_panel_options }}"
+  # rsyslog:
+  #   - queries:
+  #       - 'SELECT "rsyslogd_process_status" FROM "rsyslogd_process_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+  #     measurement: rsyslog status
+  #     panel_options: "{{ grafana_status_panel_options }}"
+  # "rsyslog availability":
+  #   - queries:
+  #       - 'SELECT mean("rsyslogd_process_status") * 100 FROM "rsyslogd_process_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+  #     measurement: rsyslog availability
+  #     panel_options: "{{ grafana_single_status_panel_options }}"
   rabbitmq:
     - queries:
-        - 'SELECT "rabbitmq_fd_total", "rabbitmq_fd_used" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_fd_total", "rabbitmq_fd_used" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: rabbitmq fd
       panel_options: {}
     - queries:
-        - 'SELECT "rabbitmq_get" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_get" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: rabbitmq get
       panel_options: {}
     - queries:
-        - 'SELECT "rabbitmq_max_channels_per_conn" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_max_channels_per_conn" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: rabbitmq max channles per connection
       panel_options: {}
     - queries:
-        - 'SELECT "rabbitmq_mem_alarm_status" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_mem_alarm_status" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: rabbitmq mem alarm status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "rabbitmq_mem_limit" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "rabbitmq_mem_used" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_mem_limit" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_mem_used" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: rabbitmq mem
       panel_options: {}
     - queries:
-        - 'SELECT "rabbitmq_messages" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "rabbitmq_messages_ready" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "rabbitmq_messages_unacknowledged" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "rabbitmq_msgs_excl_notifications" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "rabbitmq_notification_messages" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_messages" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_messages_ready" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_messages_unacknowledged" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_msgs_excl_notifications" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_notification_messages" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: rabbitmq messages
       panel_options: {}
     - queries:
-        - 'SELECT "rabbitmq_queues_without_consumers" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_queues_without_consumers" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: rabbitmq queues without consumers
       panel_options: {}
     - queries:
-        - 'SELECT "rabbitmq_sockets_total" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "rabbitmq_sockets_used" FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_sockets_total" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "rabbitmq_sockets_used" FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: rabbitmq sockets
       panel_options: {}
   "rabbitmq availability":
     - queries:
-        - 'SELECT mean("rabbitmq_mem_alarm_status") * 100 FROM "rabbitmq_messages_ready" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("rabbitmq_mem_alarm_status") * 100 FROM "maas_rabbitmq" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: rabbitmq availability
       panel_options: "{{ grafana_single_status_panel_options }}"
   swift:
     - queries:
-        - 'SELECT "swift_proxy_server_api_local_response_time" FROM "swift_proxy_server" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "swift_object_server_api_local_response_time" FROM "swift_object_server" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "swift_container_server_api_local_response_time" FROM "swift_container_server" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
-        - 'SELECT "swift_account_server_api_local_response_time" FROM "swift_account_server" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "swift_proxy_server_api_local_response_time" FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "swift_object_server_api_local_response_time" FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "swift_container_server_api_local_response_time" FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "swift_account_server_api_local_response_time" FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: api response time
       panel_options: "{{ grafana_time_panel_options }}"
     - queries:
-        - 'SELECT "swift_object_server_api_local_status" FROM "swift_object_server" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "swift_object_server_api_local_status" FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: swift object server status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "swift_container_server_api_local_status" FROM "swift_container_server" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "swift_container_server_api_local_status" FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: swift container server status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "swift_account_server_api_local_status" FROM "swift_account_server" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "swift_account_server_api_local_status" FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: swift account server status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "swift_proxy_server_api_local_status" FROM "swift_proxy_server" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "swift_proxy_server_api_local_status" FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: proxy service status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "swift-container-auditor_process_status", "swift-container-replicator_process_status", "swift-container-server_process_status", "swift-container-updater_process_status" FROM "swift_container_auditor_process_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "swift-container-auditor_process_status", "swift-container-replicator_process_status", "swift-container-server_process_status", "swift-container-updater_process_status" FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: swift container process status
       panel_options: "{{ grafana_status_panel_options }}"
     - queries:
-        - 'SELECT "swift-account-auditor_process_status", "swift-account-reaper_process_status", "swift-account-replicator_process_status", "swift-account-server_process_status" FROM "swift_account_auditor_process_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
+        - 'SELECT "swift-account-auditor_process_status", "swift-account-reaper_process_status", "swift-account-replicator_process_status", "swift-account-server_process_status" FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter'
       measurement: swift account process status
       panel_options: "{{ grafana_status_panel_options }}"
   "swift availability":
     - queries:
-        - 'SELECT mean("swift_proxy_server_api_local_status") * 100 FROM "swift_proxy_server" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("swift_proxy_server_api_local_status") * 100 FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: swift proxy availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("swift-account-auditor_process_status") * 100 FROM "swift_account_auditor_process_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("swift-account-auditor_process_status") * 100 FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: swift account process availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("swift-account-reaper_process_status") * 100 FROM "swift_account_auditor_process_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("swift-account-reaper_process_status") * 100 FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: swift account reaper process availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("swift-account-replicator_process_status") * 100 FROM "swift_account_auditor_process_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("swift-account-replicator_process_status") * 100 FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: swift account replicator process availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("swift-account-server_process_status") * 100 FROM "swift_account_auditor_process_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("swift-account-server_process_status") * 100 FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: swift account server process availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("swift-container-auditor_process_status") * 100 FROM "swift_container_auditor_process_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("swift-container-auditor_process_status") * 100 FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: swift container auditor process availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
@@ -533,11 +533,11 @@ grafana_panels:
       measurement: swift container replicator process availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("swift-container-server_process_status") * 100 FROM "swift_container_auditor_process_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("swift-container-server_process_status") * 100 FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: swift container server process availability
       panel_options: "{{ grafana_single_status_panel_options }}"
     - queries:
-        - 'SELECT mean("swift-container-updater_process_status") * 100 FROM "swift_container_auditor_process_status" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
+        - 'SELECT mean("swift-container-updater_process_status") * 100 FROM "maas_swift" WHERE "host" =~ /$server$/ AND "job_reference" =~ /$job_reference/ AND $timeFilter GROUP BY time($__interval) fill(null)'
       measurement: swift container updater process availability
       panel_options: "{{ grafana_single_status_panel_options }}"
 


### PR DESCRIPTION
Measurement names were random and hard to track, this change ensures
that all maas plugins using a known measurement name. This makes it easy
to write new queries and track changes without having to first figure
out the measurement name based on an inconsistent maas check label.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>