### PR TITLE
Addrgwmon

### DIFF
--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -17,6 +17,7 @@
 import argparse
 import json
 import maas_common
+import requests
 import subprocess
 
 
@@ -36,6 +37,19 @@ def check_command(command, container_name=None):
     output = subprocess.check_output(command, stderr=subprocess.STDOUT)
     lines = output.strip().split('\n')
     return json.loads(lines[-1])
+
+
+def get_ceph_rgw_hostcheck(rgw_host, rgw_port, container_name=None):
+    host_url = "http://%s:%s" % (rgw_host, rgw_port)
+    try:
+        sc = requests.get(host_url).status_code
+        if (sc >= 200) and (sc < 300):
+            status_code = 2
+        else:
+            status_code = 1
+    except requests.exceptions.ConnectionError:
+        status_code = 0
+    return status_code
 
 
 def get_ceph_status(client, keyring, fmt='json', container_name=None):
@@ -71,6 +85,13 @@ def get_mon_statistics(client=None, keyring=None, host=None,
             health_status = STATUSES[each['health']]
             break
     maas_common.metric('mon_health', 'uint32', health_status)
+
+
+def get_rgw_checkup(client, keyring=None, rgw_port=None,
+                    rgw_host=None, container_name=None):
+    rgw_status = get_ceph_rgw_hostcheck(rgw_host, rgw_port,
+                                        container_name=container_name)
+    maas_common.metric('rgw_up', 'uint32', rgw_status)
 
 
 def get_osd_statistics(client=None, keyring=None, osd_ids=None,
@@ -189,12 +210,16 @@ def get_args():
 def main(args):
     get_statistics = {'cluster': get_cluster_statistics,
                       'mon': get_mon_statistics,
+                      'rgw': get_rgw_checkup,
                       'osd': get_osd_statistics}
     kwargs = {'client': args.name, 'keyring': args.keyring}
     if args.subparser_name == 'osd':
         kwargs['osd_ids'] = [int(i) for i in args.osd_ids.split(' ')]
     if args.subparser_name == 'mon':
         kwargs['host'] = args.host
+    if args.subparser_name == 'rgw':
+        kwargs['rgw_port'] = args.rgw_port
+        kwargs['rgw_host'] = args.rgw_host
 
     kwargs['container_name'] = args.container_name
 

--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -199,6 +199,9 @@ def get_args():
     parser_osd = subparsers.add_parser('osd')
     parser_osd.add_argument('--osd_ids', required=True,
                             help='Space separated list of OSD IDs')
+    parser_rgw = subparsers.add_parser('rgw')
+    parser_rgw.add_argument('--rgw_port', required=True, help='RGW port')
+    parser_rgw.add_argument('--rgw_host', required=True, help='RGW host')
     parser.add_argument('--telegraf-output',
                         action='store_true',
                         default=False,

--- a/playbooks/maas-ceph-all.yml
+++ b/playbooks/maas-ceph-all.yml
@@ -20,3 +20,7 @@
 - include: maas-ceph-osd.yml
   tags:
     - maas-ceph
+
+- include: maas-ceph-rgw.yml
+  tags:
+    - maas-ceph

--- a/playbooks/maas-ceph-rgw.yml
+++ b/playbooks/maas-ceph-rgw.yml
@@ -1,0 +1,70 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Gather facts
+  hosts: rgws
+  gather_facts: "{{ gather_facts | default(true) }}"
+  tasks:
+    - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: rgws
+  
+  tags:
+    - maas-ceph-rgws
+
+- include: maas-ceph-raxmon.yml
+
+- name: Install checks for ceph rgws
+  hosts: rgws
+  gather_facts: false
+  pre_tasks:
+    - name: Write Ceph monitoring client key to file
+      copy:
+        content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"
+        dest: "/etc/ceph/ceph.client.raxmon.keyring"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+    - name: Write Ceph monitoring client key to file within legacy rpc hosts
+      copy:
+        content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"
+        dest: "/etc/ceph/ceph.client.raxmon.keyring"
+      when:
+        - maas_rpc_legacy_ceph | bool
+
+  post_tasks:
+    - name: Install local rgws checks
+      template:
+        src: "templates/rax-maas/{{ item }}.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/{{ item }}.yaml--{{ inventory_hostname }}.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      with_items:
+        - ceph_rgw_stats
+      notify:
+        - Restart rax-maas
+
+  handlers:
+    - include: handlers/main.yml
+  vars_files:
+    - vars/main.yml
+  tags:
+    - maas-ceph-rgws
+
+# NOTE(cloudnull): When we get to ONLY using Ansible 2.2+ this playbook can be removed as the handler
+#                  will be globally unified.
+- include: maas-restart.yml

--- a/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
@@ -1,0 +1,30 @@
+{% set label = "ceph_rgw_stats" %}
+{% set check_name = label+'--'+inventory_hostname %}
+{% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
+{% set _ = ceph_args.extend(["rgw", "--rgw_port", "8080"]) %}
+{% set _ = ceph_args.extend(["--rgw_host", ansible_host]) %}
+{% set _ceph_args = ceph_args | to_yaml(width=1000) %}
+{% set ceph_args = _ceph_args %}
+
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : {{ ceph_args }}
+alarms      :
+    ceph_rgw_status :
+        label                   : ceph_rgw_status.{{ inventory_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (('ceph_rgw_status.'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["rgw_up"] == 0) {
+                return new AlarmStatus(CRITICAL, "Ceph rgw error.");
+            }
+            if (metric["rgw_up"] == 1) {
+                return new AlarmStatus(WARNING, "Ceph rgw warning.");
+            }
+


### PR DESCRIPTION
This is a rework of the ceph rgw status alert and plugin based on review comments.   
From original pull request
Addition of rgw montioring for ceph Rados Gateway.

This adds general monitoring for nodes in the rgws group.
Adds a local check that hits the rgw endpoint ( http://localhost:/) and returns:
0 = Failure to Connect or Other failure (Critical)
1 = Status Code > 299 (WARNING)
2 = Status Code >= 200 < 299 . (OK)