### PR TITLE
RE-312 Implement overridable vars for influx repo

### DIFF
--- a/playbooks/common-tasks/maas-agent-ubuntu-install.yml
+++ b/playbooks/common-tasks/maas-agent-ubuntu-install.yml
@@ -28,6 +28,7 @@
   apt_repository:
     repo: "{{ maas_repos.repo }}"
     state: "{{ maas_repos.state }}"
+    filename: "{{ maas_repos.filename | default(omit) }}"
     update_cache: yes
   register: add_repos
   until: add_repos | success

--- a/playbooks/maas-tigkstack-grafana.yml
+++ b/playbooks/maas-tigkstack-grafana.yml
@@ -64,12 +64,16 @@
 
     - name: Add grafana apt-keys
       apt_key:
-        url: "https://packagecloud.io/gpg.key"
+        id: "{{ maas_grafana_key.id | default(omit) }}"
+        keyserver: "{{ maas_grafana_key.keyserver | default(omit) }}"
+        data: "{{ maas_grafana_key.data | default(omit) }}"
+        url: "{{ maas_grafana_key.url | default(omit) }}"
         state: "present"
 
     - name: Add grafana repo
       apt_repository:
-        repo: "deb https://packagecloud.io/grafana/stable/debian/ jessie main"
+        repo: "{{ maas_grafana_repo.url }}"
+        filename: "{{ maas_grafana_repo.filename | default(omit) }}"
         state: "present"
         update_cache: yes
 

--- a/playbooks/maas-tigkstack-influxdb.yml
+++ b/playbooks/maas-tigkstack-influxdb.yml
@@ -41,13 +41,18 @@
 
     - name: Add influxdata apt-keys
       apt_key:
-        url: "https://repos.influxdata.com/influxdb.key"
+        id: "{{ maas_influxdata_key.id | default(omit) }}"
+        keyserver: "{{ maas_influxdata_key.keyserver | default(omit) }}"
+        data: "{{ maas_influxdata_key.data | default(omit) }}"
+        url: "{{ maas_influxdata_key.url | default(omit) }}"
         state: "present"
 
     - name: Add influxdata repo
       apt_repository:
-        repo: "deb https://repos.influxdata.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+        repo: "{{ maas_influxdata_repo.url }}"
+        filename: "{{ maas_influxdata_repo.filename | default(omit) }}"
         state: "present"
+        update_cache: yes
 
     - name: Update apt sources
       apt:

--- a/playbooks/maas-tigkstack-telegraf.yml
+++ b/playbooks/maas-tigkstack-telegraf.yml
@@ -97,12 +97,16 @@
   tasks:
     - name: Add influxdata apt-keys
       apt_key:
-        url: "https://repos.influxdata.com/influxdb.key"
+        id: "{{ maas_influxdata_key.id | default(omit) }}"
+        keyserver: "{{ maas_influxdata_key.keyserver | default(omit) }}"
+        data: "{{ maas_influxdata_key.data | default(omit) }}"
+        url: "{{ maas_influxdata_key.url | default(omit) }}"
         state: "present"
 
     - name: Add influxdata repo
       apt_repository:
-        repo: "deb https://repos.influxdata.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+        repo: "{{ maas_influxdata_repo.url }}"
+        filename: "{{ maas_influxdata_repo.filename | default(omit) }}"
         state: "present"
         update_cache: yes
 

--- a/playbooks/vars/maas-tigkstack.yml
+++ b/playbooks/vars/maas-tigkstack.yml
@@ -13,6 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#
+# Set the grafana distro package source & key
+#
+maas_grafana_key:
+  url: "https://packagecloud.io/gpg.key"
+
+maas_grafana_repo:
+  url: "deb https://packagecloud.io/grafana/stable/debian/ jessie main"
+
 # InfluxDB vars
 influxdb_admin_port: 8083
 influxdb_port: 8086

--- a/playbooks/vars/maas-tigkstack.yml
+++ b/playbooks/vars/maas-tigkstack.yml
@@ -14,6 +14,15 @@
 # limitations under the License.
 
 #
+# Set the influxdata distro package source & key
+#
+maas_influxdata_key:
+  url: "https://repos.influxdata.com/influxdb.key"
+
+maas_influxdata_repo:
+  url: "deb https://repos.influxdata.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+
+#
 # Set the grafana distro package source & key
 #
 maas_grafana_key:

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -30,6 +30,15 @@ maas_pip_package_state: "latest"
 maas_package_state: "latest"
 
 #
+# Set the influxdata distro package source & key
+#
+maas_influxdata_key:
+  url: "https://repos.influxdata.com/influxdb.key"
+
+maas_influxdata_repo:
+  url: "deb https://repos.influxdata.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+
+#
 # MaaS release version, this was tied to the RPC release version
 #   however it is now release independent.
 #

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -30,15 +30,6 @@ maas_pip_package_state: "latest"
 maas_package_state: "latest"
 
 #
-# Set the influxdata distro package source & key
-#
-maas_influxdata_key:
-  url: "https://repos.influxdata.com/influxdb.key"
-
-maas_influxdata_repo:
-  url: "deb https://repos.influxdata.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
-
-#
 # MaaS release version, this was tied to the RPC release version
 #   however it is now release independent.
 #


### PR DESCRIPTION
In order to ensure that RPC-O deployments make use
of a frozen set of apt artifacts, the repo/key
settings must be overridable.

While it'd be ideal for the variables to be set as
role defaults, allowing these settings to be set
via group_vars - this is not possible due to the
way playbooks have been used instead of roles.

As such, we use vars and RPC-O will be forced to
use extra-vars as that's the only option which
has a higher precedence.