### PR TITLE
LA-367 Install maas_telegraf_format.py dependency

### DIFF
--- a/playbooks/files/pip-constraints.txt
+++ b/playbooks/files/pip-constraints.txt
@@ -23,6 +23,7 @@ python-openstackclient==3.2.1
 
 ### General dependencies
 python-memcached==1.58
+PyYAML==3.12
 rackspace-monitoring-cli==0.7.2
 requests==2.11.1
 waxeye==0.8.1

--- a/playbooks/maas-tigkstack-telegraf.yml
+++ b/playbooks/maas-tigkstack-telegraf.yml
@@ -25,6 +25,27 @@
         group: "root"
         mode: "0755"
 
+    - name: Copy over pip constraints
+      copy:
+        src: "files/pip-constraints.txt"
+        dest: "/tmp/pip-constraints.txt"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+    - name: Install maas_telegraf_format pip packages to venv
+      pip:
+        name: "{{ maas_telegraf_format_pip_packages | join(' ') }}"
+        state: "{{ maas_pip_package_state }}"
+        extra_args: >-
+          --isolated
+          --constraint /tmp/pip-constraints.txt
+          {{ pip_install_options | default('') }}
+        virtualenv: "{{ maas_venv }}"
+      register: install_pip_packages
+      until: install_pip_packages | success
+      retries: 5
+      delay: 2
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
     - name: Drop MaaS telegraf output runner
       template:
         src: "files/tigkstack/maas_telegraf_format.py"
@@ -100,7 +121,7 @@
         - /opt/telegraf
 
     - name: Return Commands for metric
-      command: "{{ maas_plugin_dir }}/maas_telegraf_format.py"
+      command: "{{ maas_venv_bin }}/python {{ maas_plugin_dir }}/maas_telegraf_format.py"
       changed_when: false
       register: _telegraf_maas_commands
       when:

--- a/playbooks/vars/maas-tigkstack.yml
+++ b/playbooks/vars/maas-tigkstack.yml
@@ -601,3 +601,6 @@ grafana_panel_skel:
     sort: 0
     value_type: individual
   type: graph
+
+maas_telegraf_format_pip_packages:
+  - "PyYAML"


### PR DESCRIPTION
The script `maas_telegraf_format.py` requires `PyYAML` to be installed.
On an AIO this dependency is met because the AIO host is also the
deployment node. When there are multiple hosts, such as a multi-node
AIO, `PyYAML` is missing.

This commit installs `PyYAML` into the `maas_venv` and uses the Python
binary in that virtual env to run the script.