### PR TITLE
HUM-304 Monitor Ceph OSD service in containers

### DIFF
--- a/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
@@ -1,6 +1,9 @@
 {% set label = "ceph_osd_stats" %}
 {% set check_name = label+'--'+inventory_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
+{% if physical_host is defined and physical_host != ansible_host %}
+{%   set _ = ceph_args.extend(["--container-name", container_name]) %}
+{% endif %}
 {% set _ = ceph_args.extend(["osd", "--osd_ids"]) %}
 {% set _ = ceph_args.append(ceph_osd_host['osd_ids'] | default([]) | join(' ')) %}
 {% set _ceph_args = ceph_args | to_yaml(width=1000) %}


### PR DESCRIPTION
For testing multiple OSD hosts in an AIO we need to run these in
containers, we need to target OSD MaaS against the container correctly,
this patch allows the container_name to be passed to ceph_monitoring.py.