### PR TITLE
Add maas_external_hostname variable

### DIFF
--- a/playbooks/templates/rax-maas/lb_api_check_cinder.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_cinder.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (inventory_hostname != groups['cinder_api'][0] or check_
 target_resolver   : "IPv4"
 target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_cinder_scheme | default(maas_scheme)}}://{{ maas_external_ip_address }}:8776"
+    url           : "{{ maas_cinder_scheme | default(maas_scheme)}}://{{ maas_external_hostname }}:8776"
 monitoring_zones_poll:
 {% for zone in maas_monitoring_zones %}
   - {{ zone }}

--- a/playbooks/templates/rax-maas/lb_api_check_glance.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_glance.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (inventory_hostname != groups['glance_api'][0] or check_
 target_resolver   : "IPv4"
 target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_glance_scheme | default(maas_scheme)}}://{{ maas_external_ip_address }}:9292"
+    url           : "{{ maas_glance_scheme | default(maas_scheme)}}://{{ maas_external_hostname }}:9292"
 monitoring_zones_poll:
 {% for zone in maas_monitoring_zones %}
   - {{ zone }}

--- a/playbooks/templates/rax-maas/lb_api_check_heat_api.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_heat_api.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (inventory_hostname != groups['heat_api'][0] or check_na
 target_resolver   : "IPv4"
 target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_heat_api_scheme | default(maas_scheme)}}://{{ maas_external_ip_address }}:8004"
+    url           : "{{ maas_heat_api_scheme | default(maas_scheme)}}://{{ maas_external_hostname }}:8004"
 monitoring_zones_poll:
 {% for zone in maas_monitoring_zones %}
   - {{ zone }}

--- a/playbooks/templates/rax-maas/lb_api_check_heat_cfn.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_heat_cfn.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (inventory_hostname != groups['heat_api_cfn'][0] or chec
 target_resolver   : "IPv4"
 target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_heat_cfn_scheme | default(maas_scheme)}}://{{ maas_external_ip_address }}:8000"
+    url           : "{{ maas_heat_cfn_scheme | default(maas_scheme)}}://{{ maas_external_hostname }}:8000"
 monitoring_zones_poll:
 {% for zone in maas_monitoring_zones %}
   - {{ zone }}

--- a/playbooks/templates/rax-maas/lb_api_check_heat_cloudwatch.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_heat_cloudwatch.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (inventory_hostname != groups['heat_api_cloudwatch'][0] 
 target_resolver   : "IPv4"
 target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_heat_cloudwatch_scheme | default(maas_scheme)}}://{{ maas_external_ip_address }}:8003"
+    url           : "{{ maas_heat_cloudwatch_scheme | default(maas_scheme)}}://{{ maas_external_hostname }}:8003"
 monitoring_zones_poll:
 {% for zone in maas_monitoring_zones %}
   - {{ zone }}

--- a/playbooks/templates/rax-maas/lb_api_check_horizon.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_horizon.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (inventory_hostname != groups['horizon'][0] or check_nam
 target_resolver   : "IPv4"
 target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_horizon_scheme | default(maas_scheme)}}://{{ maas_external_ip_address }}:443/auth/login"
+    url           : "{{ maas_horizon_scheme | default(maas_scheme)}}://{{ maas_external_hostname }}:443/auth/login"
 monitoring_zones_poll:
 {% for zone in maas_monitoring_zones %}
   - {{ zone }}

--- a/playbooks/templates/rax-maas/lb_api_check_keystone.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_keystone.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (inventory_hostname != groups['keystone_all'][0] or chec
 target_resolver   : "IPv4"
 target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_keystone_scheme | default(maas_scheme)}}://{{ maas_external_ip_address }}:5000"
+    url           : "{{ maas_keystone_scheme | default(maas_scheme)}}://{{ maas_external_hostname }}:5000"
 monitoring_zones_poll:
 {% for zone in maas_monitoring_zones %}
   - {{ zone }}

--- a/playbooks/templates/rax-maas/lb_api_check_neutron.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_neutron.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (inventory_hostname != groups['neutron_server'][0] or ch
 target_resolver   : "IPv4"
 target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_neutron_scheme | default(maas_scheme)}}://{{ maas_external_ip_address }}:9696/"
+    url           : "{{ maas_neutron_scheme | default(maas_scheme)}}://{{ maas_external_hostname }}:9696/"
 monitoring_zones_poll:
 {% for zone in maas_monitoring_zones %}
   - {{ zone }}

--- a/playbooks/templates/rax-maas/lb_api_check_nova.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_nova.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (inventory_hostname != groups['nova_api_os_compute'][0] 
 target_resolver   : "IPv4"
 target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_nova_scheme | default(maas_scheme)}}://{{ maas_external_ip_address }}:8774"
+    url           : "{{ maas_nova_scheme | default(maas_scheme)}}://{{ maas_external_hostname }}:8774"
 monitoring_zones_poll:
 {% for zone in maas_monitoring_zones %}
   - {{ zone }}

--- a/playbooks/templates/rax-maas/lb_api_check_swift_access.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_swift_access.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (inventory_hostname != groups['swift_proxy'][0] or check
 target_resolver   : "IPv4"
 target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_swift_proxy_scheme | default(maas_scheme)}}://{{ maas_external_ip_address }}:8080/v1/{{ hostvars[groups['swift_proxy'][0]]['maas_swift_access_url_key'] }}/{{ maas_swift_accesscheck_container }}/index.html"
+    url           : "{{ maas_swift_proxy_scheme | default(maas_scheme)}}://{{ maas_external_hostname }}:8080/v1/{{ hostvars[groups['swift_proxy'][0]]['maas_swift_access_url_key'] }}/{{ maas_swift_accesscheck_container }}/index.html"
 monitoring_zones_poll:
 {% for zone in maas_monitoring_zones %}
   - {{ zone }}

--- a/playbooks/templates/rax-maas/lb_api_check_swift_healthcheck.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_swift_healthcheck.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (inventory_hostname != groups['swift_proxy'][0] or check
 target_resolver   : "IPv4"
 target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_swift_proxy_scheme | default(maas_scheme)}}://{{ maas_external_ip_address }}:8080/healthcheck"
+    url           : "{{ maas_swift_proxy_scheme | default(maas_scheme)}}://{{ maas_external_hostname }}:8080/healthcheck"
 monitoring_zones_poll:
 {% for zone in maas_monitoring_zones %}
   - {{ zone }}

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -96,6 +96,17 @@ internal_vip_address: "{{ internal_lb_vip_address }}"
 # ****************************************************
 
 #
+# maas_external_hostname: The hostname to use when constructing URLs for remote
+#                         API checks.
+#
+#   NOTE: In most environments this should match maas_external_ip_address. This
+#         variable exists to support environments where the monitored URL is
+#         not externally resolvable, which requires different values for MaaS's
+#         `url` and `target_hostname` settings.
+#
+maas_external_hostname: "{{ maas_external_ip_address }}"
+
+#
 # maas_alarm_local_consecutive_count: The number of consecutive failures before an alert is
 #                                     generated for local checks.
 #


### PR DESCRIPTION
This commit splits the `maas_external_ip_address` variable so that
different values can be configured in MaaS's `target_hostname` and
`url` settings.  This is required for environments where OpenStack
endpoints are not resolvable by the MaaS pollers, which requires
setting an IP for `target_hostname` and the internally resolvable
hostname in the `url`.

Closes: #311