### PR TITLE
Change alarm criteria variable ansible_host to inventory_hostname

### DIFF
--- a/playbooks/templates/rax-maas/container_storage_checks.yaml.j2
+++ b/playbooks/templates/rax-maas/container_storage_checks.yaml.j2
@@ -16,5 +16,5 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["container_storage_percent_used_critical"] != 1) {
-                return new AlarmStatus(CRITICAL, "Container storage for {{ ansible_host }} has reached a critical threshold >= {{ maas_percent_used_critical_threshold }} % used.");
+                return new AlarmStatus(CRITICAL, "Container storage for {{ inventory_hostname }} has reached a critical threshold >= {{ maas_percent_used_critical_threshold }} % used.");
             }


### PR DESCRIPTION
The template is currently generated with an IP address, which can be a bit confusing for support when a ticket is generated. Updated the variable to `inventory_hostname` instead so that identification is easier.