### PR TITLE
LA-436 Enable use of telegraf ping plugin

### DIFF
--- a/playbooks/templates/tigkstack/telegraf.conf.j2
+++ b/playbooks/templates/tigkstack/telegraf.conf.j2
@@ -104,3 +104,8 @@ takes to get metrics, worst case scenario.
 [[inputs.swap]]
 
 {% endif %}
+
+{% if telegraf_plugin_ping_urls | default([]) %}
+[[inputs.ping]]
+urls = ["{{ telegraf_plugin_ping_urls | join('", "') }}"]
+{% endif %}

--- a/playbooks/vars/maas-tigkstack.yml
+++ b/playbooks/vars/maas-tigkstack.yml
@@ -49,6 +49,7 @@ influxdb_db_password: ''
 # Telegraf vars
 telegraf_interval: 30
 telegraf_maas_commands: []
+telegraf_plugin_ping_urls: []
 
 ## Prometheus Client Outputs Plugin
 telegraf_outputs_prometheus_client: false


### PR DESCRIPTION
`telegraf_plugin_ping_urls` represents a list of hosts to ping. This
plugin is only used if there is one or more URLs specified. This plugin
is added to allow instance monitoring during upgrade test builds.