### PR TITLE
Add the ability to monitor legacy rpc-o ceph installs

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -308,3 +308,19 @@ metrics using a simple where clause, example:
 
 This simple query will select everything from the **nova_api_metadata** metric
 where the job reference tag is equal to the string "testing".
+
+
+Legacy Ceph monitoring
+~~~~~~~~~~~~~~~~~~~~~~
+
+Early versions of RPC-O have a specific Ceph deployment capability that deployed
+all of the Ceph components in containers in a very RPC-O specific way. In order
+to monitor these environments the RPC-MaaS checks need to descend into the
+containers and run the various plugins from within the environment which is
+different than more modern deployments using the "ceph-ansible" project. To
+enable legacy monitoring of RPC-O Ceph set the option `maas_rpc_legacy_ceph`
+to **true**.
+
+.. code-block:: shell
+
+    ansible-playbook -e "maas_rpc_legacy_ceph=true" /opt/rpc-maas/playbooks/site.yml

--- a/playbooks/maas-ceph-mon.yml
+++ b/playbooks/maas-ceph-mon.yml
@@ -37,6 +37,13 @@
         dest: "/etc/ceph/ceph.client.raxmon.keyring"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
+    - name: Write Ceph monitoring client key to file within legacy rpc hosts
+      copy:
+        content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"
+        dest: "/etc/ceph/ceph.client.raxmon.keyring"
+      when:
+        - maas_rpc_legacy_ceph | bool
+
   post_tasks:
     - name: Install local mons checks
       template:

--- a/playbooks/maas-ceph-osd.yml
+++ b/playbooks/maas-ceph-osd.yml
@@ -36,6 +36,13 @@
         dest: "/etc/ceph/ceph.client.raxmon.keyring"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
+    - name: Write Ceph monitoring client key to file within legacy rpc hosts
+      copy:
+        content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"
+        dest: "/etc/ceph/ceph.client.raxmon.keyring"
+      when:
+        - maas_rpc_legacy_ceph | bool
+
   tasks:
     - name: Discover Ceph facts
       ceph_osd_host_facts:

--- a/playbooks/templates/rax-maas/ceph_cluster_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_cluster_stats.yaml.j2
@@ -1,5 +1,13 @@
 {% set label = "ceph_cluster_stats" %}
 {% set check_name = label+'--'+ansible_hostname %}
+{% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
+{% if maas_rpc_legacy_ceph | bool %}
+{%   set _ = ceph_args.extend(["--container-name " + container_name]) %}
+{% endif %}
+{% set _ = ceph_args.extend(["cluster"]) %}
+{% set _ceph_args = ceph_args | join(' ') | string %}
+{% set ceph_args = _ceph_args.split() %}
+
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -7,7 +15,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "cluster"]
+    args    : {{ ceph_args }}
 alarms      :
     ceph_health_err :
         label                   : ceph_health_err--{{ ansible_hostname }}

--- a/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
@@ -1,5 +1,13 @@
 {% set label = "ceph_mon_stats" %}
 {% set check_name = label+'--'+ansible_hostname %}
+{% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
+{% if maas_rpc_legacy_ceph | bool %}
+{%   set _ = ceph_args.extend(["--container-name " + container_name]) %}
+{% endif %}
+{% set _ = ceph_args.extend(["mon", "--host " + ansible_hostname]) %}
+{% set _ceph_args = ceph_args | join(' ') | string %}
+{% set ceph_args = _ceph_args.split() %}
+
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -7,7 +15,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "mon", "--host", "{{ ansible_hostname }}"]
+    args    : {{ ceph_args }}
 alarms      :
     mon_health_err :
         label                   : mon_health_err--{{ ansible_hostname }}

--- a/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
@@ -1,5 +1,13 @@
 {% set label = "ceph_osd_stats" %}
 {% set check_name = label+'--'+ansible_hostname %}
+{% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
+{% if maas_rpc_legacy_ceph | bool %}
+{%   set _ = ceph_args.extend(["--container-name " + container_name]) %}
+{% endif %}
+{% set _ = ceph_args.extend(["osd", "--osd_ids " + ceph_osd_host['osd_ids'] | join(' ')]) %}
+{% set _ceph_args = ceph_args | join(' ') | string %}
+{% set ceph_args = _ceph_args.split() %}
+
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -7,7 +15,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring", "osd", "--osd_ids", "{{ ceph_osd_host['osd_ids'] | join(' ') }}"]
+    args    : {{ ceph_args }}
 alarms      :
 {% for osd_id in ceph_osd_host['osd_ids'] %}
     ceph_warn_osd.{{ osd_id }} :

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -205,3 +205,9 @@ maas_agent_upgrade: true
 #
 #
 maas_raxmon_ssl_verify: true
+
+#
+# maas_rpc_legacy_ceph: Instruct rpc-maas that the ceph deployment is using the old RPC
+#                       methods thereby installing ceph within containers.
+#
+maas_rpc_legacy_ceph: false


### PR DESCRIPTION
The legacy rpc-o ceph installations used a non-standard (ceph-ansible)
installation process which put both OSDs and MONs in lxc containers.
This means that maas needs to execute all of the ceph monitoring
commands from within these containers in order to retrieve metrics. This
change implements a container-name flag which supports a single argument
within all of the ceph checks allowing us to monitor these legacy
environments. To enable this capability the option,
`maas_rpc_legacy_ceph1` needs to be set "true".

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>