### PR TITLE
Rearrange poller restart for standalone ceph

### DIFF
--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -27,8 +27,8 @@
       retries: 3
       delay: 2
       when:
-        - physical_host in groups['shared-infra_hosts']
         - maas_private_monitoring_enabled | bool
+        - physical_host in groups['shared-infra_hosts']
         - maas_restart_independent | default(true) | bool or
           maas_force_restart | default(false) | bool
         - ansible_distribution_version == "16.04"
@@ -43,8 +43,8 @@
       retries: 3
       delay: 2
       when:
-        - physical_host in groups['shared-infra_hosts']
         - maas_private_monitoring_enabled | bool
+        - physical_host in groups['shared-infra_hosts']
         - maas_restart_independent | default(true) | bool or
           maas_force_restart | default(false) | bool
         - ansible_distribution_version == "14.04"


### PR DESCRIPTION
Standalone ceph deploys are currently erroring out as rackspace-monitoring-poller won't be deployed there, but the restart task for the poller first checks for `groups['shared-infra_hosts']`.
That group doesn't exist in the stripped down inventory where this is being run, so flipping the ordering to first check for the poller's deployment will keep us from continuing on in the `when` checks for things like that group which might not be available.