### PR TITLE
Add missing private ssl certificate expiry check

### DIFF
--- a/playbooks/maas-openstack-horizon.yml
+++ b/playbooks/maas-openstack-horizon.yml
@@ -84,6 +84,21 @@
       notify:
         - Restart rax-maas
 
+    - name: Install private lb-ssl check
+      template:
+        src: "templates/rax-maas/private_lb_ssl_cert_expiry_check.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_ssl_cert_expiry_check.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_ssl_check | bool
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
+      notify:
+        - Restart rax-maas
+
   handlers:
     - include: handlers/main.yml
   vars_files:

--- a/playbooks/templates/rax-maas/private_lb_ssl_cert_expiry_check.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_ssl_cert_expiry_check.yaml.j2
@@ -1,0 +1,26 @@
+{% set label = "private_lb_ssl_cert_expiry_check" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (inventory_hostname != groups['horizon'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ maas_external_ip_address }}"
+details           :
+    url           : "https://{{ maas_external_hostname }}:443/auth/login/"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_ssl_alarm_cert_expiry:
+        label               : private_lb_ssl_alarm_cert_expiry
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_ssl_alarm_cert_expiry' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            if (metric['cert_end_in'] < 604800) {
+                return new AlarmStatus(CRITICAL, 'Cert expiring in less than 7 days.');
+            }
+            if (metric['cert_end_in'] < 2628288) {
+                return new AlarmStatus(WARNING, 'Cert expiring in less than 30 days.');
+            }
+            return new AlarmStatus(OK, 'HTTP certificate does not expire soon.');


### PR DESCRIPTION
This check is missing when deploying private network monitoring against a url.