### PR TITLE
Fix potential issue of associating an improper keystone endpoint

### DIFF
--- a/playbooks/files/rax-maas/plugins/maas_common.py
+++ b/playbooks/files/rax-maas/plugins/maas_common.py
@@ -616,8 +616,8 @@ def get_auth_details(openrc_file=OPENRC):
 
 def get_url_for_type(endpoint, url_type, auth_version):
     if auth_version == 'v3':
-        return endpoint['url'] if (endpoint['interface'] == url_type
-            and 'v3' in endpoint['url']) else None
+        return endpoint['url'] if (endpoint['interface'] == url_type and
+                                   'v3' in endpoint['url']) else None
     else:
         return endpoint[url_type + 'URL']
 

--- a/playbooks/files/rax-maas/plugins/maas_common.py
+++ b/playbooks/files/rax-maas/plugins/maas_common.py
@@ -616,7 +616,8 @@ def get_auth_details(openrc_file=OPENRC):
 
 def get_url_for_type(endpoint, url_type, auth_version):
     if auth_version == 'v3':
-        return endpoint['url'] if endpoint['interface'] == url_type else None
+        return endpoint['url'] if (endpoint['interface'] == url_type
+            and 'v3' in endpoint['url']) else None
     else:
         return endpoint[url_type + 'URL']
 


### PR DESCRIPTION
If a customer has both v2 and v3 endpoints, it's possible to incorrectly associate the wrong endpoint if it's iterated through first. This change simply verifies that the endpoint is the proper version before it's set.