### PR TITLE
Fix LB ssl expiry check

### DIFF
--- a/playbooks/maas-openstack-horizon.yml
+++ b/playbooks/maas-openstack-horizon.yml
@@ -57,7 +57,7 @@
     - name: Install lb-ssl check
       template:
         src: "templates/rax-maas/lb_ssl_cert_expiry_check.yaml.j2"
-        dest: "/etc/rackspace-monitoring-agent.conf.d/lb_ssl_cert_expiry_check--{{ inventory_hostname }}.yaml"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/lb_ssl_cert_expiry_check.yaml"
         owner: "root"
         group: "root"
         mode: "0644"

--- a/playbooks/templates/rax-maas/lb_ssl_cert_expiry_check.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_ssl_cert_expiry_check.yaml.j2
@@ -4,11 +4,15 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['horizon'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ maas_external_ip_address }}"
 details           :
     url           : "https://{{ maas_external_ip_address }}:443/auth/login/"
+monitoring_zones_poll:
+{% for zone in maas_monitoring_zones %}
+  - {{ zone }}
+{% endfor %}
 alarms            :
     lb_ssl_alarm_cert_expiry:
         label               : lb_ssl_alarm_cert_expiry


### PR DESCRIPTION
Fix missing monitoring_zones_poll which is failing validation preventing the check from deploying in the monitoring agent. Also replicate disabled status of the check across nodes and destination on disk.