### PR TITLE
Add monitoring_proxy_url to poller configuration

### DIFF
--- a/playbooks/templates/rax-maas/rackspace-monitoring-poller.cfg
+++ b/playbooks/templates/rax-maas/rackspace-monitoring-poller.cfg
@@ -1,3 +1,6 @@
 monitoring_token {{ maas_agent_token }}
 monitoring_id {{ maas_entity_name }}
 monitoring_private_zones {{ maas_private_monitoring_zone }}
+{% if maas_proxy_url is defined %}
+monitoring_proxy_url {{ maas_proxy_url }}
+{% endif %}


### PR DESCRIPTION
The MaaS team is adding poller functionality similarly to the agent. Updating the template to include this value.