### PR TITLE
Include packages required for pip cryptography==1.5 on non-OSA builds

### DIFF
--- a/playbooks/vars/maas-ubuntu.yml
+++ b/playbooks/vars/maas-ubuntu.yml
@@ -30,6 +30,8 @@ maas_distro_packages:
   - libxslt-dev
   - sysstat
   - rackspace-monitoring-agent
+  - python-dev
+  - gcc
 
 maas_galera_distro_packages:
   - mariadb-client


### PR DESCRIPTION
This includes the addition of `gcc` and `python-dev` which are minimally required to compile `pip cryptography` on non-OSA servers.