### PR TITLE
RE-1082 Ensure pyyaml is installed in MaaS venv

### DIFF
--- a/playbooks/vars/maas-agent.yml
+++ b/playbooks/vars/maas-agent.yml
@@ -28,7 +28,6 @@ maas_pip_packages:
   - psutil
   - rackspace-monitoring-cli
   - requests
-  - waxeye
 
 ## PIP for maas
 # Path to pip download/installation script.

--- a/playbooks/vars/maas-verify.yml
+++ b/playbooks/vars/maas-verify.yml
@@ -18,3 +18,7 @@
 #
 maas_verify_pip_packages:
   - futures
+  - pyyaml
+  - rackspace-monitoring-cli
+  - requests
+  - waxeye


### PR DESCRIPTION
This is required for rpc-maas-tool, which is used by maas-verify to
check that MaaS functioning correctly.