### PR TITLE
Fix using a list for packages instead of with_items

### DIFF
--- a/playbooks/common-tasks/maas-poller-ubuntu-install.yml
+++ b/playbooks/common-tasks/maas-poller-ubuntu-install.yml
@@ -36,7 +36,8 @@
 
 - name: Ensure container packages are installed
   apt:
-    pkg: "{{ maas_poller_distro_packages | join(' ') }}"
+    pkg: "{{ item }}"
     state: "{{ maas_package_state }}"
     update_cache: yes
     cache_valid_time: 600
+  with_items: "{{ maas_poller_distro_packages }}"


### PR DESCRIPTION
When using the apt module you can pass a list, but not separated by
spaces, it should just be the list var. The current package install for
maas-poller will break, this patch fixes that and makes the maas-agent
packages install in the same, more efficient, way - that prevents the
need for a task per package.