### PR TITLE
Limit agent restarts preventing pollers from going out of sync

### DIFF
--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -16,7 +16,7 @@
 - name: Restart MaaS
   hosts: "{{ maas_restart_on_host_override | default('maas_restart_on_host') }}"
   gather_facts: false
-  serial: 1
+  serial: "{{ maas_restart_serial | default(1) }}"
   tasks:
     - name: Restart rackspace-monitoring-poller (systemd)
       service:

--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -16,6 +16,7 @@
 - name: Restart MaaS
   hosts: "{{ maas_restart_on_host_override | default('maas_restart_on_host') }}"
   gather_facts: false
+  serial: 1
   tasks:
     - name: Restart rackspace-monitoring-poller (systemd)
       service:


### PR DESCRIPTION
This is a temporary workaround to prevent rackspace-monitoring-poller from going out of sync in large environments when the playbooks are ran with a high number of forks. This prevents the need to reach out to the monitoring devs to force a re-sync of the private zone. This has been tested in multiple 200+ node environments and successfully allows all checks to register as intended.