### PR TITLE
Add support for HTTP proxy with MaaS agent

### DIFF
--- a/playbooks/templates/rax-maas/rackspace-monitoring-agent.cfg.j2
+++ b/playbooks/templates/rax-maas/rackspace-monitoring-agent.cfg.j2
@@ -1,3 +1,6 @@
 monitoring_id {{ maas_entity_name }}
 monitoring_token {{ maas_agent_token }}
 monitoring_upgrade {{ maas_agent_upgrade }}
+{% if maas_proxy_url is defined %}
+monitoring_proxy_url {{ maas_proxy_url }}
+{% endif %}

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -211,3 +211,10 @@ maas_raxmon_ssl_verify: true
 #                       methods thereby installing ceph within containers.
 #
 maas_rpc_legacy_ceph: false
+
+# maas_proxy_url: (Optional) Specifies an HTTP proxy for use by the MaaS agent.
+#
+#   NOTE: In an openstack-ansible deployment, this would typically be set
+#         to "{{ proxy_env_url }}".
+#
+# maas_proxy_url: http://username:pa$$w0rd@10.10.10.9:9000/


### PR DESCRIPTION
This commit adds a variable named `maas_proxy_url`, which exposes the
`monitoring_proxy_url` configuration item in Rackspace monitoring agent
configuration file.

Closes: #308