### PR TITLE
RO-2908 Set correct check port for novnc enabled console

### DIFF
--- a/playbooks/templates/rax-maas/nova_console_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_console_check.yaml.j2
@@ -4,6 +4,7 @@
 {% set console_service_name = 'nova_spice' %}
 {% set nova_console_base_url = 'spice_auto.html' %}
 {% elif nova_console_type == 'novnc' %}
+{% set nova_console_port = '6080' %}
 {% set console_service_name = 'nova_novnc' %}
 {% set nova_console_base_url = 'vnc_auto.html' %}
 {% endif %}


### PR DESCRIPTION
Use the correct HTTP port 6080 for the nova console novnc