### PR TITLE
Clone stable/pike version of OSA tests repository

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ commands =
 [testenv:tests_clone]
 commands =
     bash -c "if [ ! -d "{toxinidir}/tests/common" ]; then \
-               git clone https://git.openstack.org/openstack/openstack-ansible-tests {toxinidir}/tests/common; \
+               git clone -b stable/pike https://git.openstack.org/openstack/openstack-ansible-tests {toxinidir}/tests/common; \
                pushd {toxinidir}/tests/common; \
                  git checkout {env:OSA_TESTS_CHECKOUT:master}; \
                popd; \


### PR DESCRIPTION
Since master is changing more rapidly we should use the latest stable
branch for the tests repo to reduce the impact of upstream changes.