### PR TITLE
Add a trailing slash to Horizon URL

### DIFF
--- a/playbooks/templates/rax-maas/lb_api_check_horizon.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_horizon.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (inventory_hostname != groups['horizon'][0] or check_nam
 target_resolver   : "IPv4"
 target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_horizon_scheme | default(maas_scheme)}}://{{ maas_external_ip_address }}:443/auth/login"
+    url           : "{{ maas_horizon_scheme | default(maas_scheme)}}://{{ maas_external_ip_address }}:443/auth/login/"
 monitoring_zones_poll:
 {% for zone in maas_monitoring_zones %}
   - {{ zone }}


### PR DESCRIPTION
This commit adds a trailing slash to the Horizon URL.  Without this,
the check receives a 301 redirect and then fails.  After this change,
the check receives a 200 and passes.

Closes: #313