### PR TITLE
LA-378 Fix swift-recon release identifier

### DIFF
--- a/playbooks/templates/rax-maas/swift_account_replication_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_account_replication_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (inventory_hostname in groups['swift_proxy'][0-1] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "--ring-type", "account", "replication"]
+    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "--swift-recon-path", "{{ swift_recon_path }}", "--ring-type", "account", "replication"]
 alarms      :
     swift_account_replication_failure_check :
         label                   : swift_account_replication_failure_check--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/swift_async_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_async_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (inventory_hostname in groups['swift_proxy'][0-1] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "async-pendings"]
+    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "--swift-recon-path", "{{ swift_recon_path }}", "async-pendings"]
 alarms      :
     swift_async_failure_check :
         label                   : swift_async_failure_check--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/swift_container_replication_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_container_replication_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (inventory_hostname in groups['swift_proxy'][0-1] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "--ring-type", "container", "replication"]
+    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "--swift-recon-path", "{{ swift_recon_path }}", "--ring-type", "container", "replication"]
 alarms      :
     swift_container_replication_failure_check :
         label                   : swift_container_replication_failure_check--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/swift_md5_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_md5_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (inventory_hostname in groups['swift_proxy'][0-1] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "md5"]
+    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "--swift-recon-path", "{{ swift_recon_path }}", "md5"]
 alarms      :
     swift_ring_md5_check :
         label                   : swift_ring_md5_check--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/swift_object_replication_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_object_replication_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (inventory_hostname in groups['swift_proxy'][0-1] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "--ring-type", "object", "replication"]
+    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "--swift-recon-path", "{{ swift_recon_path }}", "--ring-type", "object", "replication"]
 alarms      :
     swift_object_replication_failure_check :
         label                   : swift_object_replication_failure_check--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/swift_quarantine_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_quarantine_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (inventory_hostname in groups['swift_proxy'][0-1] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "quarantine"]
+    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "--swift-recon-path", "{{ swift_recon_path }}", "quarantine"]
 alarms      :
     swift_quarantine_object_failed :
         label                   : swift_quarantine_object_failed--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/swift_time_sync_check.yaml.j2
+++ b/playbooks/templates/rax-maas/swift_time_sync_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (inventory_hostname in groups['swift_proxy'][0-1] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "time"]
+    args    : ["{{ maas_plugin_dir }}/swift-recon.py", "--swift-recon-path", "{{ swift_recon_path }}", "time"]
 alarms      :
     swift_time_sync_check :
         label                   : swift_time_sync_check--{{ inventory_hostname }}

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -147,6 +147,10 @@ maas_swift_container_process_names:
   - swift-container-updater
   - swift-container-auditor
 
+# the release of OpenStack Swift that has been deployed
+swift_release: "{{ openstack_release }}"
+swift_recon_path: "/openstack/venvs/swift-{{ swift_release }}/bin"
+
 # Set the nova console type and port
 nova_console_type: novnc
 nova_console_ports:

--- a/tests/user_kilo_vars.yml
+++ b/tests/user_kilo_vars.yml
@@ -40,3 +40,5 @@ nova_console_port: 6082
 # Repo compatibility for Kilo
 openstack_upstream_domain: "rpc-repo.rackspace.com"
 repo_pip_default_index: "http://{{ openstack_upstream_domain }}/pools"
+
+swift_recon_path: "/usr/local/bin/"


### PR DESCRIPTION
This change modifies the swift-recon MaaS plugin to allow the directory
containing swift-recon to be specified. This change removes the need for
the plugin to try to discover the version.

Checking `/etc/openstack-release` for the version to use in general
works however due to the ordering of playbooks in leapfrog upgrades this
causes the wrong version to be used. The use of this approach also
lengthens the time of plugin failure during an upgrade given the
separation between creating the release file and updating Swift.