### PR TITLE
Fix some hard-coded http endpoints

### DIFF
--- a/playbooks/files/rax-maas/plugins/cinder_service_check.py
+++ b/playbooks/files/rax-maas/plugins/cinder_service_check.py
@@ -37,8 +37,10 @@ def check(auth_ref, args):
     auth_token = keystone.auth_token
 
     VOLUME_ENDPOINT = (
-        'http://{hostname}:8776/v1/{tenant}'.format(hostname=args.hostname,
-                                                    tenant=keystone.tenant_id)
+        '{protocol}://{hostname}:8776/v1/{tenant}'.format(
+            protocol=args.protocol,
+            hostname=args.hostname,
+            tenant=keystone.tenant_id)
     )
 
     s = requests.Session()
@@ -124,6 +126,10 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--protocol',
+                        type=str,
+                        default='http',
+                        help='Protocol to use for cinder client')
     args = parser.parse_args()
     with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/rax-maas/plugins/neutron_service_check.py
+++ b/playbooks/files/rax-maas/plugins/neutron_service_check.py
@@ -25,7 +25,8 @@ from maas_common import status_ok
 
 def check(args):
 
-    NETWORK_ENDPOINT = 'http://{hostname}:9696'.format(hostname=args.hostname)
+    NETWORK_ENDPOINT = '{protocol}://{hostname}:9696'.format(
+        protocol=args.protocol, hostname=args.hostname)
     try:
         neutron = get_neutron_client(endpoint_url=NETWORK_ENDPOINT)
 
@@ -91,6 +92,10 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--protocol',
+                        type=str,
+                        default='http',
+                        help='Protocol for client requests')
     args = parser.parse_args()
     with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/rax-maas/plugins/nova_cloud_stats.py
+++ b/playbooks/files/rax-maas/plugins/nova_cloud_stats.py
@@ -66,8 +66,8 @@ def check(auth_ref, args):
     tenant_id = keystone.tenant_id
 
     COMPUTE_ENDPOINT = (
-        'http://{ip}:8774/v2.1/{tenant_id}'
-        .format(ip=args.ip, tenant_id=tenant_id)
+        '{protocol}://{ip}:8774/v2.1/{tenant_id}'
+        .format(ip=args.ip, tenant_id=tenant_id, protocol=args.protocol)
     )
 
     try:
@@ -134,6 +134,10 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--protocol',
+                        type=str,
+                        help='Protocol to use for contacting nova',
+                        default='http')
     args = parser.parse_args()
     with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/rax-maas/plugins/nova_service_check.py
+++ b/playbooks/files/rax-maas/plugins/nova_service_check.py
@@ -31,8 +31,9 @@ def check(auth_ref, args):
     tenant_id = keystone.tenant_id
 
     COMPUTE_ENDPOINT = (
-        'http://{hostname}:8774/v2.1/{tenant_id}'
-        .format(hostname=args.hostname, tenant_id=tenant_id)
+        '{protocol}://{hostname}:8774/v2.1/{tenant_id}'
+        .format(protocol=args.protocol, hostname=args.hostname,
+                tenant_id=tenant_id)
     )
     try:
         nova = get_nova_client(auth_token=auth_token,
@@ -88,6 +89,10 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--protocol',
+                        type=str,
+                        help='Protocol to use for contacting nova',
+                        default='http')
     args = parser.parse_args()
     with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
@@ -3,6 +3,7 @@
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
 {% set _ = ceph_args.extend(["rgw", "--rgw_port", "8080"]) %}
 {% set _ = ceph_args.extend(["--rgw_host", ansible_host]) %}
+{% set _ = ceph_args.extend(["--rgw_protocol", ceph_radosgw_protocol]) %}
 {% set _ceph_args = ceph_args | to_yaml(width=1000) %}
 {% set ceph_args = _ceph_args %}
 

--- a/playbooks/templates/rax-maas/cinder_backup_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_backup_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (not maas_monitor_cinder_backup | bool or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/cinder_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}/cinder_service_check.py", "--host", "{{ ansible_nodename }}", "--protocol", "{{ cinder_client_protocol }}", "{{ internal_vip_address }}"]
 alarms      :
     cinder_backup_status :
         label                   : cinder_backup_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/cinder_scheduler_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_scheduler_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/cinder_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}/cinder_service_check.py", "--host", "{{ ansible_nodename }}", "--protocol", "{{ cinder_client_protocol }}", "{{ internal_vip_address }}"]
 alarms      :
     cinder_scheduler_status :
         label                   : cinder_scheduler_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/cinder_volume_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_volume_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/cinder_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}/cinder_service_check.py", "--host", "{{ ansible_nodename }}", "--protocol", "{{ cinder_client_protocol }}", "{{ internal_vip_address }}"]
 alarms      :
     cinder_volume_{{ item.key }}_status :
         label                   : cinder_volume_{{ item.key }}_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/neutron_dhcp_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_dhcp_agent_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--protocol", "{{ neutron_client_protocol }}", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_dhcp_agent_status :
         label                   : neutron_dhcp_agent_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/neutron_l3_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_l3_agent_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--protocol", "{{ neutron_client_protocol }}", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_l3_agent_status :
         label                   : neutron_l3_agent_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/neutron_linuxbridge_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_linuxbridge_agent_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--protocol", "{{ neutron_client_protocol }}", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_linuxbridge_agent_status :
         label                   : neutron_linuxbridge_agent_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/neutron_metadata_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_metadata_agent_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--protocol", "{{ neutron_client_protocol }}", "--host", "{{ ansible_nodename }}", "--fqdn", "{{ ansible_fqdn }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_metadata_agent_status :
         label                   : neutron_metadata_agent_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/neutron_metering_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_metering_agent_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}/neutron_service_check.py", "--protocol", "{{ neutron_client_protocol }}", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
 alarms      :
     neutron_metering_agent_status :
         label                   : neutron_metering_agent_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/nova_cert_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_cert_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "--protocol", "{{ nova_service_check_protocol }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_cert_status :
         label                   : nova_cert_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/nova_cloud_stats_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_cloud_stats_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/nova_cloud_stats.py", "--cpu", "{{ maas_cloud_resource_cpu_allocation_ratio }}", "--mem", "{{ maas_cloud_resource_mem_allocation_ratio }}", "{{ ansible_host }}"]
+    args    : ["{{ maas_plugin_dir }}/nova_cloud_stats.py", "--cpu", "{{ maas_cloud_resource_cpu_allocation_ratio }}", "--mem", "{{ maas_cloud_resource_mem_allocation_ratio }}",  "--protocol", "{{ nova_service_check_protocol }}", "{{ internal_vip_address }}"]
 
 alarms      :
     nova_cloud_memory_status :

--- a/playbooks/templates/rax-maas/nova_compute_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_compute_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "--protocol", "{{ nova_service_check_protocol }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_compute_status :
         label                   : nova_compute_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/nova_conductor_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_conductor_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "--protocol", "{{ nova_service_check_protocol }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_conductor_status :
         label                   : nova_conductor_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/nova_consoleauth_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_consoleauth_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "--protocol", "{{ nova_service_check_protocol }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_consoleauth_status :
         label                   : nova_consoleauth_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/nova_scheduler_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_scheduler_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "{{ internal_vip_address }}"]
+    args    : ["{{ maas_plugin_dir }}/nova_service_check.py", "--host", "{{ ansible_nodename }}", "--protocol", "{{ nova_service_check_protocol }}", "{{ internal_vip_address }}"]
 alarms      :
     nova_scheduler_status :
         label                   : nova_scheduler_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/plugins/rabbitmq_status.py
+++ b/playbooks/templates/rax-maas/plugins/rabbitmq_status.py
@@ -26,12 +26,12 @@ from maas_common import status_ok
 import re
 import requests
 
-OVERVIEW_URL = "http://%s:%s/api/overview"
-NODES_URL = "http://%s:%s/api/nodes"
-CONNECTIONS_URL = "http://%s:%s/api/connections?columns=channels"
-QUEUES_URL = "http://%s:%s/api/queues"
-CONSUMERS_QUEUES_URL = "http://%s:%s/api/queues/%s"
-VHOSTS_URL = "http://%s:%s/api/vhosts"
+OVERVIEW_URL = "%s://%s:%s/api/overview"
+NODES_URL = "%s://%s:%s/api/nodes"
+CONNECTIONS_URL = "%s://%s:%s/api/connections?columns=channels"
+QUEUES_URL = "%s://%s:%s/api/queues"
+CONSUMERS_QUEUES_URL = "%s://%s:%s/api/queues/%s"
+VHOSTS_URL = "%s://%s:%s/api/vhosts"
 
 CLUSTERED = True
 # NOTE(cloudnull): The cluster size is set using a Jinja2 variable
@@ -102,12 +102,16 @@ def parse_args():
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--protocol',
+                        type=str,
+                        default='http',
+                        help='Protocol to use for rabbit checks')
     return parser.parse_args()
 
 
 def _get_rabbit_json(session, url):
     try:
-        response = session.get(url)
+        response = session.get(url, verify=False)
     except requests.exceptions.ConnectionError as e:
         metric_bool('client_success', False, m_name='maas_rabbitmq')
         status_err(str(e), m_name='maas_rabbitmq')
@@ -120,9 +124,10 @@ def _get_rabbit_json(session, url):
             response.status_code), m_name='maas_rabbitmq')
 
 
-def _get_connection_metrics(session, metrics, host, port):
+def _get_connection_metrics(session, metrics, protocol, host, port):
 
-    response = _get_rabbit_json(session, CONNECTIONS_URL % (host, port))
+    response = _get_rabbit_json(session, CONNECTIONS_URL % (protocol,
+                                                            host, port))
 
     max_chans = max(chain(connection['channels'] for connection in response
                     if 'channels' in connection), '0')
@@ -130,8 +135,8 @@ def _get_connection_metrics(session, metrics, host, port):
         metrics[k] = {'value': max_chans, 'unit': CONNECTIONS_METRICS[k]}
 
 
-def _get_overview_metrics(session, metrics, host, port):
-    response = _get_rabbit_json(session, OVERVIEW_URL % (host, port))
+def _get_overview_metrics(session, metrics, protocol, host, port):
+    response = _get_rabbit_json(session, OVERVIEW_URL % (protocol, host, port))
 
     for k in OVERVIEW_METRICS:
         if k in response:
@@ -140,8 +145,8 @@ def _get_overview_metrics(session, metrics, host, port):
                     metrics[a] = {'value': response[k][a], 'unit': b}
 
 
-def _get_node_metrics(session, metrics, host, port, name):
-    response = _get_rabbit_json(session, NODES_URL % (host, port))
+def _get_node_metrics(session, metrics, protocol, host, port, name):
+    response = _get_rabbit_json(session, NODES_URL % (protocol, host, port))
 
     # Either use the option provided by the commandline flag or the current
     # hostname
@@ -171,8 +176,8 @@ def _get_node_metrics(session, metrics, host, port, name):
         metrics[k] = {'value': nodes_matching_name[0][k], 'unit': v}
 
 
-def _get_queue_metrics(session, metrics, host, port):
-    response = _get_rabbit_json(session, QUEUES_URL % (host, port))
+def _get_queue_metrics(session, metrics, protocol, host, port):
+    response = _get_rabbit_json(session, QUEUES_URL % (protocol, host, port))
     notification_messages = sum([q['messages'] for q in response
                                 if re.match('/^(versioned_)?notifications\.',
                                             q['name']) and
@@ -188,9 +193,10 @@ def _get_queue_metrics(session, metrics, host, port):
     }
 
 
-def _get_consumer_metrics(session, metrics, host, port):
+def _get_consumer_metrics(session, metrics, protocol, host, port):
     VHOSTS = []
-    vhosts_response = _get_rabbit_json(session, VHOSTS_URL % (host, port))
+    vhosts_response = _get_rabbit_json(session, VHOSTS_URL % (protocol,
+                                                              host, port))
     # get the vhosts
     for vhost in vhosts_response:
         VHOSTS.append(vhost['name'])
@@ -200,7 +206,7 @@ def _get_consumer_metrics(session, metrics, host, port):
         # uri encode /
         URI_ENCODED = vhost.replace('/', '%2F')
         queue_response = _get_rabbit_json(session, CONSUMERS_QUEUES_URL %
-                                          (host, port, URI_ENCODED))
+                                          (protocol, host, port, URI_ENCODED))
         for queue in queue_response:
             if queue['consumers'] == 0 and queue['messages'] > 0:
                 queues_without_consumers += 1
@@ -216,12 +222,16 @@ def main():
     session = requests.Session()  # Make a Session to store the auth creds
     session.auth = (options.username, options.password)
 
-    _get_connection_metrics(session, metrics, options.host, options.port)
-    _get_overview_metrics(session, metrics, options.host, options.port)
-    _get_node_metrics(session, metrics, options.host, options.port,
-                      options.name)
-    _get_queue_metrics(session, metrics, options.host, options.port)
-    _get_consumer_metrics(session, metrics, options.host, options.port)
+    _get_connection_metrics(session, metrics, options.protocol,
+                            options.host, options.port)
+    _get_overview_metrics(session, metrics, options.protocol,
+                          options.host, options.port)
+    _get_node_metrics(session, metrics, options.protocol, options.host,
+                      options.port, options.name)
+    _get_queue_metrics(session, metrics, options.protocol, options.host,
+                       options.port)
+    _get_consumer_metrics(session, metrics, options.protocol, options.host,
+                          options.port)
 
     status_ok(m_name='maas_rabbitmq')
 

--- a/playbooks/templates/rax-maas/plugins/rabbitmq_status.py
+++ b/playbooks/templates/rax-maas/plugins/rabbitmq_status.py
@@ -102,10 +102,12 @@ def parse_args():
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
-    parser.add_argument('--protocol',
-                        type=str,
-                        default='http',
-                        help='Protocol to use for rabbit checks')
+    parser.add_argument('--http',
+                        action='store_true',
+                        help='Use http for checks')
+    parser.add_argument('--https',
+                        action='store_true',
+                        help='Use https for checks')
     return parser.parse_args()
 
 
@@ -222,15 +224,17 @@ def main():
     session = requests.Session()  # Make a Session to store the auth creds
     session.auth = (options.username, options.password)
 
-    _get_connection_metrics(session, metrics, options.protocol,
+    protocol = 'https' if options.https else 'http'
+
+    _get_connection_metrics(session, metrics, protocol,
                             options.host, options.port)
-    _get_overview_metrics(session, metrics, options.protocol,
+    _get_overview_metrics(session, metrics, protocol,
                           options.host, options.port)
-    _get_node_metrics(session, metrics, options.protocol, options.host,
+    _get_node_metrics(session, metrics, protocol, options.host,
                       options.port, options.name)
-    _get_queue_metrics(session, metrics, options.protocol, options.host,
+    _get_queue_metrics(session, metrics, protocol, options.host,
                        options.port)
-    _get_consumer_metrics(session, metrics, options.protocol, options.host,
+    _get_consumer_metrics(session, metrics, protocol, options.host,
                           options.port)
 
     status_ok(m_name='maas_rabbitmq')

--- a/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
+++ b/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/rabbitmq_status.py", "-H", "{{ ansible_host }}", "-n", "{{ ansible_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}", "--protocol", "{{ rabbitmq_http_protocol }}"]
+    args    : ["{{ maas_plugin_dir }}/rabbitmq_status.py", "-H", "{{ ansible_host }}", "-n", "{{ ansible_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}", "--{{ rabbitmq_http_protocol }}"]
 alarms      :
     rabbitmq_disk_free_alarm_status :
         label                   : rabbitmq_disk_free_alarm_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
+++ b/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/rabbitmq_status.py", "-H", "{{ ansible_host }}", "-n", "{{ ansible_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}"]
+    args    : ["{{ maas_plugin_dir }}/rabbitmq_status.py", "-H", "{{ ansible_host }}", "-n", "{{ ansible_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}", "--protocol", "{{ rabbitmq_http_protocol }}"]
 alarms      :
     rabbitmq_disk_free_alarm_status :
         label                   : rabbitmq_disk_free_alarm_status--{{ inventory_hostname }}

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -265,3 +265,37 @@ maas_holland_enabled: false
 #                            in the galera containers (RPC-O newton and onward).
 #
 maas_holland_venv_enabled: false
+
+#
+# nova_service_check_protocol: Protocol to use when authenticating for nova
+#                              service checks. Valid values are "http" or
+#                              "https".
+# TODO Should this be moved to the openstack vars file?
+nova_service_check_protocol: 'http'
+
+#
+# rabbitmq_http_protocol: Protocol to use when authenticating for rabbitmq
+#                         service checks. Valid values are "http" or
+#                         "https".
+# TODO Should this be moved to the openstack vars file?
+rabbitmq_http_protocol: 'http'
+
+#
+# neutron_client_protocol: Protocol to use when authenticating for neutron
+#                          service checks. Valid values are "http" or
+#                          "https".
+# TODO Should this be moved to the openstack vars file?
+neutron_client_protocol: 'http'
+
+#
+# cinder_client_protocol: Protocol to use when authenticating for cinder
+#                         service checks. Valid values are "http" or
+#                         "https".
+# TODO Should this be moved to the openstack vars file?
+cinder_client_protocol: 'http'
+
+#
+# ceph_radosgw_protocol: Protocol to use for ceph radosgw checks. Valid values
+#                        are "http" or "https".
+#
+ceph_radosgw_protocol: 'http'


### PR DESCRIPTION
Fixes hard-coded HTTP endpoints for the following checks:
- nova service checks
- nova cloud stats checks
- cinder service checks
- neutron service checks
- ceph radosgw checks
- rabbitmq checks

This also makes the nova cloud stats hit the VIP instead of the ansible
host so proper TLS termination can occur in that case.