### PR TITLE
HUM-304 Install sysstat for disk_utilisation.py

### DIFF
--- a/playbooks/vars/maas-ubuntu.yml
+++ b/playbooks/vars/maas-ubuntu.yml
@@ -28,6 +28,7 @@ maas_distro_packages:
   - libssl-dev
   - libxml2-dev
   - libxslt-dev
+  - sysstat
   - rackspace-monitoring-agent
 
 maas_galera_distro_packages:


### PR DESCRIPTION
disk_utilisation.py requires sysstat for iostat to be present. In RPC-O
the openstack-hosts role will install sysstat so for RPC-O it was always
present.

When using a standlone ceph deployment or other service that doesn't
require the openstack-hosts role, we need sysstat in order to run the
disk_utilisation.py monitoring script.