### PR TITLE
Deploy holland by default

### DIFF
--- a/playbooks/files/rax-maas/plugins/holland_local_check.py
+++ b/playbooks/files/rax-maas/plugins/holland_local_check.py
@@ -55,7 +55,7 @@ def parse_args():
 
 
 def print_metrics(name, size):
-    metric('hollabd_backup_size', 'double', size, 'Megabytes')
+    metric('holland_backup_size', 'double', size, 'Megabytes')
 
 
 def container_holland_lb_check(container, binary, backupset):

--- a/playbooks/maas-infra-galera.yml
+++ b/playbooks/maas-infra-galera.yml
@@ -42,15 +42,6 @@
       when:
         - ansible_distribution | lower == 'ubuntu'
 
-    - name: Check for holland
-      stat:
-        path: "{{ maas_holland_venv_bin }}"
-      register: holland_check
-
-    - name: Set holland enabled fact disabled
-      set_fact:
-        holland_check_disabled: "{{ not holland_check.stat.exists }}"
-
     - name: Install holland check
       template:
         src: "templates/rax-maas/holland_local_check.yaml.j2"
@@ -60,7 +51,7 @@
         mode: "0644"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
-        - not holland_check_disabled | bool
+        - maas_holland_enabled | bool
       notify:
         - Restart rax-maas
 

--- a/playbooks/templates/rax-maas/holland_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/holland_local_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}holland_local_check.py", "{{ container_name }}"]
+    args    : ["{{ maas_plugin_dir }}/holland_local_check.py", "{{ container_name }}"]
 alarms      :
      holland_backup_status:
         label                   : holland_backup_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/holland_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/holland_local_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}holland_local_check.py", "{{ container_name }}", "{{ holland_venv_bin + '/holland' }}"]
+    args    : ["{{ maas_plugin_dir }}holland_local_check.py", "{{ container_name }}"]
 alarms      :
      holland_backup_status:
         label                   : holland_backup_status--{{ inventory_hostname }}

--- a/playbooks/vars/maas-infra.yml
+++ b/playbooks/vars/maas-infra.yml
@@ -19,7 +19,6 @@ elasticsearch_process_names:
 filebeat_process_names:
   - filebeat
 
-maas_holland_venv_bin: "/openstack/venvs/holland-{{ maas_release }}/bin"
 maas_mysql_connection_warning_threshold: 80
 maas_mysql_connection_critical_threshold: 90
 maas_mysql_access_denied_errors_rate_warning_threshold: 10

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -253,3 +253,8 @@ maas_rpc_legacy_ceph: false
 #         to "{{ proxy_env_url }}".
 #
 # maas_proxy_url: http://username:pa$$w0rd@10.10.10.9:9000/
+
+# maas_holland_enabled: Instruct rpc-maas to deploy holland check to verify daily galera
+#                       backups.
+#
+maas_holland_enabled: true


### PR DESCRIPTION
Holland was depending on a virtualenv that didn't exist. I've changed this to deploy based on a boolean instead. Additionally, fixed a few typos in the holland plugin and template.