### PR TITLE
Add fact to prevent handler failure

### DIFF
--- a/playbooks/maas-host-private-checks.yml
+++ b/playbooks/maas-host-private-checks.yml
@@ -18,6 +18,9 @@
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: hosts
   tags:
     - maas-poller-setup
 


### PR DESCRIPTION
This playbook was missing the `maas_current_group` fact which caused the playbook to fail when running the handler.