### PR TITLE
HUM-304 Allow the use of other ansible-playbook binaries

### DIFF
--- a/tests/test-ansible-functional.sh
+++ b/tests/test-ansible-functional.sh
@@ -46,7 +46,7 @@ export ANSIBLE_PARAMETERS="${ANSIBLE_PARAMETERS:-false}"
 export ANSIBLE_LOG_DIR="${TESTING_HOME}/.ansible/logs"
 export ANSIBLE_LOG_PATH="${ANSIBLE_LOG_DIR}/ansible-functional.log"
 # Ansible Inventory will be set to OSA
-export ANSIBLE_INVENTORY="/opt/openstack-ansible/playbooks/inventory"
+export ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY:-/opt/openstack-ansible/playbooks/inventory}"
 
 export TEST_PLAYBOOK="${TEST_PLAYBOOK:-$WORKING_DIR/tests/test.yml}"
 export TEST_SETUP_PLAYBOOK="${TEST_SETUP_PLAYBOOK:-$WORKING_DIR/tests/test-setup.yml}"
@@ -54,6 +54,7 @@ export TEST_CHECK_MODE="${TEST_CHECK_MODE:-false}"
 export TEST_IDEMPOTENCE="${TEST_IDEMPOTENCE:-false}"
 
 export COMMON_TESTS_PATH="${WORKING_DIR}/tests/common"
+export ANSIBLE_BINARY="${ANSIBLE_BINARY:-openstack-ansible}"
 
 echo "ANSIBLE_OVERRIDES: ${ANSIBLE_OVERRIDES}"
 echo "ANSIBLE_PARAMETERS: ${ANSIBLE_PARAMETERS}"
@@ -78,7 +79,7 @@ function set_ansible_parameters {
 
 function execute_ansible_playbook {
 
-  CMD_TO_EXECUTE="openstack-ansible $@ ${ANSIBLE_CLI_PARAMETERS}"
+  CMD_TO_EXECUTE="${ANSIBLE_BINARY} $@ ${ANSIBLE_CLI_PARAMETERS}"
   echo "Executing: ${CMD_TO_EXECUTE}"
   echo "With:"
   echo "    ANSIBLE_INVENTORY: ${ANSIBLE_INVENTORY}"


### PR DESCRIPTION
For non OpenStack deploys we shouldnt enforce the use of
openstack-ansible. For example, for deploying Ceph standalone.

We should allow MaaS to not force the use of openstack-ansible binary
and instead allow this to be set by an environment variable.