### PR TITLE
fix unicode strings

### DIFF
--- a/playbooks/templates/rax-maas/ceph_cluster_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_cluster_stats.yaml.j2
@@ -2,11 +2,11 @@
 {% set check_name = label+'--'+ansible_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
 {% if maas_rpc_legacy_ceph | bool %}
-{%   set _ = ceph_args.extend(["--container-name " + container_name]) %}
+{%   set _ = ceph_args.extend(["--container-name", container_name]) %}
 {% endif %}
 {% set _ = ceph_args.extend(["cluster"]) %}
-{% set _ceph_args = ceph_args | join(' ') | string %}
-{% set ceph_args = _ceph_args.split() %}
+{% set _ceph_args = ceph_args | to_yaml(width=1000) %}
+{% set ceph_args = _ceph_args %}
 
 type        : agent.plugin
 label       : "{{ check_name }}"

--- a/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
@@ -2,11 +2,11 @@
 {% set check_name = label+'--'+ansible_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
 {% if maas_rpc_legacy_ceph | bool %}
-{%   set _ = ceph_args.extend(["--container-name " + container_name]) %}
+{%   set _ = ceph_args.extend(["--container-name", container_name]) %}
 {% endif %}
-{% set _ = ceph_args.extend(["mon", "--host " + ansible_hostname]) %}
-{% set _ceph_args = ceph_args | join(' ') | string %}
-{% set ceph_args = _ceph_args.split() %}
+{% set _ = ceph_args.extend(["mon", "--host", ansible_hostname]) %}
+{% set _ceph_args = ceph_args | to_yaml(width=1000) %}
+{% set ceph_args = _ceph_args %}
 
 type        : agent.plugin
 label       : "{{ check_name }}"

--- a/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
@@ -1,12 +1,10 @@
 {% set label = "ceph_osd_stats" %}
 {% set check_name = label+'--'+ansible_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
-{% if maas_rpc_legacy_ceph | bool %}
-{%   set _ = ceph_args.extend(["--container-name " + container_name]) %}
-{% endif %}
-{% set _ = ceph_args.extend(["osd", "--osd_ids " + ceph_osd_host['osd_ids'] | join(' ')]) %}
-{% set _ceph_args = ceph_args | join(' ') | string %}
-{% set ceph_args = _ceph_args.split() %}
+{% set _ = ceph_args.extend(["osd", "--osd_ids"]) %}
+{% set _ = ceph_args.append(ceph_osd_host['osd_ids'] | default([]) | join(' ')) %}
+{% set _ceph_args = ceph_args | to_yaml(width=1000) %}
+{% set ceph_args = _ceph_args %}
 
 type        : agent.plugin
 label       : "{{ check_name }}"


### PR DESCRIPTION
The maas agent can't deal with unicode, this change ensures that no unicode is used with the args list.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>