### PR TITLE
Adding nf_conntrack monitoring for neutron agent container

### DIFF
--- a/playbooks/maas-container-all.yml
+++ b/playbooks/maas-container-all.yml
@@ -16,3 +16,7 @@
 - include: maas-container-storage.yml
   tags:
     - maas-container
+
+- include: maas-container-conntrack.yml
+  tags:
+    - maas-container

--- a/playbooks/maas-container-conntrack.yml
+++ b/playbooks/maas-container-conntrack.yml
@@ -1,0 +1,72 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Gather facts
+  hosts: neutron_agent
+  gather_facts: "{{ gather_facts | default(true) }}"
+  pre_tasks:
+    - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: neutron_agent
+
+  tasks:
+    - name: Copy over pip constraints
+      copy:
+        src: "files/pip-constraints.txt"
+        dest: "/tmp/pip-constraints.txt"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+  post_tasks:
+    - name: Install container pip packages to venv
+      pip:
+        name: "{{ maas_container_pip_packages | join(' ') }}"
+        state: "{{ maas_pip_package_state }}"
+        extra_args: >-
+          --isolated
+          --constraint /tmp/pip-constraints.txt
+          {{ pip_install_options | default('') }}
+        virtualenv: "{{ maas_venv }}"
+      register: install_pip_packages
+      until: install_pip_packages|success
+      retries: 5
+      delay: 2
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas-container.yml
+  tags:
+    - maas-container-conntrack
+
+- name: Install checks for container conntrack monitoring
+  hosts: neutron_agent
+  gather_facts: false
+  tasks:
+    - name: Install conntrack count checks
+      template:
+        src: "templates/rax-maas/conntrack_count.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/conntrack_count--{{ inventory_hostname }}.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas-host.yml
+    - vars/maas-container.yml
+  tags:
+    - maas-container-container

--- a/playbooks/templates/rax-maas/conntrack_count.yaml.j2
+++ b/playbooks/templates/rax-maas/conntrack_count.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/conntrack_count.py"]
+    args    : ["{{ maas_plugin_dir }}/conntrack_count.py"{% if inventory_hostname in groups['neutron_agents_container'] | default([]) %}, "--container", "{{ inventory_hostname }}" {% endif %}]
 alarms      :
     conntrack_count_status :
         label                   : conntrack_count_status--{{ inventory_hostname }}


### PR DESCRIPTION
Netfilter connection tracking is separately configured per LXC container,
in addition to the netfilter settings of the host OS.
The current MAAS check is changed to add the capability to query
connection tracking statistics from inside the LXC container.

Closes-Bug: TURTLES-289