### PR TITLE
RE-613 Respect artifact location environment vars

### DIFF
--- a/playbooks/maas-verify.yml
+++ b/playbooks/maas-verify.yml
@@ -109,7 +109,7 @@
 
   vars:
     working_dir_logs: "{{ lookup('env', 'WORKING_DIR') | default('/tmp', true) }}/logs"
-    workspace_logs: "{{ lookup('env', 'WORKING_DIR') | default('/tmp', true) }}/../../logs"
+    workspace_logs: "{{ lookup('env', 'RE_HOOK_ARTIFACT_DIR') | default('/tmp', true) }}"
   vars_files:
     - vars/main.yml
     - vars/maas-verify.yml


### PR DESCRIPTION
RE provide environment variables which hold the path to the
correct place to store artifacts and test results:
  * RE_HOOK_ARTIFACT_DIR
  * RE_HOOK_RESULT_DIR

These are now available in the IRR jobs so can be used here.

Depends: https://github.com/rcbops/rpc-gating/pull/450