### PR TITLE
Allow limiting swift-recon checks to one proxy node per deployment

### DIFF
--- a/playbooks/maas-openstack-swift.yml
+++ b/playbooks/maas-openstack-swift.yml
@@ -206,7 +206,7 @@
   tasks:
     - name: Set recon nodes fact
       set_fact:
-        maas_swift_recon_nodes: "{{ (maas_swift_multi_region_proxy_nodes | length == 2) | ternary(maas_swift_multi_region_proxy_nodes, groups['swift_proxy'][0:2]) }}"
+        maas_swift_recon_nodes: "{{ (maas_swift_multi_region_proxy_nodes | length > 0) | ternary(maas_swift_multi_region_proxy_nodes, groups['swift_proxy'][0:2]) }}"
       when:
         - maas_swift_recon_nodes is undefined
     


### PR DESCRIPTION
The initial implementation assumed a single deployment node was used for both regions. It turns out multi-region swift in our implementation uses two deployment nodes, one per data center. This change allows us to define a single node per region/deployment host instead of the default two.