### PR TITLE
[CEPHSTORA-22] Fix MaaS to allow Ceph Luminous support

### DIFF
--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -80,12 +80,6 @@ def get_mon_statistics(client=None, keyring=None, host=None,
            if m['name'] == host]
     mon_in = mon[0]['rank'] in ceph_status['quorum']
     maas_common.metric_bool('mon_in_quorum', mon_in)
-    health_status = 0
-    for each in ceph_status['health']['health']['health_services'][0]['mons']:
-        if each['name'] == host:
-            health_status = STATUSES[each['health']]
-            break
-    maas_common.metric('mon_health', 'uint32', health_status)
 
 
 def get_rgw_checkup(client, keyring=None, rgw_protocol=None, rgw_port=None,

--- a/playbooks/maas-ceph-raxmon.yml
+++ b/playbooks/maas-ceph-raxmon.yml
@@ -18,8 +18,12 @@
   gather_facts: false
   pre_tasks:
     - name: Create ceph monitoring client
-      command: ceph auth get-or-create client.raxmon mon 'allow r'
+      command: ceph auth get-or-create client.raxmon
       register: _ceph_raxmon_client
+      tags:
+        - skip_ansible_lint
+    - name: Add mgr auth for client.raxmon
+      command: ceph auth caps client.raxmon mon 'allow r' mgr 'allow *'
       tags:
         - skip_ansible_lint
     - name: Set the raxmon_client facts

--- a/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
@@ -17,22 +17,12 @@ details     :
     file    : run_plugin_in_venv.sh
     args    : {{ ceph_args }}
 alarms      :
-    mon_health_err :
-        label                   : mon_health_err--{{ inventory_hostname }}
+    mon_in_err :
+        label                   : mon_in_err--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('mon_health_err--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('mon_in_err--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (metric["mon_health"] == 0) {
+            if (metric["mon_in_quorum"] == 0) {
                 return new AlarmStatus(CRITICAL, "Ceph mon error.");
-            }
-
-    mon_health_warn :
-        label                   : mon_health_warn--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('mon_health_err--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
-        criteria                : |
-            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (metric["mon_health"] == 1) {
-                return new AlarmStatus(CRITICAL, "Ceph mon warning.");
             }


### PR DESCRIPTION
In order to support luminous, we need to allow access to client.raxmon
for the mgr service (which is required to perform the ceph commands we
run in the script).

Additionally - the health_services stanza from ceph status has been
removed.
https://www.spinics.net/lists/ceph-devel/msg37767.html
This was not a useful measurement and was removed. This patch removes
that check/metric and adjusts the check to use the "mon_in" metric which
will calculate if the mon is in and up.