### PR TITLE
LA-371 Install required apt packages for lxml

### DIFF
--- a/playbooks/vars/maas-ubuntu.yml
+++ b/playbooks/vars/maas-ubuntu.yml
@@ -26,6 +26,8 @@ maas_distro_packages:
   - libffi-dev
   - libjpeg8-dev
   - libssl-dev
+  - libxml2-dev
+  - libxslt-dev
   - rackspace-monitoring-agent
 
 maas_galera_distro_packages:


### PR DESCRIPTION
The Python package lxml requires libxml2 and libxslt to be installed.