### PR TITLE
RE-360 Include Reno notes in release notes

### DIFF
--- a/gating/generate_release_notes/generate_release_notes.sh
+++ b/gating/generate_release_notes/generate_release_notes.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -xe
+
+# This script is run within a docker container to generate release notes.
+
+/generate_reno_report.sh $NEW_TAG reno_report.md
+cat reno_report.md > all_notes.md

--- a/gating/generate_release_notes/generate_reno_report.sh
+++ b/gating/generate_release_notes/generate_reno_report.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -x
+
+release=${1}
+out_file=${2}
+err_file=${out_file}.err
+rst_file=${out_file}.rst
+
+reno report --branch ${release} --version ${release} --no-show-source --output ${rst_file} &> ${err_file}
+return_code=$?
+cat $err_file
+
+if [[ ${return_code} != 0 ]]; then
+  if grep -q "KeyError: '${release}'" ${err_file}; then
+    cat > ${out_file} << EOF
+Release Notes
+=============
+
+${release}
+-------------
+
+### No release notes
+
+EOF
+    return_code=0
+    echo "Warning: No new Reno release notes found, this can indicate an issue with the tag."
+  else
+    echo "Failure: Reno failed to generate the report."
+  fi
+else
+  pandoc --from rst --to markdown_github < ${rst_file} > ${out_file}
+  echo "Success: New Reno release notes found."
+fi
+
+exit ${return_code}

--- a/gating/generate_release_notes/release_notes_dockerfile
+++ b/gating/generate_release_notes/release_notes_dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:16.04
+RUN apt-get update && apt-get install -y python-pip build-essential python-dev libssl-dev
+RUN apt-get install -y libffi-dev
+RUN apt-get install -y sudo
+RUN apt-get install -y git-core
+RUN useradd jenkins --shell /bin/bash --create-home --uid 500
+RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+RUN apt-get install -y pandoc
+
+RUN pip install reno==2.5.1
+
+COPY gating/generate_release_notes/generate_release_notes.sh /generate_release_notes.sh
+COPY gating/generate_release_notes/generate_reno_report.sh /generate_reno_report.sh
+CMD /generate_release_notes.sh

--- a/gating/generate_release_notes/run
+++ b/gating/generate_release_notes/run
@@ -1,0 +1,22 @@
+#!/bin/bash -xe
+
+# This script is called by Jenkins to generate release notes.
+
+# It runs in docker as it requires pandoc which is an apt package, and
+# apt packages can't be installed on shared Jenkins slaves.
+
+docker_tag="${BUILD_TAG:-rpco_reno_$(date +%d%m%Y_%H%M)}"
+docker_tag_filtered="$(tr A-Z a-z <<<$docker_tag |tr -dc 'a-z0-9-_.')"
+docker build \
+  -f \
+  gating/generate_release_notes/release_notes_dockerfile \
+  -t $docker_tag_filtered .
+docker run \
+  -e "PREVIOUS_TAG=${RE_HOOK_PREVIOUS_VERSION}" \
+  -e "NEW_TAG=${RE_HOOK_VERSION}" \
+  -e "REPO_URL=${RE_HOOK_REPO_HTTP_URL}" \
+  -v "$(pwd)":"$(pwd)" \
+  -w "$(pwd)" \
+  $docker_tag_filtered
+
+cp all_notes.md "${RE_HOOK_RELEASE_NOTES}"


### PR DESCRIPTION
This changes adds support for the rpc-gating generate_release_notes
hook.

New releases will now automatically have release notes generated from
those managed by Reno. If there are no Reno notes for the release that
will be explicitly stated in the release notes.

This code is ported from that used by rpc-openstack, with the use of
rpc-differ removed. The same basic structure is maintained to simplify
working on the two projects and to make it easier to unify if this ever
becomes something that is centrally managed.

Test with new note: https://github.com/wherenoworg/rpc-maas/releases/tag/987.654.3210
Test without new note: https://github.com/wherenoworg/rpc-maas/releases/tag/987.654.3211