### PR TITLE
Add customization to private_lb_api_check templates

### DIFF
--- a/playbooks/templates/rax-maas/private_lb_api_check_cinder.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_cinder.yaml.j2
@@ -4,11 +4,11 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['cinder_api'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
-target_hostname   : "{{ internal_vip_address }}"
+target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8776"
+    url           : "{{ maas_cinder_scheme | default(maas_scheme) }}://{{ maas_external_hostname }}:8776"
 monitoring_zones_poll:
   - "{{ maas_private_monitoring_zone }}"
 alarms            :

--- a/playbooks/templates/rax-maas/private_lb_api_check_glance.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_glance.yaml.j2
@@ -4,11 +4,11 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['glance_api'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
-target_hostname   : "{{ internal_vip_address }}"
+target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:9292"
+    url           : "{{ maas_glance_scheme | default(maas_scheme) }}://{{ maas_external_hostname }}:9292"
 monitoring_zones_poll:
   - "{{ maas_private_monitoring_zone }}"
 alarms            :

--- a/playbooks/templates/rax-maas/private_lb_api_check_heat_api.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_heat_api.yaml.j2
@@ -4,11 +4,11 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['heat_api'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
-target_hostname   : "{{ internal_vip_address }}"
+target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8004"
+    url           : "{{ maas_heat_api_scheme | default(maas_scheme) }}://{{ maas_external_hostname }}:8004"
 monitoring_zones_poll:
   - "{{ maas_private_monitoring_zone }}"
 alarms            :

--- a/playbooks/templates/rax-maas/private_lb_api_check_heat_cfn.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_heat_cfn.yaml.j2
@@ -4,11 +4,11 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['heat_api_cfn'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
-target_hostname   : "{{ internal_vip_address }}"
+target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8000"
+    url           : "{{ maas_heat_cfn_scheme | default(maas_scheme) }}://{{ maas_external_hostname }}:8000"
 monitoring_zones_poll:
   - "{{ maas_private_monitoring_zone }}"
 alarms            :

--- a/playbooks/templates/rax-maas/private_lb_api_check_heat_cloudwatch.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_heat_cloudwatch.yaml.j2
@@ -4,11 +4,11 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['heat_api_cloudwatch'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
-target_hostname   : "{{ internal_vip_address }}"
+target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8003"
+    url           : "{{ maas_heat_cloudwatch_scheme | default(maas_scheme) }}://{{ maas_external_hostname }}:8003"
 monitoring_zones_poll:
   - "{{ maas_private_monitoring_zone }}"
 alarms            :

--- a/playbooks/templates/rax-maas/private_lb_api_check_horizon.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_horizon.yaml.j2
@@ -4,11 +4,11 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['horizon'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
-target_hostname   : "{{ internal_vip_address }}"
+target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_horizon_scheme | default(maas_scheme)}}://{{ internal_vip_address }}:443/auth/login/"
+    url           : "{{ maas_horizon_scheme | default(maas_scheme) }}://{{ maas_external_hostname }}:443/auth/login/"
 monitoring_zones_poll:
   - "{{ maas_private_monitoring_zone }}"
 alarms            :

--- a/playbooks/templates/rax-maas/private_lb_api_check_ironic_api.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_ironic_api.yaml.j2
@@ -6,9 +6,9 @@ period            : "{{ maas_check_period_override[label] | default(maas_check_p
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
 disabled          : "{{ (inventory_hostname != groups['ironic_api'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
-target_hostname   : "{{ internal_vip_address }}"
+target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:6385"
+    url           : "{{ maas_ironic_api_scheme | default(maas_scheme) }}://{{ maas_external_hostname }}:6385"
 monitoring_zones_poll:
   - "{{ maas_private_monitoring_zone }}"
 alarms            :

--- a/playbooks/templates/rax-maas/private_lb_api_check_keystone.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_keystone.yaml.j2
@@ -4,11 +4,11 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['keystone_all'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
-target_hostname   : "{{ internal_vip_address }}"
+target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:5000"
+    url           : "{{ maas_keystone_scheme | default(maas_scheme) }}://{{ maas_external_hostname }}:5000"
 monitoring_zones_poll:
   - "{{ maas_private_monitoring_zone }}"
 alarms            :

--- a/playbooks/templates/rax-maas/private_lb_api_check_neutron.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_neutron.yaml.j2
@@ -4,11 +4,11 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['neutron_server'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
-target_hostname   : "{{ internal_vip_address }}"
+target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:9696/"
+    url           : "{{ maas_neutron_scheme | default(maas_scheme) }}://{{ maas_external_hostname }}:9696/"
 monitoring_zones_poll:
   - "{{ maas_private_monitoring_zone }}"
 alarms            :

--- a/playbooks/templates/rax-maas/private_lb_api_check_nova.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_nova.yaml.j2
@@ -4,11 +4,11 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['nova_api_os_compute'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
-target_hostname   : "{{ internal_vip_address }}"
+target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8774"
+    url           : "{{ maas_nova_scheme | default(maas_scheme) }}://{{ maas_external_hostname }}:8774"
 monitoring_zones_poll:
   - "{{ maas_private_monitoring_zone }}"
 alarms            :

--- a/playbooks/templates/rax-maas/private_lb_api_check_octavia.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_octavia.yaml.j2
@@ -4,11 +4,11 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['octavia-api'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
-target_hostname   : "{{ internal_vip_address }}"
+target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:9876/"
+    url           : "{{ maas_octavia_scheme | default(maas_scheme) }}://{{ maas_external_hostname }}:9876/"
 monitoring_zones_poll:
   - "{{ maas_private_monitoring_zone }}"
 alarms            :
@@ -20,5 +20,4 @@ alarms            :
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric['code'] != '200') {
                 return new AlarmStatus(CRITICAL, 'API unavailable.');
-            }
             }

--- a/playbooks/templates/rax-maas/private_lb_api_check_swift_access.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_swift_access.yaml.j2
@@ -4,11 +4,11 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['swift_proxy'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
-target_hostname   : "{{ internal_vip_address }}"
+target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8080/v1/{{ hostvars[groups['swift_proxy'][0]]['maas_swift_access_url_key'] }}/{{ maas_swift_accesscheck_container }}/index.html"
+    url           : "{{ maas_swift_proxy_scheme | default(maas_scheme)}}://{{ maas_external_hostname }}:8080/v1/{{ hostvars[groups['swift_proxy'][0]]['maas_swift_access_url_key'] }}/{{ maas_swift_accesscheck_container }}/index.html"
 monitoring_zones_poll:
   - "{{ maas_private_monitoring_zone }}"
 alarms            :

--- a/playbooks/templates/rax-maas/private_lb_api_check_swift_healthcheck.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_swift_healthcheck.yaml.j2
@@ -4,11 +4,11 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['swift_proxy'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
-target_hostname   : "{{ internal_vip_address }}"
+target_hostname   : "{{ maas_external_ip_address }}"
 details           :
-    url           : "{{ maas_scheme }}://{{ internal_vip_address }}:8080/healthcheck"
+    url           : "{{ maas_swift_proxy_scheme | default(maas_scheme) }}://{{ maas_external_hostname }}:8080/healthcheck"
 monitoring_zones_poll:
   - "{{ maas_private_monitoring_zone }}"
 alarms            :

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -27,6 +27,7 @@ maas_horizon_scheme: https
 # maas_heat_cloudwatch_scheme: https
 # maas_ironic_api_scheme: https
 # maas_maas_swift_proxy_scheme: https
+# maas_octavia_scheme: https
 
 #
 # pip installable packages for given services used within maas


### PR DESCRIPTION
Ensure `private_lb_api_checks` are enabled on a single node and allow a custom scheme/IP/url to be used instead of being hardcoded to `http://{{ internal_vip_address }}`.