### PR TITLE
Ability to override default notification plan for each check

### DIFF
--- a/playbooks/templates/rax-maas/ceph_cluster_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_cluster_stats.yaml.j2
@@ -19,7 +19,7 @@ details     :
 alarms      :
     ceph_health_err :
         label                   : ceph_health_err--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('ceph_health_err--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -29,7 +29,7 @@ alarms      :
 
     ceph_health_warn :
         label                   : ceph_health_warn--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('ceph_health_warn--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
@@ -19,7 +19,7 @@ details     :
 alarms      :
     mon_health_err :
         label                   : mon_health_err--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('mon_health_err--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -29,7 +29,7 @@ alarms      :
 
     mon_health_warn :
         label                   : mon_health_warn--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('mon_health_err--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
@@ -18,7 +18,7 @@ alarms      :
 {% for osd_id in ceph_osd_host['osd_ids'] %}
     ceph_warn_osd.{{ osd_id }} :
         label                   : ceph_warn_osd.{{ osd_id }}--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('ceph_warn_osd.'+osd_id|string+'--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/cinder_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_api_local_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     cinder_api_local_status :
         label                   : cinder_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('cinder_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/cinder_backup_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_backup_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     cinder_backup_status :
         label                   : cinder_backup_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('cinder_backup_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/cinder_scheduler_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_scheduler_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     cinder_scheduler_status :
         label                   : cinder_scheduler_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('cinder_scheduler_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/cinder_vg_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_vg_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     cinder_vg_space_status :
         label                   : cinder_vg_space_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('cinder_vg_space_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/cinder_volume_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_volume_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     cinder_volume_{{ item.key }}_status :
         label                   : cinder_volume_{{ item.key }}_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('cinder_volume_'+item.key+'_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/conntrack_count.yaml.j2
+++ b/playbooks/templates/rax-maas/conntrack_count.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     conntrack_count_status :
         label                   : conntrack_count_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('conntrack_count_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/container_storage_checks.yaml.j2
+++ b/playbooks/templates/rax-maas/container_storage_checks.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     container_storage_percent_used_critical:
         label                   : container_storage_percent_used--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('container_storage_percent_used_critical--' + inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/cpu_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cpu_check.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | terna
 alarms            :
     idle_percent_average        :
         label                   : idle_percent_average--{{ inventory_hostname|quote }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('idle_percent_average--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/disk_utilisation.yaml.j2
+++ b/playbooks/templates/rax-maas/disk_utilisation.yaml.j2
@@ -12,7 +12,7 @@ alarms      :
 {% for device in maas_disk_util_devices %}
     percentage_disk_utilisation_{{ device }}:
         label                   : percentage_disk_utilisation_{{ device }}--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('percentage_disk_utilisation_'+device+'--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/elasticsearch_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/elasticsearch_process_check.yaml.j2
@@ -12,7 +12,7 @@ alarms      :
 {% for process in elasticsearch_process_names %}
     {{ process }}_process_status:
         label                   : {{ process }}_process_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ ((process+'_process_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/filebeat_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/filebeat_process_check.yaml.j2
@@ -12,7 +12,7 @@ alarms      :
 {% for process in filebeat_process_names %}
     {{ process }}_process_status:
         label                   : {{ process }}_process_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : "{{ ((process+'_process_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/filesystem.yaml.j2
+++ b/playbooks/templates/rax-maas/filesystem.yaml.j2
@@ -10,7 +10,7 @@ details     :
 alarms      :
     filesystem_{{ item.filesystem }}_check :
         label                   : "Disk space used on {{ item.filesystem }}--{{ inventory_hostname }}"
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('Disk space used on '+item.filesystem+'--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/galera_check.yaml.j2
+++ b/playbooks/templates/rax-maas/galera_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     wsrep_cluster_size :
         label                   : wsrep_cluster_size--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('wsrep_cluster_size--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -20,7 +20,7 @@ alarms      :
             }
     wsrep_local_state :
         label                   : wsrep_local_state--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('wsrep_local_state--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -29,7 +29,7 @@ alarms      :
             }
     percentage_used_mysql_connections :
         label                   : percentage_used_mysql_connections--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('percentage_used_mysql_connections--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -41,7 +41,7 @@ alarms      :
             }
     open_file_size_limit_reached :
         label                   : open_file_size_limit_reached--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('open_file_size_limit_reached--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -53,7 +53,7 @@ alarms      :
             }
     innodb_row_lock_time_avg :
         label                   : innodb_row_lock_time_avg--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('innodb_row_lock_time_avg--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -65,7 +65,7 @@ alarms      :
             }
     innodb_deadlocks :
         label                   : innodb_deadlocks--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('innodb_deadlocks--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -77,7 +77,7 @@ alarms      :
             }
     access_denied_errors :
         label                   : access_denied_errors--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('access_denied_errors--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -89,7 +89,7 @@ alarms      :
             }
     aborted_clients :
         label                   : aborted_clients--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('aborted_clients--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -101,7 +101,7 @@ alarms      :
             }
     aborted_connects :
         label                   : aborted_connects--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('aborted_connects--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/glance_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/glance_api_local_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     glance_api_local_status :
         label                   : glance_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('glance_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/glance_registry_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/glance_registry_local_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     glance_registry_local_status :
         label                   : glance_registry_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('glance_registry_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/heat_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/heat_api_local_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     heat_api_local_status :
         label                   : heat_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('heat_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/heat_cfn_api_check.yaml.j2
+++ b/playbooks/templates/rax-maas/heat_cfn_api_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     heat_cfn_api_local_status :
         label                   : heat_cfn_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('heat_cfn_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/heat_cw_api_check.yaml.j2
+++ b/playbooks/templates/rax-maas/heat_cw_api_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     heat_cw_api_local_status :
         label                   : heat_cw_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('heat_cw_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/holland_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/holland_local_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
      holland_backup_status:
         label                   : holland_backup_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('holland_backup_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/horizon_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/horizon_local_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     horizon_local_status :
         label                   : "horizon_local_status--{{ inventory_hostname }}"
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('horizon_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/keystone_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/keystone_api_local_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     keystone_api_local_status :
         label                   : keystone_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('keystone_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/lb_api_check_cinder.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_cinder.yaml.j2
@@ -16,7 +16,7 @@ monitoring_zones_poll:
 alarms            :
     lb_api_alarm_cinder     :
         label               : lb_api_alarm_cinder
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ ('lb_api_alarm_cinder' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/lb_api_check_glance.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_glance.yaml.j2
@@ -16,7 +16,7 @@ monitoring_zones_poll:
 alarms            :
     lb_api_alarm_glance     :
         label               : lb_api_alarm_glance
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ ('lb_api_alarm_glance' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/lb_api_check_heat_api.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_heat_api.yaml.j2
@@ -16,7 +16,7 @@ monitoring_zones_poll:
 alarms            :
     lb_api_alarm_heat_api   :
         label               : lb_api_alarm_heat_api
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ ('lb_api_alarm_heat_api' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/lb_api_check_heat_cfn.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_heat_cfn.yaml.j2
@@ -16,7 +16,7 @@ monitoring_zones_poll:
 alarms            :
     lb_api_alarm_heat_cfn   :
         label               : lb_api_alarm_heat_cfn
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ ('lb_api_alarm_heat_cfn' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/lb_api_check_heat_cloudwatch.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_heat_cloudwatch.yaml.j2
@@ -16,7 +16,7 @@ monitoring_zones_poll:
 alarms            :
     lb_api_alarm_heat_cloudwatch :
         label               : lb_api_alarm_heat_cloudwatch
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ ('lb_api_alarm_heat_cloudwatch' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/lb_api_check_horizon.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_horizon.yaml.j2
@@ -16,7 +16,7 @@ monitoring_zones_poll:
 alarms            :
     lb_api_alarm_horizon     :
         label               : lb_api_alarm_horizon
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ ('lb_api_alarm_horizon' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/lb_api_check_keystone.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_keystone.yaml.j2
@@ -16,7 +16,7 @@ monitoring_zones_poll:
 alarms            :
     lb_api_alarm_keystone   :
         label               : lb_api_alarm_keystone
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ ('lb_api_alarm_keystone' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/lb_api_check_neutron.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_neutron.yaml.j2
@@ -16,7 +16,7 @@ monitoring_zones_poll:
 alarms            :
     lb_api_alarm_neutron    :
         label               : lb_api_alarm_neutron
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ ('lb_api_alarm_neutron' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/lb_api_check_nova.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_nova.yaml.j2
@@ -16,7 +16,7 @@ monitoring_zones_poll:
 alarms            :
     lb_api_alarm_nova       :
         label               : lb_api_alarm_nova
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ ('lb_api_alarm_nova' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/lb_api_check_swift_access.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_swift_access.yaml.j2
@@ -16,7 +16,7 @@ monitoring_zones_poll:
 alarms            :
     lb_api_alarm_swift_access:
         label               : lb_api_alarm_swift_access
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ ('lb_api_alarm_swift_access' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/lb_api_check_swift_healthcheck.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_swift_healthcheck.yaml.j2
@@ -16,7 +16,7 @@ monitoring_zones_poll:
 alarms            :
     lb_api_alarm_swift_healthcheck:
         label               : lb_api_alarm_swift_healthcheck
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ ('lb_api_alarm_swift_healthcheck' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/lb_ssl_cert_expiry_check.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_ssl_cert_expiry_check.yaml.j2
@@ -12,7 +12,7 @@ details           :
 alarms            :
     lb_ssl_alarm_cert_expiry:
         label               : lb_ssl_alarm_cert_expiry
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ ('lb_ssl_alarm_cert_expiry' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria            : |
             if (metric['cert_end_in'] < 604800) {

--- a/playbooks/templates/rax-maas/magnum_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/magnum_api_local_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     magnum_api_local_status :
         label                   : magnum_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('magnum_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/magnum_conductor_check.yaml.j2
+++ b/playbooks/templates/rax-maas/magnum_conductor_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     magnum_conductor_status :
         label                   : magnum_conductor_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('magnum_conductor_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/memcached_status.yaml.j2
+++ b/playbooks/templates/rax-maas/memcached_status.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     memcache_api_local_status :
         label                   : memcache_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('memcache_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -20,7 +20,7 @@ alarms      :
             }
     memcache_curr_connections :
         label                   : memcache_curr_connections--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('memcache_curr_connections--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/memory_check.yaml.j2
+++ b/playbooks/templates/rax-maas/memory_check.yaml.j2
@@ -8,7 +8,7 @@ disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | terna
 alarms            :
     memory_used                 :
         label                   : memory_check--{{ inventory_hostname|quote }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('memory_check--'+inventory_hostname | quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/network_throughput.yaml.j2
+++ b/playbooks/templates/rax-maas/network_throughput.yaml.j2
@@ -16,7 +16,7 @@ details:
 alarms:
     alarm-network-receive:
         label: Network receive rate on {{ item.0.name }}
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ (('Network receive rate on '+item.0.name) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria: |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -29,7 +29,7 @@ alarms:
             return new AlarmStatus(OK, "Network receive rate on {{ item.0.name }} is below your warning threshold of {{ item.0.rx_pct_warn }}% utilisation.");
     alarm-network-transmit:
         label: Network transmit rate on {{ item.0.name }}
-        notification_plan_id: "{{ maas_notification_plan }}"
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled            : {{ (('Network transmit rate on '+item.0.name) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria: |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/neutron_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_api_local_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     neutron_api_local_status :
         label                   : neutron_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('neutron_api_local_status--'+inventory_hostname )| match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/neutron_dhcp_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_dhcp_agent_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     neutron_dhcp_agent_status :
         label                   : neutron_dhcp_agent_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('neutron_dhcp_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/neutron_l3_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_l3_agent_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     neutron_l3_agent_status :
         label                   : neutron_l3_agent_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('neutron_l3_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/neutron_linuxbridge_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_linuxbridge_agent_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     neutron_linuxbridge_agent_status :
         label                   : neutron_linuxbridge_agent_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('neutron_linuxbridge_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/neutron_metadata_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_metadata_agent_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     neutron_metadata_agent_status :
         label                   : neutron_metadata_agent_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('neutron_metadata_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/neutron_metering_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_metering_agent_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     neutron_metering_agent_status :
         label                   : neutron_metering_agent_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('neutron_metering_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/nova_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_api_local_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     nova_api_local_status :
         label                   : nova_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('nova_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/nova_api_metadata_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_api_metadata_local_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     nova_api_metadata_local_status :
         label                   : nova_api_metadata_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('nova_api_metadata_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
 
         criteria                : |

--- a/playbooks/templates/rax-maas/nova_cert_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_cert_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     nova_cert_status :
         label                   : nova_cert_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('nova_cert_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/nova_cloud_stats_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_cloud_stats_check.yaml.j2
@@ -12,7 +12,7 @@ details     :
 alarms      :
     nova_cloud_memory_status :
         label                   : nova_cloud_memory_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('nova_cloud_memory_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -24,7 +24,7 @@ alarms      :
             }
     nova_cloud_disk_status :
         label                   : nova_cloud_disk_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('nova_cloud_disk_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -36,7 +36,7 @@ alarms      :
             }
     nova_cloud_vcpu_status :
         label                   : nova_cloud_vcpu_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('nova_cloud_vcpu_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/nova_compute_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_compute_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     nova_compute_status :
         label                   : nova_compute_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('nova_compute_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/nova_conductor_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_conductor_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     nova_conductor_status :
         label                   : nova_conductor_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('nova_conductor_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/nova_console_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_console_check.yaml.j2
@@ -18,7 +18,7 @@ details     :
 alarms      :
     nova_{{ console_service_name }}_api_local_status :
         label                   : nova_{{ console_service_name}}_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('nova_{{ console_service_name}}_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/nova_consoleauth_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_consoleauth_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     nova_consoleauth_status :
         label                   : nova_consoleauth_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('nova_consoleauth_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/nova_scheduler_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_scheduler_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     nova_scheduler_status :
         label                   : nova_scheduler_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('nova_scheduler_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
+++ b/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     rabbitmq_disk_free_alarm_status :
         label                   : rabbitmq_disk_free_alarm_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('rabbitmq_disk_free_alarm_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -21,7 +21,7 @@ alarms      :
 
     rabbitmq_mem_alarm_status :
         label                   : rabbitmq_mem_alarm_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('rabbitmq_mem_alarm_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -31,7 +31,7 @@ alarms      :
 
     rabbitmq_max_channels_per_conn :
         label                   : rabbitmq_max_channels_per_conn--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('rabbitmq_max_channels_per_conn--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -41,7 +41,7 @@ alarms      :
 
     rabbitmq_fd_used_alarm_status :
         label                   : rabbitmq_fd_used_alarm_status-{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('rabbitmq_fd_used_alarm_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -51,7 +51,7 @@ alarms      :
 
     rabbitmq_proc_used_alarm_status :
         label                   : rabbitmq_proc_used_alarm_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('rabbitmq_proc_used_alarm_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -61,7 +61,7 @@ alarms      :
 
     rabbitmq_socket_used_alarm_status :
         label                   : rabbitmq_socket_used_alarm_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('rabbitmq_socket_used_alarm_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -70,7 +70,7 @@ alarms      :
             }
     rabbitmq_msgs_excl_notifications :
         label                   : rabbitmq_msgs_excl_notifications--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('rabbitmq_msgs_excl_notifications--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -79,7 +79,7 @@ alarms      :
             }
     rabbitmq_qgrowth_excl_notifications :
         label                   : rabbitmq_qgrowth_excl_notifications--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('rabbitmq_qgrowth_excl_notifications--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -89,7 +89,7 @@ alarms      :
 
     rabbitmq_queues_without_consumers :
         label                   : rabbitmq_queues_without_consumers--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('rabbitmq_queues_without_consumers--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/rsyslogd_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/rsyslogd_process_check.yaml.j2
@@ -12,7 +12,7 @@ alarms      :
 {% for process in rsyslogd_process_names %}
     {{ process }}_process_status:
         label                   : {{ process }}_process_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ ((process+'_process_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_account_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_account_process_check.yaml.j2
@@ -12,7 +12,7 @@ alarms      :
 {% for process in maas_swift_account_process_names %}
     {{ process }}_process_status:
         label                   : {{ process }}_process_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : "{{ ((process+'_process_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_account_replication_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_account_replication_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     swift_account_replication_failure_check :
         label                   : swift_account_replication_failure_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_account_replication_failure_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -20,7 +20,7 @@ alarms      :
             }
     swift_account_replication_rate_check :
         label                   : swift_account_replication_rate_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_account_replication_rate_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -29,7 +29,7 @@ alarms      :
             }
     swift_account_replication_avg_time_check :
         label                   : swift_account_replication_avg_time_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_account_replication_avg_time_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_account_server_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_account_server_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     swift_account_server_api_local_status :
         label                   : swift_account_server_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_account_server_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_async_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_async_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     swift_async_failure_check :
         label                   : swift_async_failure_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_async_failure_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -21,7 +21,7 @@ alarms      :
 
     swift_async_avg_check :
         label                   : swift_async_avg_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_async_avg_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_container_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_container_process_check.yaml.j2
@@ -12,7 +12,7 @@ alarms      :
 {% for process in maas_swift_container_process_names %}
     {{ process }}_process_status:
         label                   : {{ process }}_process_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : "{{ ((process+'_process_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_container_replication_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_container_replication_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     swift_container_replication_failure_check :
         label                   : swift_container_replication_failure_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_container_replication_failure_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -20,7 +20,7 @@ alarms      :
             }
     swift_container_replication_rate_check :
         label                   : swift_container_replication_rate_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_container_replication_rate_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -29,7 +29,7 @@ alarms      :
             }
     swift_container_replication_avg_time_check :
         label                   : swift_container_replication_avg_time_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_container_replication_avg_time_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_container_server_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_container_server_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     swift_container_server_api_local_status :
         label                   : swift_container_server_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_container_server_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_md5_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_md5_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     swift_ring_md5_check :
         label                   : swift_ring_md5_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_ring_md5_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -21,7 +21,7 @@ alarms      :
 
     swift_conf_md5_check :
         label                   : swift_conf_md5_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_conf_md5_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_object_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_object_process_check.yaml.j2
@@ -12,7 +12,7 @@ alarms      :
 {% for process in maas_swift_object_process_names %}
     {{ process }}_process_status:
         label                   : {{ process }}_process_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : "{{ ((process+'_process_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}"
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_object_replication_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_object_replication_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     swift_object_replication_failure_check :
         label                   : swift_object_replication_failure_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_object_replication_failure_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -20,7 +20,7 @@ alarms      :
             }
     swift_object_replication_rate_check :
         label                   : swift_object_replication_rate_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_object_replication_rate_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -29,7 +29,7 @@ alarms      :
             }
     swift_object_replication_avg_time_check :
         label                   : swift_object_replication_avg_time_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_object_replication_avg_time_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_object_server_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_object_server_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     swift_object_server_api_local_status :
         label                   : swift_object_server_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_object_server_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_proxy_server_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_proxy_server_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     swift_proxy_server_api_local_status :
         label                   : swift_proxy_server_api_local_status--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_proxy_server_api_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_quarantine_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_quarantine_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     swift_quarantine_object_failed :
         label                   : swift_quarantine_object_failed--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_quarantine_object_failed--'+inventory_hostname )| match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -21,7 +21,7 @@ alarms      :
 
     swift_quarantine_object_avg :
         label                   : swift_quarantine_object_avg--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_quarantine_object_avg--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -31,7 +31,7 @@ alarms      :
 
     swift_quarantine_account_failed :
         label                   : swift_quarantine_account_failed--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_quarantine_account_failed--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -41,7 +41,7 @@ alarms      :
 
     swift_quarantine_account_avg :
         label                   : swift_quarantine_account_avg--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_quarantine_account_avg--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -51,7 +51,7 @@ alarms      :
 
     swift_quarantine_container_failed :
         label                   : swift_quarantine_container_failed--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_quarantine_container_failed--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
@@ -61,7 +61,7 @@ alarms      :
 
     swift_quarantine_container_avg :
         label                   : swift_quarantine_container_avg--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_quarantine_container_avg--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/templates/rax-maas/swift_time_sync_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_time_sync_check.yaml.j2
@@ -11,7 +11,7 @@ details     :
 alarms      :
     swift_time_sync_check :
         label                   : swift_time_sync_check--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('swift_time_sync_check--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -85,6 +85,17 @@ maas_verify_status: false
 maas_notification_plan: npManaged
 
 #
+# Customizing override for maas_notification_plan.
+# If a customer wants to see alerts pertaining to certain checks. This will allow each check
+# to be overridden with a specific notification plan. The override should include the check
+# label and appropriate notification plan to override it with.
+#
+#   maas_notification_plan_override:
+#     - lb_api_check_keystone: npHj234ksd
+#
+maas_notification_plan_override: {}
+
+#
 # maas_external_ip_address:
 #
 maas_external_ip_address: "{{ external_lb_vip_address }}"


### PR DESCRIPTION
This adds the ability to override individual checks with a different notification plan. Custom notification plans that include services such as PagerDuty can be tailored and deployed for monitoring that may be critical for a given customer without losing our ability to generate tickets.