### PR TITLE
Turtles-317:  Add ceph_standalone override options

### DIFF
--- a/playbooks/maas-host-private-checks.yml
+++ b/playbooks/maas-host-private-checks.yml
@@ -33,6 +33,7 @@
       when:
         - maas_private_monitoring_enabled | bool
         - maas_private_monitoring_zone is defined
+        - not (ceph_standalone and inventory_hostname in groups['ceph_all'])
       template:
         src: "templates/rax-maas/{{ item.name }}.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/{{ item.name }}.yaml"

--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -29,7 +29,14 @@
       delay: 2
       when:
         - maas_private_monitoring_enabled | bool
+<<<<<<< Upstream, based on branch 'master' of https://github.com/rcbops/rpc-maas.git
         - physical_host in groups['shared-infra_hosts']
+=======
+        - ceph_standalone or 
+          physical_host in groups['shared-infra_hosts']
+        - maas_restart_independent | default(true) | bool or
+          maas_force_restart | default(false) | bool
+>>>>>>> c93a06e Turtles-317:  Add ceph_standalone override options
         - ansible_distribution_version == "16.04"
 
     - name: Restart rackspace-monitoring-poller (upstart)
@@ -43,7 +50,14 @@
       delay: 2
       when:
         - maas_private_monitoring_enabled | bool
+<<<<<<< Upstream, based on branch 'master' of https://github.com/rcbops/rpc-maas.git
         - physical_host in groups['shared-infra_hosts']
+=======
+        - ceph_standalone or 
+          physical_host in groups['shared-infra_hosts']
+        - maas_restart_independent | default(true) | bool or
+          maas_force_restart | default(false) | bool
+>>>>>>> c93a06e Turtles-317:  Add ceph_standalone override options
         - ansible_distribution_version == "14.04"
 
     - name: Restart rackspace-monitoring-agent

--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -29,14 +29,7 @@
       delay: 2
       when:
         - maas_private_monitoring_enabled | bool
-<<<<<<< Upstream, based on branch 'master' of https://github.com/rcbops/rpc-maas.git
         - physical_host in groups['shared-infra_hosts']
-=======
-        - ceph_standalone or 
-          physical_host in groups['shared-infra_hosts']
-        - maas_restart_independent | default(true) | bool or
-          maas_force_restart | default(false) | bool
->>>>>>> c93a06e Turtles-317:  Add ceph_standalone override options
         - ansible_distribution_version == "16.04"
 
     - name: Restart rackspace-monitoring-poller (upstart)
@@ -50,14 +43,7 @@
       delay: 2
       when:
         - maas_private_monitoring_enabled | bool
-<<<<<<< Upstream, based on branch 'master' of https://github.com/rcbops/rpc-maas.git
         - physical_host in groups['shared-infra_hosts']
-=======
-        - ceph_standalone or 
-          physical_host in groups['shared-infra_hosts']
-        - maas_restart_independent | default(true) | bool or
-          maas_force_restart | default(false) | bool
->>>>>>> c93a06e Turtles-317:  Add ceph_standalone override options
         - ansible_distribution_version == "14.04"
 
     - name: Restart rackspace-monitoring-agent

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -391,3 +391,7 @@ glance_local_api_port: '9292'
 #
 glance_local_api_protocol: 'http'
 
+# 
+# ceph_standalone: whether it is deployed in a ceph_standalone environment
+#
+ceph_standalone: false


### PR DESCRIPTION
1. Add ceph_standalone variable, defaults to False.
2. Only deploy private network checks to non ceph_nodes when in Ceph
standalone.