### PR TITLE
Fix conntrack_count check

### DIFF
--- a/playbooks/maas-host-kernel.yml
+++ b/playbooks/maas-host-kernel.yml
@@ -27,6 +27,12 @@
 - name: Install checks for hosts kernel
   hosts: hosts
   gather_facts: false
+  pre_tasks:
+    - name: Check nf_conntrack status
+      stat:
+        path: "/proc/sys/net/nf_conntrack_max"
+      register: nf_conntrack
+
   tasks:
     - name: Install local checks
       template:
@@ -35,6 +41,13 @@
         owner: "root"
         group: "root"
         mode: "0644"
+      when: nf_conntrack.stat.exists |bool
+
+    - name: Remove conntrack count checks if not needed
+      file:
+        path: "/etc/rackspace-monitoring-agent.conf.d/conntrack_count--{{ inventory_hostname }}.yaml"
+        state: "absent"
+      when: not nf_conntrack.stat.exists |bool
 
   vars_files:
     - vars/main.yml

--- a/playbooks/maas-host-network.yml
+++ b/playbooks/maas-host-network.yml
@@ -47,14 +47,6 @@
       with_together:
         - "{{ maas_network_checks_list }}"
 
-    - name: Install conntrack count checks
-      template:
-        src: "templates/rax-maas/conntrack_count.yaml.j2"
-        dest: "/etc/rackspace-monitoring-agent.conf.d/conntrack_count--{{ inventory_hostname }}.yaml"
-        owner: "root"
-        group: "root"
-        mode: "0644"
-
   vars_files:
     - vars/main.yml
     - vars/maas-host.yml


### PR DESCRIPTION
The conntrack_count check is only installed onto hosts
having nf_conntrack module installed and loaded.

Closes-Bug: RO-3009