### PR TITLE
Do not leak password in ansible log

### DIFF
--- a/playbooks/maas-tigkstack-influxdb.yml
+++ b/playbooks/maas-tigkstack-influxdb.yml
@@ -86,6 +86,7 @@
         influx -username {{ influxdb_db_root_name }}
         -password {{ influxdb_db_root_password }}
         -execute "{{ item }}"
+      no_log: True
       with_items:
         - "CREATE DATABASE {{ influxdb_db_name }}"
         - "CREATE RETENTION POLICY {{ influxdb_db_retention_policy }} ON {{ influxdb_db_name }} DURATION {{ influxdb_db_retention }} REPLICATION {{ influxdb_db_replication }}"


### PR DESCRIPTION
no_log: True to remove passwords from appearing in the logs.
no_log was introduced in ansible 1.8 and should be easy to
backport.