### PR TITLE
RO-2619: Change alarm label to be consistent with other alarms

### DIFF
--- a/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
+++ b/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
@@ -40,7 +40,7 @@ alarms      :
             }
 
     rabbitmq_fd_used_alarm_status :
-        label                   : rabbitmq_fd_used_alarm_status-{{ inventory_hostname }}
+        label                   : rabbitmq_fd_used_alarm_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
         disabled                : {{ (('rabbitmq_fd_used_alarm_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |


### PR DESCRIPTION
Fix alarm label to align naming across all templates.