### PR TITLE
Properly set interface speed instead of defaulting to 0

### DIFF
--- a/playbooks/templates/rax-maas/network_throughput.yaml.j2
+++ b/playbooks/templates/rax-maas/network_throughput.yaml.j2
@@ -1,6 +1,6 @@
 {% set label = "network_throughput_"+item.0.name %}
 {% set check_name = label+'--'+inventory_hostname %}
-{% set max_speed = item.0.max_speed | default(0, boolean=true) %}
+{% set max_speed = item.0.max_speed %}
 {% set rx_warn = (max_speed | int * item.0.rx_pct_warn | float / 100) | int %}
 {% set rx_crit = (max_speed | int * item.0.rx_pct_crit | float / 100) | int %}
 {% set tx_warn = (max_speed | int * item.0.tx_pct_warn | float / 100) | int %}

--- a/playbooks/vars/maas-host.yml
+++ b/playbooks/vars/maas-host.yml
@@ -79,8 +79,8 @@ maas_poller_fd_critical_threshold: 90
 
 maas_network_checks_list:
   - name: "{{ ansible_default_ipv4.interface }}"
-    max_speed: null
-    rx_pct_warn: 40
-    rx_pct_crit: 60
-    tx_pct_warn: 40
-    tx_pct_crit: 60
+    max_speed: "{{ ((ansible_default_ipv4 | default({})).speed | default(1000) | int) * 131072 }}"
+    rx_pct_warn: 60
+    rx_pct_crit: 80
+    tx_pct_warn: 60
+    tx_pct_crit: 80


### PR DESCRIPTION
Attempt to utilize `ansible_default_ipv4.speed` (ansible 2.0+) to build the interface speed and default to 1Gb. This resolves the issue of it being defaulted to 0 within the template, preventing continual state changes in production.