### PR TITLE
Increase maas-restart retries

### DIFF
--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -55,8 +55,8 @@
         state: restarted
       register: _maas_agent_restart
       until: _maas_agent_restart | success
-      retries: 3
-      delay: 2
+      retries: 5
+      delay: 3
       when: >
         maas_restart_independent | default(true) | bool or
         maas_force_restart | default(false) | bool


### PR DESCRIPTION
For ceph standalone integration, fewer tasks have run, and the MaaS
agent fails to restart for longer.

This patch adds additional retries and a slightly longer delay to ensure
the service restarts properly.