### PR TITLE
RE-1127 Revert "RE-645 use ansible_hostname..."

### DIFF
--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -59,7 +59,7 @@ maas_fqdn_extension: ""
 # The entity name is the inventory hostname and fqdn extension combined.
 #
 # Set the hostname for use with the api checks
-maas_entity_name: "{{ ansible_hostname }}{{ maas_fqdn_extension }}"
+maas_entity_name: "{{ inventory_hostname }}{{ maas_fqdn_extension }}"
 
 #
 # Plugin directory when all agent plugins will be installed.


### PR DESCRIPTION
This reverts commit 25f4a298cb67184026d8e1ef289f07cd19ef8fd6.

Reverted because it breaks support's workflow.

![](https://imgs.xkcd.com/comics/workflow.png)
