### PR TITLE
LA-367 Install virtualenv prior to telegraf

### DIFF
--- a/playbooks/maas-tigkstack-telegraf.yml
+++ b/playbooks/maas-tigkstack-telegraf.yml
@@ -29,7 +29,18 @@
       copy:
         src: "files/pip-constraints.txt"
         dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+    - name: Install virtualenv pip package
+      pip:
+        name: "virtualenv"
+        state: "{{ maas_pip_package_state }}"
+        extra_args: >-
+          --constraint /tmp/pip-constraints.txt
+          {{ pip_install_options | default('') }}
+      register: install_packages
+      until: install_packages|success
+      retries: 5
+      delay: 2
 
     - name: Install maas_telegraf_format pip packages to venv
       pip:
@@ -44,7 +55,6 @@
       until: install_pip_packages | success
       retries: 5
       delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
 
     - name: Drop MaaS telegraf output runner
       template:


### PR DESCRIPTION
The package `virtualenv` needs installing prior to deploying
`maas_telegraf_format.py`. In general, due to the ordering of MaaS
playbooks in rpc-openstack, it is already installed. However, currently
rpc-gating configures MaaS separately and so `virtualenv` is not
installed when `maas-tigkstack-telegraf.yml` runs.

In addition, two `delegate_to` lines are removed given that the play is
already targeting the group `hosts`.