### PR TITLE
Add maas_rally performance monitoring

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -191,6 +191,40 @@ run. The variable required to be set is ``maas_rabbitmq_password``.
     ansible-playbook -e @/etc/openstack_deploy/user_secrets.yml /opt/rpc-maas/playbooks/maas-openstack-keystone.yml -i inventory
 
 
+maas-openstack-rally.yml
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``maas-openstack-rally.yml`` playbook deploys rally-based performance
+monitoring and requires the following variables:
+
+- ``maas_rally_enabled`` - must be set to ``true`` to enable performance
+  monitoring.
+
+- ``maas_rally_check_overrides`` - must be configured with appropriate values
+  for the environment's size and usage.  Full documentation and examples are
+  maintained in ``playbooks/vars/maas_rally.yml``.
+
+The following secrets are also required:
+
+- ``maas_rally_galera_password`` - A database user (``maas_rally`` by default)
+  will be created for accessing Rally data.  This value will be used for the
+  database user's password.
+
+- ``maas_rally_users_password`` - Each performance scenario will have a
+  keystone user created to isolate resources.  This value will be used for the
+  users' passwords. See ``playbooks/vars/maas_rally.yml`` for guidance on using
+  different passwords for each scenario's user.
+
+.. code-block:: bash
+
+    # Variable file set
+    echo 'maas_rally_galera_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
+    echo 'maas_rally_users_password: secrete' | tee -a /etc/openstack_deploy/user_secrets.yml
+
+    # Example playbook run with variable file.
+    ansible-playbook -e @/etc/openstack_deploy/user_secrets.yml /opt/rpc-maas/playbooks/maas-openstack-rally.yml -i inventory
+
+
 maas-openstack-swift.yml
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/playbooks/common-tasks/mysql-db-user.yml
+++ b/playbooks/common-tasks/mysql-db-user.yml
@@ -1,0 +1,40 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Create DB for service
+  mysql_db:
+    login_user: "{{ galera_root_user }}"
+    login_password: "{{ galera_root_password }}"
+    login_host: "{{ login_host }}"
+    name: "{{ db_name }}"
+    state: "present"
+  delegate_to: "{{ groups['galera_all'][0] }}"
+  tags:
+    - common-mysql
+
+- name: Grant access to the DB for the service
+  mysql_user:
+    login_user: "{{ galera_root_user }}"
+    login_password: "{{ galera_root_password }}"
+    login_host: "{{ login_host }}"
+    name: "{{ user_name }}"
+    password: "{{ password }}"
+    host: "{{ item }}"
+    state: "present"
+    priv: "{{ db_name }}.*:ALL"
+  delegate_to: "{{ groups['galera_all'][0] }}"
+  with_items: "{{ grant_list | default(['localhost', '%']) }}"
+  tags:
+    - common-mysql

--- a/playbooks/files/rax-maas/plugins/rally_performance.py
+++ b/playbooks/files/rax-maas/plugins/rally_performance.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import numpy as np
+import os
+import time
+import yaml
+
+import maas_common
+from maas_common import status_err, status_ok, metric
+
+import rally
+from rally.api import API
+
+PLUGIN_PATH = '/usr/lib/rackspace-monitoring-agent/plugins/rally/plugins/'
+TASKS_PATH = '/usr/lib/rackspace-monitoring-agent/plugins/rally/tasks/'
+LOCKS_PATH = '/var/lock/maas_rally'
+
+
+class ParseError(maas_common.MaaSException):
+    pass
+
+
+class CommandNotRecognized(maas_common.MaaSException):
+    pass
+
+
+def make_parser():
+    parser = argparse.ArgumentParser(
+        description='Execute rally performance scenario and print the results'
+    )
+    parser.add_argument('task',
+                        help='Which task definition to execute.  The task '
+                             'definition must exist in {{ maas_plugin_dir }}/ '
+                             'tasks/<TASKNAME>.yml. \n'
+                             'Examples: "keystone", "nova", etc.')
+    parser.add_argument('-c', '--concurrency',
+                        type=int,
+                        help='Number of tasks to run in parallel')
+    parser.add_argument('-e', '--extra_vars',
+                        action='append',
+                        help='Extra variable to pass to the Rally task in key='
+                             'value format.  May be specified multiple times. '
+                             'Example: "-e size=2 -e image_name=\'^cirros$\'"')
+    parser.add_argument('-t', '--times',
+                        type=int,
+                        help='Number of times to execute the task')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    return parser
+
+
+def parse_task_results(task_result):
+    # This expects the format returned by `rally task results <UUID>`
+    action_data = {}
+    action_data[args.task + '_total'] = list()
+    for iteration in task_result['result']:
+        iteration_total_duration = 0
+        for action in iteration['atomic_actions'].keys():
+            action_duration = iteration['atomic_actions'][action]
+            iteration_total_duration += action_duration
+            if action not in action_data:
+                action_data[action] = list()
+            action_data[action].append(action_duration)
+        action_data[args.task + '_total'].append(iteration_total_duration)
+
+    # Quota exceeded would be a typical error here
+    if task_result['result'][0]['error']:
+        status_err(' '.join(task_result['result'][0]['error']),
+                   m_name='maas_rally')
+
+    status_ok(m_name='maas_rally')
+
+    metric('rally_load_duration', 'double',
+           '{:.2f}'.format(task_result['load_duration']))
+    metric('rally_full_duration', 'double',
+           '{:.2f}'.format(task_result['full_duration']))
+
+    metric('rally_sample_count', 'uint32',
+           '{}'.format(task_result['key']['kw']['runner']['times']))
+    metric('rally_sample_concurrency', 'uint32',
+           '{}'.format(task_result['key']['kw']['runner']['concurrency']))
+
+    for action in action_data.keys():
+        metric('{}_min'.format(action), 'double',
+               '{:.2f}'.format(np.amin(action_data[action])))
+        metric('{}_max'.format(action), 'double',
+               '{:.2f}'.format(np.amax(action_data[action])))
+        metric('{}_median'.format(action), 'double',
+               '{:.2f}'.format(np.median(action_data[action])))
+        metric('{}_mean'.format(action), 'double',
+               '{:.2f}'.format(np.mean(action_data[action])))
+
+        metric('{}_90pctl'.format(action), 'double',
+               '{:.2f}'.format(np.percentile(action_data[action], 90)))
+        metric('{}_95pctl'.format(action), 'double',
+               '{:.2f}'.format(np.percentile(action_data[action], 95)))
+
+
+def main():
+    start = time.time()
+
+    # Ensure we can find the task definition
+    tasks_path = os.path.realpath(TASKS_PATH)
+    task_file = tasks_path + '/' + args.task + '.yml'
+    if not os.path.isfile(task_file):
+        status_err('Unable to locate task definition '
+                   'for {} in {}'.format(args.task, tasks_path),
+                   m_name='maas_rally')
+
+    if not os.path.exists(LOCKS_PATH):
+        os.makedirs(LOCKS_PATH)
+
+    rapi = API()
+
+    task_obj = rapi.task.create(args.task, [args.task])
+    task_uuid = task_obj['uuid']
+
+    LOCK_PATH = LOCKS_PATH + '/' + args.task + '/'
+    if os.path.exists(LOCK_PATH):
+        lock_uuid = os.listdir(LOCK_PATH)[0]
+        lock_mtime = os.stat(LOCK_PATH + lock_uuid)[8]
+        lock_duration = time.time() - lock_mtime
+        try:
+            task_status = rapi.task.get(lock_uuid)['status']
+            if task_status == 'finished':
+                os.rmdir(LOCK_PATH + '/' + lock_uuid)
+            elif task_status == 'init' and lock_duration > 30:
+                os.rmdir(LOCK_PATH + '/' + lock_uuid)
+            else:
+                lock_mtime_str = time.strftime('%H:%M:%S %Y-%m-%d %Z',
+                                               time.localtime(lock_mtime))
+                status_err("Unable to get lock for {} - locked by "
+                           "task {} at {}.".format(args.task,
+                                                   lock_uuid,
+                                                   lock_mtime_str),
+                           m_name='maas_rally')
+        except rally.exceptions.TaskNotFound:
+            os.rmdir(LOCK_PATH + '/' + lock_uuid)
+    else:
+        os.mkdir(LOCK_PATH)
+
+    os.mkdir(LOCK_PATH + '/' + task_uuid)
+
+    task_args = {}
+    if args.times is not None:
+        task_args['times'] = args.times
+    if args.concurrency is not None:
+        task_args['concurrency'] = args.concurrency
+    if args.extra_vars is not None:
+        for extra_var in args.extra_vars:
+            k, v = extra_var.lstrip().split('=')
+            task_args.update({k: v})
+
+    with open(task_file) as f:
+            input_task = f.read()
+            task_dir = os.path.expanduser(
+                os.path.dirname(task_file)) or "./"
+            rendered_task = rapi.task.render_template(input_task,
+                                                      task_dir,
+                                                      **task_args)
+
+    parsed_task = yaml.safe_load(rendered_task)
+
+    rally.common.plugin.discover.load_plugins(PLUGIN_PATH)
+    rally.plugins.load()
+    rapi.task.start(args.task, parsed_task, task_obj)
+
+    # This is the format returned by `rally task results <UUID>`
+    results = [{"key": x["key"], "result": x["data"]["raw"],
+                "sla": x["data"]["sla"],
+                "hooks": x["data"].get("hooks", []),
+                "load_duration": x["data"]["load_duration"],
+                "full_duration": x["data"]["full_duration"],
+                "created_at": x.get("created_at").strftime(
+                    "%Y-%d-%mT%H:%M:%S")}
+               for x in task_obj.get_results()][0]
+
+    parse_task_results(results)
+
+    os.rmdir(LOCK_PATH + '/' + task_uuid)
+    os.rmdir(LOCK_PATH)
+
+    end = time.time()
+    metric('maas_check_duration', 'double', "{:.2f}".format((end - start) * 1))
+
+    return
+
+
+if __name__ == '__main__':
+    parser = make_parser()
+    args = parser.parse_args()
+    with maas_common.print_output(print_telegraf=args.telegraf_output):
+        main()

--- a/playbooks/files/rax-maas/rally/plugins/neutron_secgroup_create_update_delete.py
+++ b/playbooks/files/rax-maas/rally/plugins/neutron_secgroup_create_update_delete.py
@@ -1,0 +1,31 @@
+from rally import consts
+from rally.plugins.openstack import scenario
+from rally.plugins.openstack.scenarios.neutron import utils
+from rally.task import validation
+
+@validation.required_services(consts.Service.NEUTRON)
+@validation.required_openstack(users=True)
+@scenario.configure(context={"cleanup": ["neutron"]},
+                    name=("NeutronSecurityGroup"
+                          ".create_update_and_delete_security_groups"))
+class CreateUpdateAndDeleteSecurityGroups(utils.NeutronScenario):
+
+    def run(self, security_group_create_args=None,
+            security_group_update_args=None):
+        """Create and update Neutron security-groups.
+
+        Measure the "neutron security-group-create" and "neutron
+        security-group-update" command performance.
+
+        :param security_group_create_args: dict, POST /v2.0/security-groups
+                                           request options
+        :param security_group_update_args: dict, PUT /v2.0/security-groups
+                                           update options
+        """
+        security_group_create_args = security_group_create_args or {}
+        security_group_update_args = security_group_update_args or {}
+        security_group = self._create_security_group(
+            **security_group_create_args)
+        self._update_security_group(security_group,
+                                    **security_group_update_args)
+        self._delete_security_group(security_group)

--- a/playbooks/files/rax-maas/rally/plugins/swift_customer_container_object_scenario.py
+++ b/playbooks/files/rax-maas/rally/plugins/swift_customer_container_object_scenario.py
@@ -1,0 +1,31 @@
+import tempfile
+
+from rally import consts
+from rally.plugins.openstack import scenario
+from rally.plugins.openstack.scenarios.swift import utils
+from rally.task import atomic
+from rally.task import validation
+
+
+"""Scenarios for Swift Objects."""
+
+
+@validation.required_services(consts.Service.SWIFT)
+@validation.required_openstack(users=True)
+@scenario.configure(context={"cleanup": ["swift"]},
+                    name="SwiftObjects.create_c_and_o"
+                         "_then_download_and_delete_all")
+class CreateContainerAndObjectThenDownloadAndDeleteAll(utils.SwiftScenario):
+
+    def run(self, object_size=1024, **kwargs):
+        container_name = None
+        container_name = self._create_container(**kwargs)
+
+        with tempfile.TemporaryFile() as dummy_file:
+            dummy_file.truncate(object_size)
+            dummy_file.seek(0)
+            object_name = self._upload_object(container_name, dummy_file)[1]
+
+        self._download_object(container_name, object_name)
+        self._delete_object(container_name, object_name)
+        self._delete_container(container_name)

--- a/playbooks/files/rax-maas/rally/tasks/cinder.yml
+++ b/playbooks/files/rax-maas/rally/tasks/cinder.yml
@@ -1,0 +1,22 @@
+{% set size = size or 1 %}
+{% set image_name = image_name or "^rally_cirros$" %}
+{% set flavor_name = flavor_name or "rally" %}
+{% set times = times or 1 %}
+{% set concurrency = concurrency or 1 %}
+{% set net_id = net_id %}
+
+  CinderVolumes.create_and_attach_volume:
+    -
+      args:
+          size: {{ size }}
+          image:
+            name: "{{ image_name }}"
+          flavor:
+            name: "{{ flavor_name }}"
+          nics:
+            - net-id: "{{ net_id }}"
+      runner:
+        type: "constant"
+        times: {{ times }}
+        concurrency: {{ concurrency }}
+      context: {}

--- a/playbooks/files/rax-maas/rally/tasks/glance.yml
+++ b/playbooks/files/rax-maas/rally/tasks/glance.yml
@@ -1,0 +1,16 @@
+{% set image_location = image_location or "/usr/lib/rackspace-monitoring-agent/plugins/rally/cirros-0.3.5-x86_64-disk.img" %}
+{% set times = times or 1 %}
+{% set concurrency = concurrency or 1 %}
+
+
+GlanceImages.create_and_delete_image:
+  -
+    args:
+      image_location: "{{ image_location }}"
+      container_format: "bare"
+      disk_format: "qcow2"
+    runner:
+      type: "constant"
+      times: {{ times }}
+      concurrency: {{ concurrency }}
+    context: {}

--- a/playbooks/files/rax-maas/rally/tasks/keystone.yml
+++ b/playbooks/files/rax-maas/rally/tasks/keystone.yml
@@ -1,0 +1,11 @@
+{% set times = times or 1 %}
+{% set concurrency = concurrency or 1 %}
+
+
+KeystoneBasic.authenticate_user_and_validate_token:
+  -
+    args: {}
+    runner:
+      type: "constant"
+      times: {{ times }}
+      concurrency: {{ concurrency }}

--- a/playbooks/files/rax-maas/rally/tasks/neutron_ports.yml
+++ b/playbooks/files/rax-maas/rally/tasks/neutron_ports.yml
@@ -1,0 +1,15 @@
+{% set times = times or 1 %}
+{% set concurrency = concurrency or 1 %}
+
+
+NeutronNetworks.create_and_delete_ports:
+  -
+    args:
+      network_create_args: {}
+      port_create_args: {}
+      ports_per_network: 1
+    runner:
+      type: "constant"
+      times: {{ times }}
+      concurrency: {{ concurrency }}
+    context: {}

--- a/playbooks/files/rax-maas/rally/tasks/neutron_secgroups.yml
+++ b/playbooks/files/rax-maas/rally/tasks/neutron_secgroups.yml
@@ -1,0 +1,14 @@
+{% set times = times or 1 %}
+{% set concurrency = concurrency or 1 %}
+
+
+  NeutronSecurityGroup.create_update_and_delete_security_groups:
+    -
+      args:
+        security_group_create_args: {}
+        security_group_update_args: {}
+      runner:
+        type: "constant"
+        times: {{ times }}
+        concurrency: {{ concurrency }}
+      context: {}

--- a/playbooks/files/rax-maas/rally/tasks/nova.yml
+++ b/playbooks/files/rax-maas/rally/tasks/nova.yml
@@ -1,0 +1,21 @@
+{% set flavor_name = flavor_name or "rally" %}
+{% set image_name = image_name or "^rally_cirros$" %}
+{% set times = times or 1 %}
+{% set concurrency = concurrency or 1 %}
+{% set net_id = net_id %}
+
+NovaServers.boot_and_delete_server:
+  -
+    args:
+      flavor:
+          name: "{{ flavor_name }}"
+      image:
+          name: "{{ image_name }}"
+      force_delete: false
+      nics:
+        - net-id: "{{ net_id }}"
+    runner:
+      type: "constant"
+      times: {{ times }}
+      concurrency: {{ concurrency }}
+    context: {}

--- a/playbooks/files/rax-maas/rally/tasks/nova_cinder.yml
+++ b/playbooks/files/rax-maas/rally/tasks/nova_cinder.yml
@@ -1,0 +1,24 @@
+{% set flavor_name = flavor_name or "rally" %}
+{% set image_name = image_name or "^rally_cirros$" %}
+{% set volume_type = volume_type or "" %}
+{% set times = times or 1 %}
+{% set concurrency = concurrency or 1 %}
+{% set net_id = net_id %}
+
+NovaServers.boot_server_from_volume_and_delete:
+  -
+    args:
+      flavor:
+          name: "{{ flavor_name }}"
+      image:
+          name: "{{ image_name }}"
+      volume_size: 10
+      volume_type: "{{ volume_type }}"
+      force_delete: false
+      nics:
+        - net-id: "{{ net_id }}"
+    runner:
+      type: "constant"
+      times: {{ times }}
+      concurrency: {{ concurrency }}
+    context: {}

--- a/playbooks/files/rax-maas/rally/tasks/swift.yml
+++ b/playbooks/files/rax-maas/rally/tasks/swift.yml
@@ -1,0 +1,13 @@
+{% set times = times or 1 %}
+{% set concurrency = concurrency or 1 %}
+
+
+  SwiftObjects.create_c_and_o_then_download_and_delete_all:
+    -
+      args:
+        object_size: 1024
+      runner:
+        type: "constant"
+        times: {{ times }}
+        concurrency: {{ concurrency }}
+      context: {}

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -1,0 +1,489 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in witing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Perform pre-flight and configuration checks
+  hosts: "{{ maas_rally_target_group }}[0]"
+  gather_facts: false
+  pre_tasks:
+    - name: Safety check - ensure maas_rally is enabled
+      fail:
+        msg: "Rally performance tests are disabled.  If you really want them please read the documentation and set maas_rally_enabled to true."
+      when: not maas_rally_enabled
+
+    - name: Generate check template dictionary
+      set_fact:
+        check_template: "{{ check_template|default({})|combine({item: maas_rally_check_default_template}) }}"
+      with_items:
+        - "{{ maas_rally_checks.keys() | list }}"
+
+    - name: Combine check template dictionary and checks variables
+      set_fact:
+        maas_rally_checks: "{{ check_template|combine(maas_rally_checks, recursive=True) }}"
+
+    - name: Generate a list of enabled checks
+      set_fact:
+        enabled_checks: "{{ enabled_checks|default([])|union([item.key]) }}"
+      with_dict: "{{ maas_rally_checks }}"
+
+    - name: Config validation - ensure concurrency <= times
+      fail:
+        msg: "Config error for {{ item }}: concurrency ({{ maas_rally_checks[item]['concurrency'] }}) must be less than or equal to times ({{ maas_rally_checks[item]['times'] }})."
+      with_items: "{{ enabled_checks }}"
+      when:
+        - not maas_rally_skip_config_validation
+        - maas_rally_checks[item]['concurrency'] > maas_rally_checks[item]['times']
+
+    - name: Config validation - ensure ( times / concurrency ) * crit_threshold < poll_interval
+      fail:
+        msg: "Config error for {{ item }}: poll_interval too short to reach crit_threshold based on times and concurrency"
+      with_items: "{{ enabled_checks }}"
+      when:
+        - not maas_rally_skip_config_validation
+        - (maas_rally_checks[item]['times']/maas_rally_checks[item]['concurrency'])*maas_rally_checks[item]['crit_threshold'] >= maas_rally_checks[item]['poll_interval']
+
+    - name: Config validation - ensure warning threshold < critical threshold
+      fail:
+        msg: "Config error for {{ item }}: warning threshold must be less than critical threshold"
+      with_items: "{{ enabled_checks }}"
+      when:
+        - not maas_rally_skip_config_validation
+        - maas_rally_checks[item]['warn_threshold'] >= maas_rally_checks[item]['crit_threshold']
+
+    - name: Config validation - ensure (1 <= duration threshold <= 100)
+      fail:
+        msg: "Config error for {{ item }}: duration threshold should be >= 1 and <= 100"
+      with_items: "{{ enabled_checks }}"
+      when:
+        - not maas_rally_skip_config_validation
+        - maas_rally_checks[item]['duration_threshold'] < 1 or maas_rally_checks[item]['duration_threshold'] > 100
+
+  vars_files:
+    - vars/maas-rally.yml
+
+
+- name: Configure maas_rally virtual environments
+  hosts: "{{ maas_rally_target_group }}"
+  gather_facts: true
+  pre_tasks:
+    - name: Install maas and maas_rally pip packages to venv
+      pip:
+        name: "{{ maas_pip_packages | union(maas_rally_pip_packages) | join(' ') }}"
+        state: "{{ maas_rally_pip_package_state }}"
+        extra_args: >-
+          --isolated
+          --constraint /tmp/pip-constraints.txt
+          {{ pip_install_options | default('') }}
+        virtualenv: "{{ maas_rally_venv }}"
+      register: install_pip_packages
+      until: install_pip_packages|success
+      retries: 5
+      delay: 2
+
+    - name: Create rally config directory
+      file:
+        name: /etc/rally
+        state: directory
+        owner: "root"
+        group: "root"
+        mode: "0750"
+
+    - name: Write rally configuration file
+      template:
+        src: "templates/rax-maas/rally.conf.j2"
+        dest: "/etc/rally/rally.conf"
+        owner: "root"
+        group: "root"
+        mode: "0600"
+
+    # Shade is required for the os_* ansible modules
+    - name: Ensure target has shade module installed
+      pip:
+        name: shade
+        state: present
+        virtualenv: /tmp/maas_rally_shade_venv
+        extra_args: >-
+          --isolated
+          {{ pip_install_options | default('') }}
+
+    - name: Ensure OpenStack client configuration directory
+      file:
+        dest: "{{ openrc_openstack_client_config_dir_dest }}"
+        owner: "{{ openrc_openstack_client_config_dir_owner }}"
+        group: "{{ openrc_openstack_client_config_dir_group }}"
+        mode: "{{ openrc_openstack_client_config_dir_mode }}"
+        state: directory
+
+    - name: Create clouds.yaml file
+      template:
+        src: templates/rax-maas/clouds.yaml.j2
+        dest: "{{ openrc_clouds_yml_file_dest }}"
+        owner: "{{ openrc_clouds_yml_file_owner }}"
+        group: "{{ openrc_clouds_yml_file_group }}"
+        mode: "{{ openrc_clouds_yml_file_mode }}"
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas-agent.yml
+    - vars/maas-rally.yml
+
+
+- name: Prepare OpenStack and DB for performance monitoring
+  hosts: "{{ maas_rally_target_group }}[0]"
+  gather_facts: false
+  pre_tasks:
+    - include: "common-tasks/maas_excluded_regex.yml"
+
+    - name: Create maas_rally database
+      include: common-tasks/mysql-db-user.yml
+      static: no
+      vars:
+        user_name: "{{ maas_rally_galera_user }}"
+        password: "{{ maas_rally_galera_password }}"
+        login_host: "{{ maas_rally_galera_address }}"
+        db_name: "{{ maas_rally_galera_database }}"
+
+    - name: Generate check template dictionary
+      set_fact:
+        check_template: "{{ check_template|default({})|combine({item: maas_rally_check_default_template}) }}"
+      with_items:
+        - "{{ maas_rally_checks.keys() | list }}"
+
+    - name: Combine check template dictionary and checks variables
+      set_fact:
+        maas_rally_checks: "{{ check_template|combine(maas_rally_checks, recursive=True) }}"
+
+    - name: Add check's name to maas_rally_checks dictionary
+      set_fact:
+        maas_rally_checks: "{{ maas_rally_checks|combine({item: {'check_name': item}}, recursive=True) }}"
+      with_items:
+        - "{{ maas_rally_checks.keys() | list }}"
+
+    - name: Create maas_rally projects
+      os_project:
+        name: "{{ item.value.project | default('rally_' + item.key) }}"
+        state: present
+        cloud: default
+        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+        domain_id: "Default"
+      with_dict: "{{ maas_rally_checks }}"
+      when:
+        - item.value.enabled
+      vars:
+        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
+      register: rally_projects
+
+# NOTE(cfarquhar): The os_quota module is new in ansible 2.3.  Use it instead
+#                  of the shell module below when we reach ansible >=2.3.
+
+#    - name: Ensure quotas for rally projects
+#      os_quota:
+#        state: present
+#        cloud: default
+#        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+#        name: "{{ item.value.project | default('rally_' + item.key) }}"
+#        instances: "{{ item.value.quotas.instances }}"
+#        cores: "{{ item.value.quotas.cores }}"
+#        ram: "{{ item.value.quotas.ram }}"
+#        fixed_ips: "{{ item.value.quotas.fixed-ips }}"
+#        floatingip: "{{ item.value.quotas.floating-ips }}"
+#        port: "{{ item.value.quotas.ports }}"
+#        snapshots: "{{ item.value.quotas.snapshots }}"
+#        volumes: "{{ item.value.quotas.volumes }}"
+#        per_volume_gigabytes: "{{ item.value.quotas.gigabytes }}"
+#      with_dict: "{{ maas_rally_checks }}"
+#      when:
+#        - item.value.quotas is defined
+
+    - name: Set quotas for maas_rally projects
+      shell: |
+        . /root/openrc
+        {{ maas_rally_venv_bin }}/openstack \
+        {% if keystone_service_adminuri_insecure %} --insecure \ {% endif %}
+        quota set \
+        {% for quota in item.value.per_iter_quotas %} \
+            --{{ quota }} \
+            {{ item.value.per_iter_quotas[quota]*item.value.concurrency }} \
+        {% endfor %} \
+        {{ item.value.project | default('rally_' + item.key) }}
+      with_dict: "{{ maas_rally_checks }}"
+      when:
+        - item.value.enabled
+
+    - name: Create maas_rally users in keystone
+      os_user:
+        name: "{{ item.value.user_name | default('rally_' + item.key) }}"
+        password: "{{ item.value.user_password }}"
+        default_project: "{{ item.value.project | default('rally_' + item.key) }}"
+        state: present
+        cloud: default
+        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+        domain: "Default"
+      with_dict: "{{ maas_rally_checks }}"
+      vars:
+        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
+      when:
+        - item.value.enabled
+
+    - name: Grant _member_ role for rally users
+      os_user_role:
+        user: "{{ item.value.user_name | default('rally_' + item.key) }}"
+        project: "{{ item.value.project | default('rally_' + item.key) }}"
+        role: "_member_"
+        state: present
+        cloud: default
+        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+      with_dict: "{{ maas_rally_checks }}"
+      vars:
+        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
+      when:
+        - item.value.enabled
+
+    - name: Grant extra roles for rally users
+      os_user_role:
+        user: "{{ item.0.user_name | default('rally_' + item.0.check_name) }}"
+        project: "{{ item.0.project | default('rally_' + item.0.check_name) }}"
+        role: "{{ item.1 }}"
+        state: present
+        cloud: default
+        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+      with_subelements:
+        - "{{ maas_rally_checks }}"
+        - extra_user_roles
+        - skip_missing: yes
+      vars:
+        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
+      when:
+        - item.0.enabled
+
+    - name: Download cirros image for rally_cirros
+      get_url:
+        url: http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img
+        dest: /tmp/cirros-0.3.5-x86_64-disk.img"
+
+    - name: Create rally_cirros image in glance
+      os_image:
+        cloud: default
+        state: present
+        name: rally_cirros
+        filename: /tmp/cirros-0.3.5-x86_64-disk.img"
+        is_public: yes
+        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+      vars:
+        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
+
+    - name: Create rally nova flavor
+      os_nova_flavor:
+        cloud: default
+        state: present
+        name: rally
+        ram: 256
+        disk: 1
+        vcpus: 1
+        is_public: true
+        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+      vars:
+        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
+
+# NOTE(cfarquhar): Unfortunately rally's validation step doesn't account for
+#                  predefined contexts (i.e. project and user) and non-public
+#                  flavors.  Once that is fixed then is_public above should
+#                  be set to false and the next two tasks should be enabled.
+
+#   - name: Check flavor access for rally users
+#     shell: |
+#       . "{{ maas_rally_venv_bin }}"/activate
+#       . /root/openrc
+#       nova flavor-access-list --flavor rally | grep rally_ | awk '{print $4}'
+#     register: flavor_access
+#     changed_when: False
+
+#    - name: Grant flavor access to maas_rally users
+#      shell: |
+#        . "{{ maas_rally_venv_bin }}"/activate
+#        . /root/openrc
+#        nova flavor-access-add rally "{{ item.value.project | default('rally_' + item.key) }}"
+#      with_dict: "{{ maas_rally_checks }}"
+#      when:
+#        - item.value.enabled
+
+    - name: Create rally networks
+      os_network:
+        cloud: default
+        state: present
+        name: "{{ item.value.net_name | default('rally_net_' + item.key) }}"
+        shared: no
+        project: "{{ item.value.project | default('rally_' + item.key) }}"
+        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+        wait: yes
+      with_dict: "{{ maas_rally_checks }}"
+      vars:
+        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
+      when:
+        - item.value.enabled
+        - item.value.creates_instances
+
+    - name: Create rally subnets
+      os_subnet:
+        cloud: default
+        state: present
+        name: "{{ item.value.subnet_name | default('rally_subnet_' + item.key) }}"
+        network_name: "{{ item.value.net_name | default('rally_net_' + item.key) }}"
+        cidr: "{{ item.value.subnet_cidr | default('192.168.0.0/24') }}"
+        project: "{{ item.value.project | default('rally_' + item.key) }}"
+        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+        wait: yes
+      with_dict: "{{ maas_rally_checks }}"
+      vars:
+        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
+      when:
+        - item.value.enabled
+        - item.value.creates_instances
+
+    - name: Check for existing maas_rally database initialization
+      command: "{{ maas_rally_venv_bin }}/rally-manage db revision"
+      register: rally_db_revision
+      changed_when: False
+
+    - name: Initialize maas_rally database
+      command: "{{ maas_rally_venv_bin }}/rally-manage db create"
+      when:
+        - "'None' in rally_db_revision.stdout"
+
+    - name: Check for existing rally deployments
+      shell: |
+        {{ maas_rally_venv_bin }}/rally deployment list | \
+        tail -n+4 | \
+        head -n-1 | \
+        awk -F'|' '{print $4}' | \
+        sed 's/ //g'
+      register: rally_deployments
+      changed_when: False
+
+    - name: Generate rally deployment definition files
+      template:
+        src: "templates/rax-maas/rally_deployment.yaml.j2"
+        dest: "/tmp/rally_{{ item.key }}_deployment.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0600"
+      with_dict: "{{ maas_rally_checks }}"
+      when:
+        - item.value.enabled
+        - item.key not in rally_deployments.stdout_lines
+
+    - name: Create rally deployments
+      command: |
+        {{ maas_rally_venv_bin }}/rally deployment create --name
+        {{ item.key }} --filename /tmp/rally_{{ item.key }}_deployment.yaml
+        --no-use
+      with_dict: "{{ maas_rally_checks }}"
+      when:
+        - item.value.enabled
+        - item.key not in rally_deployments.stdout_lines
+
+    - name: Clean up rally deployment definition files
+      file:
+        dest: "/tmp/rally_{{ item.key }}_deployment.yaml"
+        state: absent
+      with_dict: "{{ maas_rally_checks }}"
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas-agent.yml
+    - vars/maas-rally.yml
+
+
+- name: Configure performance checks
+  hosts: "{{ maas_rally_target_group }}"
+  gather_facts: false
+  pre_tasks:
+    - include: "common-tasks/maas_excluded_regex.yml"
+
+    - name: Install maas_rally venv wrapper script
+      template:
+        src: "templates/rax-maas/run_plugin_in_rally_venv.sh.j2"
+        dest: "{{ maas_plugin_dir }}/run_plugin_in_rally_venv.sh"
+        owner: "root"
+        group: "root"
+        mode: "0755"
+
+    - name: Install rally_performance plugin
+      copy:
+        src: "files/rax-maas/plugins/rally_performance.py"
+        dest: "{{ maas_plugin_dir }}/"
+
+    - name: Install custom rally plugins and tasks
+      copy:
+        src: "files/rax-maas/rally"
+        dest: "{{ maas_plugin_dir }}/"
+
+    - name: Generate check template dictionary
+      set_fact:
+        check_template: "{{ check_template|default({})|combine({item: maas_rally_check_default_template}) }}"
+      with_items:
+        - "{{ maas_rally_checks.keys() | list }}"
+
+    - name: Combine check template dictionary and checks variables
+      set_fact:
+        maas_rally_checks: "{{ check_template|combine(maas_rally_checks, recursive=True) }}"
+
+    - name: Retrieve network UUIDs
+      os_networks_facts:
+        cloud: default
+        wait: yes
+        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+      vars:
+        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
+
+    - name: Store network UUIDs in dictionary
+      set_fact:
+        network_uuids: "{{ network_uuids|default({})|combine({item.name: item.id}) }}"
+      with_items: "{{ openstack_networks }}"
+
+    - name: Add network UUIDs to checks' extra_vars
+      set_fact:
+        maas_rally_checks: "{{ maas_rally_checks|combine({item.key: {'extra_vars': {'net_id': network_uuids[item.value.net_name | default('rally_net_' + item.key)]}}}, recursive=True) }}"
+      with_dict: "{{ maas_rally_checks }}"
+      when:
+        - item.value.enabled
+        - item.value.creates_instances
+        - network_uuids["{{ item.value.net_name | default('rally_net_' + item.key) }}"] is defined
+
+    - name: Download cirros image for maas_rally
+      get_url:
+        url: http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img
+        dest: "{{ maas_plugin_dir }}/rally/cirros-0.3.5-x86_64-disk.img"
+
+    - name: Remove disabled rally performance checks
+      file:
+        dest: "/etc/rackspace-monitoring-agent.conf.d/rally_{{ item.key }}_check--{{ inventory_hostname }}.yaml"
+        state: absent
+      with_dict: "{{ maas_rally_checks }}"
+      when: not item.value.enabled
+
+    - name: Install enabled rally performance checks
+      template:
+        src: "templates/rax-maas/rally_check.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/rally_{{ item.key }}_check--{{ inventory_hostname }}.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      with_dict: "{{ maas_rally_checks }}"
+      when: item.value.enabled
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas-agent.yml
+    - vars/maas-rally.yml

--- a/playbooks/templates/rax-maas/clouds.yaml.j2
+++ b/playbooks/templates/rax-maas/clouds.yaml.j2
@@ -1,0 +1,18 @@
+# {{ ansible_managed }}
+clouds:
+  default:
+    auth:
+      auth_url: {{ openrc_os_auth_url }}
+      project_name: {{ openrc_os_tenant_name }}
+      tenant_name: {{ openrc_os_tenant_name }}
+      username: {{ openrc_os_username }}
+      password: {{ openrc_os_password }}
+      user_domain_name: {{ openrc_os_domain_name }}
+      project_domain_name: {{ openrc_os_domain_name }}
+    region_name: {{ openrc_region_name }}
+    interface: {{ openrc_clouds_yml_interface }}
+{% if openrc_os_auth_url.endswith('v2.0') %}
+    identity_api_version: "2.0"
+{% else %}
+    identity_api_version: "3"
+{% endif %}

--- a/playbooks/templates/rax-maas/rally.conf.j2
+++ b/playbooks/templates/rax-maas/rally.conf.j2
@@ -1,0 +1,694 @@
+[DEFAULT]
+# Disable stderr logging
+use_stderr = True
+
+#
+# From oslo.log
+#
+
+# If set to true, the logging level will be set to DEBUG instead of
+# the default INFO level. (boolean value)
+#debug = false
+
+# The name of a logging configuration file. This file is appended to
+# any existing logging configuration files. For details about logging
+# configuration files, see the Python logging module documentation.
+# Note that when logging configuration files are used then all logging
+# configuration is set in the configuration file and other logging
+# configuration options are ignored (for example,
+# logging_context_format_string). (string value)
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append = <None>
+
+# Defines the format string for %%(asctime)s in log records. Default:
+# %(default)s . This option is ignored if log_config_append is set.
+# (string value)
+#log_date_format = %Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to send logging output to. If no default
+# is set, logging will go to stderr as defined by use_stderr. This
+# option is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
+#log_file = <None>
+
+# (Optional) The base directory used for relative log_file  paths.
+# This option is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir = <None>
+
+# Uses logging handler designed to watch file system. When log file is
+# moved or removed this handler will open a new log file with
+# specified path instantaneously. It makes sense only if log_file
+# option is specified and Linux platform is used. This option is
+# ignored if log_config_append is set. (boolean value)
+#watch_log_file = false
+
+# Use syslog for logging. Existing syslog format is DEPRECATED and
+# will be changed later to honor RFC5424. This option is ignored if
+# log_config_append is set. (boolean value)
+#use_syslog = false
+
+# Syslog facility to receive log lines. This option is ignored if
+# log_config_append is set. (string value)
+#syslog_log_facility = LOG_USER
+
+# Log output to standard error. This option is ignored if
+# log_config_append is set. (boolean value)
+#use_stderr = true
+
+# Format string to use for log messages with context. (string value)
+#logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages when context is undefined.
+# (string value)
+#logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Additional data to append to log message when logging level for the
+# message is DEBUG. (string value)
+#logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format. (string
+# value)
+#logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+# Defines the format string for %(user_identity)s that is used in
+# logging_context_format_string. (string value)
+#logging_user_identity_format = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s
+
+# List of package logging levels in logger=LEVEL pairs. This option is
+# ignored if log_config_append is set. (list value)
+#default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,dogpile.core.dogpile=INFO
+
+# Enables or disables publication of error events. (boolean value)
+#publish_errors = false
+
+# The format for an instance that is passed with the log message.
+# (string value)
+#instance_format = "[instance: %(uuid)s] "
+
+# The format for an instance UUID that is passed with the log message.
+# (string value)
+#instance_uuid_format = "[instance: %(uuid)s] "
+
+# Enables or disables fatal status of deprecations. (boolean value)
+#fatal_deprecations = false
+
+#
+# From rally
+#
+
+# Print debugging output only for Rally. Off-site components stay
+# quiet. (boolean value)
+#rally_debug = false
+
+# HTTP timeout for any of OpenStack service in seconds (floating point
+# value)
+#openstack_client_http_timeout = 180.0
+
+
+[benchmark]
+
+#
+# From rally
+#
+
+# Time to sleep after creating a resource before polling for it status
+# (floating point value)
+#cinder_volume_create_prepoll_delay = 2.0
+
+# Time to wait for cinder volume to be created. (floating point value)
+#cinder_volume_create_timeout = 600.0
+
+# Interval between checks when waiting for volume creation. (floating
+# point value)
+#cinder_volume_create_poll_interval = 2.0
+
+# Time to wait for cinder volume to be deleted. (floating point value)
+#cinder_volume_delete_timeout = 600.0
+
+# Interval between checks when waiting for volume deletion. (floating
+# point value)
+#cinder_volume_delete_poll_interval = 2.0
+
+# Time to sleep after boot before polling for status (floating point
+# value)
+#ec2_server_boot_prepoll_delay = 1.0
+
+# Server boot timeout (floating point value)
+#ec2_server_boot_timeout = 300.0
+
+# Server boot poll interval (floating point value)
+#ec2_server_boot_poll_interval = 1.0
+
+# Time to sleep after creating a resource before polling for it status
+# (floating point value)
+#glance_image_create_prepoll_delay = 2.0
+
+# Time to wait for glance image to be created. (floating point value)
+#glance_image_create_timeout = 120.0
+
+# Interval between checks when waiting for image creation. (floating
+# point value)
+#glance_image_create_poll_interval = 1.0
+
+# Time to wait for glance image to be deleted. (floating point value)
+#glance_image_delete_timeout = 120.0
+
+# Interval between checks when waiting for image deletion. (floating
+# point value)
+#glance_image_delete_poll_interval = 1.0
+
+# Time(in sec) to sleep after creating a resource before polling for
+# it status. (floating point value)
+#heat_stack_create_prepoll_delay = 2.0
+
+# Time(in sec) to wait for heat stack to be created. (floating point
+# value)
+#heat_stack_create_timeout = 3600.0
+
+# Time interval(in sec) between checks when waiting for stack
+# creation. (floating point value)
+#heat_stack_create_poll_interval = 1.0
+
+# Time(in sec) to wait for heat stack to be deleted. (floating point
+# value)
+#heat_stack_delete_timeout = 3600.0
+
+# Time interval(in sec) between checks when waiting for stack
+# deletion. (floating point value)
+#heat_stack_delete_poll_interval = 1.0
+
+# Time(in sec) to wait for stack to be checked. (floating point value)
+#heat_stack_check_timeout = 3600.0
+
+# Time interval(in sec) between checks when waiting for stack
+# checking. (floating point value)
+#heat_stack_check_poll_interval = 1.0
+
+# Time(in sec) to sleep after updating a resource before polling for
+# it status. (floating point value)
+#heat_stack_update_prepoll_delay = 2.0
+
+# Time(in sec) to wait for stack to be updated. (floating point value)
+#heat_stack_update_timeout = 3600.0
+
+# Time interval(in sec) between checks when waiting for stack update.
+# (floating point value)
+#heat_stack_update_poll_interval = 1.0
+
+# Time(in sec) to wait for stack to be suspended. (floating point
+# value)
+#heat_stack_suspend_timeout = 3600.0
+
+# Time interval(in sec) between checks when waiting for stack suspend.
+# (floating point value)
+#heat_stack_suspend_poll_interval = 1.0
+
+# Time(in sec) to wait for stack to be resumed. (floating point value)
+#heat_stack_resume_timeout = 3600.0
+
+# Time interval(in sec) between checks when waiting for stack resume.
+# (floating point value)
+#heat_stack_resume_poll_interval = 1.0
+
+# Time(in sec) to wait for stack snapshot to be created. (floating
+# point value)
+#heat_stack_snapshot_timeout = 3600.0
+
+# Time interval(in sec) between checks when waiting for stack snapshot
+# to be created. (floating point value)
+#heat_stack_snapshot_poll_interval = 1.0
+
+# Time(in sec) to wait for stack to be restored from snapshot.
+# (floating point value)
+#heat_stack_restore_timeout = 3600.0
+
+# Time interval(in sec) between checks when waiting for stack to be
+# restored. (floating point value)
+#heat_stack_restore_poll_interval = 1.0
+
+# Time (in sec) to wait for stack to scale up or down. (floating point
+# value)
+#heat_stack_scale_timeout = 3600.0
+
+# Time interval (in sec) between checks when waiting for a stack to
+# scale up or down. (floating point value)
+#heat_stack_scale_poll_interval = 1.0
+
+# Interval(in sec) between checks when waiting for node creation.
+# (floating point value)
+#ironic_node_create_poll_interval = 1.0
+
+# Delay between creating Manila share and polling for its status.
+# (floating point value)
+#manila_share_create_prepoll_delay = 2.0
+
+# Timeout for Manila share creation. (floating point value)
+#manila_share_create_timeout = 300.0
+
+# Interval between checks when waiting for Manila share creation.
+# (floating point value)
+#manila_share_create_poll_interval = 3.0
+
+# Timeout for Manila share deletion. (floating point value)
+#manila_share_delete_timeout = 180.0
+
+# Interval between checks when waiting for Manila share deletion.
+# (floating point value)
+#manila_share_delete_poll_interval = 2.0
+
+# A timeout in seconds for an environment deploy (integer value)
+# Deprecated group/name - [DEFAULT]/deploy_environment_timeout
+#murano_deploy_environment_timeout = 1200
+
+# Deploy environment check interval in seconds (integer value)
+# Deprecated group/name - [DEFAULT]/deploy_environment_check_interval
+#murano_deploy_environment_check_interval = 5
+
+# Time to sleep after start before polling for status (floating point
+# value)
+#nova_server_start_prepoll_delay = 0.0
+
+# Server start timeout (floating point value)
+#nova_server_start_timeout = 300.0
+
+# Server start poll interval (floating point value)
+#nova_server_start_poll_interval = 1.0
+
+# Time to sleep after stop before polling for status (floating point
+# value)
+#nova_server_stop_prepoll_delay = 0.0
+
+# Server stop timeout (floating point value)
+#nova_server_stop_timeout = 300.0
+
+# Server stop poll interval (floating point value)
+#nova_server_stop_poll_interval = 2.0
+
+# Time to sleep after boot before polling for status (floating point
+# value)
+#nova_server_boot_prepoll_delay = 1.0
+
+# Server boot timeout (floating point value)
+#nova_server_boot_timeout = 300.0
+
+# Server boot poll interval (floating point value)
+#nova_server_boot_poll_interval = 1.0
+
+# Time to sleep after delete before polling for status (floating point
+# value)
+#nova_server_delete_prepoll_delay = 2.0
+
+# Server delete timeout (floating point value)
+#nova_server_delete_timeout = 300.0
+
+# Server delete poll interval (floating point value)
+#nova_server_delete_poll_interval = 2.0
+
+# Time to sleep after reboot before polling for status (floating point
+# value)
+#nova_server_reboot_prepoll_delay = 2.0
+
+# Server reboot timeout (floating point value)
+#nova_server_reboot_timeout = 300.0
+
+# Server reboot poll interval (floating point value)
+#nova_server_reboot_poll_interval = 2.0
+
+# Time to sleep after rebuild before polling for status (floating
+# point value)
+#nova_server_rebuild_prepoll_delay = 1.0
+
+# Server rebuild timeout (floating point value)
+#nova_server_rebuild_timeout = 300.0
+
+# Server rebuild poll interval (floating point value)
+#nova_server_rebuild_poll_interval = 1.0
+
+# Time to sleep after rescue before polling for status (floating point
+# value)
+#nova_server_rescue_prepoll_delay = 2.0
+
+# Server rescue timeout (floating point value)
+#nova_server_rescue_timeout = 300.0
+
+# Server rescue poll interval (floating point value)
+#nova_server_rescue_poll_interval = 2.0
+
+# Time to sleep after unrescue before polling for status (floating
+# point value)
+#nova_server_unrescue_prepoll_delay = 2.0
+
+# Server unrescue timeout (floating point value)
+#nova_server_unrescue_timeout = 300.0
+
+# Server unrescue poll interval (floating point value)
+#nova_server_unrescue_poll_interval = 2.0
+
+# Time to sleep after suspend before polling for status (floating
+# point value)
+#nova_server_suspend_prepoll_delay = 2.0
+
+# Server suspend timeout (floating point value)
+#nova_server_suspend_timeout = 300.0
+
+# Server suspend poll interval (floating point value)
+#nova_server_suspend_poll_interval = 2.0
+
+# Time to sleep after resume before polling for status (floating point
+# value)
+#nova_server_resume_prepoll_delay = 2.0
+
+# Server resume timeout (floating point value)
+#nova_server_resume_timeout = 300.0
+
+# Server resume poll interval (floating point value)
+#nova_server_resume_poll_interval = 2.0
+
+# Time to sleep after pause before polling for status (floating point
+# value)
+#nova_server_pause_prepoll_delay = 2.0
+
+# Server pause timeout (floating point value)
+#nova_server_pause_timeout = 300.0
+
+# Server pause poll interval (floating point value)
+#nova_server_pause_poll_interval = 2.0
+
+# Time to sleep after unpause before polling for status (floating
+# point value)
+#nova_server_unpause_prepoll_delay = 2.0
+
+# Server unpause timeout (floating point value)
+#nova_server_unpause_timeout = 300.0
+
+# Server unpause poll interval (floating point value)
+#nova_server_unpause_poll_interval = 2.0
+
+# Time to sleep after shelve before polling for status (floating point
+# value)
+#nova_server_shelve_prepoll_delay = 2.0
+
+# Server shelve timeout (floating point value)
+#nova_server_shelve_timeout = 300.0
+
+# Server shelve poll interval (floating point value)
+#nova_server_shelve_poll_interval = 2.0
+
+# Time to sleep after unshelve before polling for status (floating
+# point value)
+#nova_server_unshelve_prepoll_delay = 2.0
+
+# Server unshelve timeout (floating point value)
+#nova_server_unshelve_timeout = 300.0
+
+# Server unshelve poll interval (floating point value)
+#nova_server_unshelve_poll_interval = 2.0
+
+# Time to sleep after image_create before polling for status (floating
+# point value)
+#nova_server_image_create_prepoll_delay = 0.0
+
+# Server image_create timeout (floating point value)
+#nova_server_image_create_timeout = 300.0
+
+# Server image_create poll interval (floating point value)
+#nova_server_image_create_poll_interval = 2.0
+
+# Time to sleep after image_delete before polling for status (floating
+# point value)
+#nova_server_image_delete_prepoll_delay = 0.0
+
+# Server image_delete timeout (floating point value)
+#nova_server_image_delete_timeout = 300.0
+
+# Server image_delete poll interval (floating point value)
+#nova_server_image_delete_poll_interval = 2.0
+
+# Time to sleep after resize before polling for status (floating point
+# value)
+#nova_server_resize_prepoll_delay = 2.0
+
+# Server resize timeout (floating point value)
+#nova_server_resize_timeout = 400.0
+
+# Server resize poll interval (floating point value)
+#nova_server_resize_poll_interval = 5.0
+
+# Time to sleep after resize_confirm before polling for status
+# (floating point value)
+#nova_server_resize_confirm_prepoll_delay = 0.0
+
+# Server resize_confirm timeout (floating point value)
+#nova_server_resize_confirm_timeout = 200.0
+
+# Server resize_confirm poll interval (floating point value)
+#nova_server_resize_confirm_poll_interval = 2.0
+
+# Time to sleep after resize_revert before polling for status
+# (floating point value)
+#nova_server_resize_revert_prepoll_delay = 0.0
+
+# Server resize_revert timeout (floating point value)
+#nova_server_resize_revert_timeout = 200.0
+
+# Server resize_revert poll interval (floating point value)
+#nova_server_resize_revert_poll_interval = 2.0
+
+# Time to sleep after live_migrate before polling for status (floating
+# point value)
+#nova_server_live_migrate_prepoll_delay = 1.0
+
+# Server live_migrate timeout (floating point value)
+#nova_server_live_migrate_timeout = 400.0
+
+# Server live_migrate poll interval (floating point value)
+#nova_server_live_migrate_poll_interval = 2.0
+
+# Time to sleep after migrate before polling for status (floating
+# point value)
+#nova_server_migrate_prepoll_delay = 1.0
+
+# Server migrate timeout (floating point value)
+#nova_server_migrate_timeout = 400.0
+
+# Server migrate poll interval (floating point value)
+#nova_server_migrate_poll_interval = 2.0
+
+# Nova volume detach timeout (floating point value)
+#nova_detach_volume_timeout = 200.0
+
+# Nova volume detach poll interval (floating point value)
+#nova_detach_volume_poll_interval = 2.0
+
+# A timeout in seconds for a cluster create operation (integer value)
+# Deprecated group/name - [DEFAULT]/cluster_create_timeout
+#sahara_cluster_create_timeout = 1800
+
+# A timeout in seconds for a cluster delete operation (integer value)
+# Deprecated group/name - [DEFAULT]/cluster_delete_timeout
+#sahara_cluster_delete_timeout = 900
+
+# Cluster status polling interval in seconds (integer value)
+# Deprecated group/name - [DEFAULT]/cluster_check_interval
+#sahara_cluster_check_interval = 5
+
+# A timeout in seconds for a Job Execution to complete (integer value)
+# Deprecated group/name - [DEFAULT]/job_execution_timeout
+#sahara_job_execution_timeout = 600
+
+# Job Execution status polling interval in seconds (integer value)
+# Deprecated group/name - [DEFAULT]/job_check_interval
+#sahara_job_check_interval = 5
+
+# Amount of workers one proxy should serve to. (integer value)
+#sahara_workers_per_proxy = 20
+
+# Interval between checks when waiting for a VM to become pingable
+# (floating point value)
+#vm_ping_poll_interval = 1.0
+
+# Time to wait for a VM to become pingable (floating point value)
+#vm_ping_timeout = 120.0
+
+
+[cleanup]
+
+#
+# From rally
+#
+
+# A timeout in seconds for deleting resources (integer value)
+#resource_deletion_timeout = 600
+
+# Number of cleanup threads to run (integer value)
+#cleanup_threads = 20
+
+
+[database]
+
+#
+# From oslo.db
+#
+
+# The file name to use with SQLite. (string value)
+# Deprecated group/name - [DEFAULT]/sqlite_db
+#sqlite_db = oslo.sqlite
+
+# If True, SQLite uses synchronous mode. (boolean value)
+# Deprecated group/name - [DEFAULT]/sqlite_synchronous
+#sqlite_synchronous = true
+
+# The back end to use for the database. (string value)
+# Deprecated group/name - [DEFAULT]/db_backend
+#backend = sqlalchemy
+
+# The SQLAlchemy connection string to use to connect to the database.
+# (string value)
+# Deprecated group/name - [DEFAULT]/sql_connection
+# Deprecated group/name - [DATABASE]/sql_connection
+# Deprecated group/name - [sql]/connection
+connection = mysql+pymysql://{{ maas_rally_galera_user }}:{{ maas_rally_galera_password }}@{{ maas_rally_galera_address }}/{{ maas_rally_galera_database }}?charset=utf8
+
+# The SQLAlchemy connection string to use to connect to the slave
+# database. (string value)
+#slave_connection = <None>
+
+# The SQL mode to be used for MySQL sessions. This option, including
+# the default, overrides any server-set SQL mode. To use whatever SQL
+# mode is set by the server configuration, set this to no value.
+# Example: mysql_sql_mode= (string value)
+#mysql_sql_mode = TRADITIONAL
+
+# Timeout before idle SQL connections are reaped. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_idle_timeout
+# Deprecated group/name - [DATABASE]/sql_idle_timeout
+# Deprecated group/name - [sql]/idle_timeout
+#idle_timeout = 3600
+
+# Minimum number of SQL connections to keep open in a pool. (integer
+# value)
+# Deprecated group/name - [DEFAULT]/sql_min_pool_size
+# Deprecated group/name - [DATABASE]/sql_min_pool_size
+#min_pool_size = 1
+
+# Maximum number of SQL connections to keep open in a pool. (integer
+# value)
+# Deprecated group/name - [DEFAULT]/sql_max_pool_size
+# Deprecated group/name - [DATABASE]/sql_max_pool_size
+#max_pool_size = <None>
+
+# Maximum number of database connection retries during startup. Set to
+# -1 to specify an infinite retry count. (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_retries
+# Deprecated group/name - [DATABASE]/sql_max_retries
+#max_retries = 10
+
+# Interval between retries of opening a SQL connection. (integer
+# value)
+# Deprecated group/name - [DEFAULT]/sql_retry_interval
+# Deprecated group/name - [DATABASE]/reconnect_interval
+#retry_interval = 10
+
+# If set, use this value for max_overflow with SQLAlchemy. (integer
+# value)
+# Deprecated group/name - [DEFAULT]/sql_max_overflow
+# Deprecated group/name - [DATABASE]/sqlalchemy_max_overflow
+#max_overflow = 50
+
+# Verbosity of SQL debugging information: 0=None, 100=Everything.
+# (integer value)
+# Deprecated group/name - [DEFAULT]/sql_connection_debug
+#connection_debug = 0
+
+# Add Python stack traces to SQL as comment strings. (boolean value)
+# Deprecated group/name - [DEFAULT]/sql_connection_trace
+#connection_trace = false
+
+# If set, use this value for pool_timeout with SQLAlchemy. (integer
+# value)
+# Deprecated group/name - [DATABASE]/sqlalchemy_pool_timeout
+#pool_timeout = <None>
+
+# Enable the experimental use of database reconnect on connection
+# lost. (boolean value)
+#use_db_reconnect = false
+
+# Seconds between retries of a database transaction. (integer value)
+#db_retry_interval = 1
+
+# If True, increases the interval between retries of a database
+# operation up to db_max_retry_interval. (boolean value)
+#db_inc_retry_interval = true
+
+# If db_inc_retry_interval is set, the maximum seconds between retries
+# of a database operation. (integer value)
+#db_max_retry_interval = 10
+
+# Maximum retries in case of connection error or deadlock error before
+# error is raised. Set to -1 to specify an infinite retry count.
+# (integer value)
+#db_max_retries = 20
+
+
+[image]
+
+#
+# From rally
+#
+
+# CirrOS image URL (string value)
+#cirros_img_url = http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img
+
+# Image disk format to use when creating the image (string value)
+#disk_format = qcow2
+
+# Image container format to use when creating the image (string value)
+#container_format = bare
+
+# Regular expression for name of an image to discover it in the cloud
+# and use it for the tests. Note that when Rally is searching for the
+# image, case insensitive matching is performed. Specify nothing
+# ('name_regex =') if you want to disable discovering. In this case
+# Rally will create needed resources by itself if the values for the
+# corresponding config options are not specified in the Tempest config
+# file (string value)
+#name_regex = ^.*(cirros|testvm).*$
+
+
+[role]
+
+#
+# From rally
+#
+
+# Role required for users to be able to create Swift containers
+# (string value)
+#swift_operator_role = Member
+
+# User role that has reseller admin (string value)
+#swift_reseller_admin_role = ResellerAdmin
+
+# Role required for users to be able to manage Heat stacks (string
+# value)
+#heat_stack_owner_role = heat_stack_owner
+
+# Role for Heat template-defined users (string value)
+#heat_stack_user_role = heat_stack_user
+
+
+[users_context]
+
+#
+# From rally
+#
+
+# How many concurrent threads use for serving users context (integer
+# value)
+#resource_management_workers = 30
+
+# ID of domain in which projects will be created. (string value)
+#project_domain = default
+
+# ID of domain in which users will be created. (string value)
+#user_domain = default

--- a/playbooks/templates/rax-maas/rally_check.yaml.j2
+++ b/playbooks/templates/rax-maas/rally_check.yaml.j2
@@ -1,0 +1,44 @@
+{% set name = item.key %}
+{% set label = "rally_"+item.key %}
+{% set check_name = label+'--'+inventory_hostname %}
+{% set period = item.value.poll_interval %}
+{% set timeout = period - 1 %}
+{% set times = item.value.times %}
+{% set concurrency = item.value.concurrency %}
+{% set crit_threshold = item.value.crit_threshold %}
+{% set warn_threshold = item.value.warn_threshold %}
+{% set alarm_consecutive_count = item.value.alarm_consecutive_count %}
+{% set duration_threshold_percent = item.value.duration_threshold %}
+{% set duration_threshold_seconds = (period*item.value.duration_threshold/100.0)|float %}
+
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ period }}"
+timeout     : "{{ timeout }}"
+disabled    : "{{ (inventory_hostname not in maas_rally_primary_node or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_rally_venv.sh
+    args    : ["{{ maas_plugin_dir }}/rally_performance.py", "{{ name }}", "-t {{ times }}", "-c {{ concurrency }}" {% for k,v in item.value.extra_vars.iteritems() | list %}, "-e {{k}}={{v}}" {% endfor %}]
+    timeout : {{ timeout * 1000 | int}}
+alarms      :
+    rally_{{ name }}_total_95pctl :
+        label                   : rally_{{ name }}_total_95pctl--{{ inventory_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (("rally_{{ name }}_total_95pctl--{{ inventory_hostname }}") | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ alarm_consecutive_count }}
+            if (metric['{{ name }}_total_95pctl'] > {{ warn_threshold }}) {
+                return new AlarmStatus(CRITICAL, "{{ name }} performance metric exceeds warning threshold of {{ warn_threshold }} seconds");
+            }
+            if (metric['{{ name }}_total_95pctl'] > {{ crit_threshold }}) {
+                return new AlarmStatus(CRITICAL, "{{ name }} performance metric exceeds BREACH threshold of {{ crit_threshold }} seconds");
+            }
+    rally_{{ name }}_maas_check_duration :
+        label                   : rally_{{ name }}_maas_check_duration--{{ inventory_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (("rally_{{ name }}_maas_check_duration--{{ inventory_hostname }}") | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ alarm_consecutive_count }}
+            if (metric["maas_check_duration"] > {{ '%0.2f' | format(duration_threshold_seconds|float) }}) {
+                return new AlarmStatus(CRITICAL, "{{ name }} performance test duration exceeds {{ duration_threshold_percent }}% of {{ period }} second polling interval.");
+            }

--- a/playbooks/templates/rax-maas/rally_deployment.yaml.j2
+++ b/playbooks/templates/rax-maas/rally_deployment.yaml.j2
@@ -1,0 +1,25 @@
+{
+    "type": "ExistingCloud",
+    "auth_url": "{{ maas_rally_auth_url }}",
+    "region_name": "{{ maas_rally_region_name }}",
+    "endpoint_type": "{{ maas_rally_endpoint_type }}",
+    "admin": {
+        "password": "{{ maas_rally_admin_password }}",
+        "project_domain_name": "{{ maas_rally_admin_domain_name }}",
+        "project_name": "{{ maas_rally_admin_project_name }}",
+        "user_domain_name": "{{ maas_rally_admin_domain_name }}",
+        "username": "{{ maas_rally_admin_user_name }}"
+    },
+{% if keystone_service_adminuri_insecure %}
+    "https_insecure": True,
+{% endif %}
+    "users": [        
+        {
+            "username": "{{ item.value.user_name | default('rally_' + item.key) }}",
+            "password": "{{ item.value.user_password }}",
+            "project_name": "{{ item.value.project | default('rally_' + item.key) }}",
+            "project_domain_name": "{{ maas_rally_admin_domain_name }}",
+            "user_domain_name": "{{ maas_rally_admin_domain_name }}"
+        }        
+    ]
+}

--- a/playbooks/templates/rax-maas/run_plugin_in_rally_venv.sh.j2
+++ b/playbooks/templates/rax-maas/run_plugin_in_rally_venv.sh.j2
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [[ -f ~/openrc ]]; then
+  source ~/openrc
+fi
+
+# NOTE(cloudnull): Hard coded because this was never addressed upstream
+export OS_API_INSECURE=True
+
+{{ maas_rally_venv_bin }}/python "$@"

--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -1,0 +1,335 @@
+#
+#  Performance monitoring has the potential to negatively impact performance
+#  and availability for an environment's primary users.  Careful consideration
+#  and tuning is required before enabling maas_rally.  The maas_rally playbook
+#  will bail out unless this is set to true. 	
+#
+maas_rally_enabled: false
+
+#
+#  The ansible host group where the maas_rally performance monitoring plugin
+#  will be installed.
+#
+maas_rally_target_group: shared-infra_hosts
+
+#
+#  The node from which checks will run.  The maas_rally plugin will be installed
+#  on all hosts in `maas_rally_target_group`, but performance checks (each of
+#  which consumes resources) should only execute from a single node to avoid
+#  uncoordinated resource consumption.  The best practice is to override this
+#  with a single hostname (e.g. infra01) in user vars.  Then, if the primary
+#  node fails maas_rally_primary_node can be updated to resume monitoring from
+#  another node.
+#
+maas_rally_primary_node: "{{ groups[maas_rally_target_group][0] }}"
+
+#
+#  The maas_rally_check_overrides dictionary is the primary configuration
+#  mechanism for maas_rally scenarios.  Each first-level key represents a
+#  scenario, and corresponds to a rally task definition file in
+#  `playbooks/files/rax-maas/rally/tasks/`.  Look in that directory or in the
+#  maas_rally_check_defaults variable to discover available scenarios.
+#
+#  The per-check (second-level keys) variables are described below.  At a
+#  minimum, deployers should select appropriate values for `times`,
+#  `poll_interval`, `warn_threshold`, and `crit_threshold` for each enabled
+#  scenario based on the characteristics of the environment being monitored.
+#  Undefined variables are inherited from `maas_rally_check_default_template`
+#  and `maas_rally_check_defaults` in that order.  
+#
+#  Per-check (second-level) keys:
+#
+#    - enabled: Boolean indicating whether the check should be deployed.  Each
+#      check must explicitly be enabled.
+#      Default: false
+#
+#    - times: Total number of times a rally task will be run per invocation of
+#      the plugin.
+#      Default: 1
+#
+#    - concurrency: Number of rally tasks that will run in parallel. In most
+#      cases, where the goal is to measure performance while impacting it
+#      minimally, default value of 1 should be used.
+#      Default: 1
+#
+#    - poll_interval: Polling interval in seconds.
+#      Default: 1800 (30 minutes)
+#
+#    - warn_threshold: A warning alarm is generated when the 95%ile metric
+#      exceeds this threshold (in seconds).
+#      Default: 300 (5 minutes)
+#
+#    - crit_threshold: An SLA breach alarm is generated with the 95%ile metric
+#      exceeds this threshold (in seconds).
+#      Default: 600 (10 minutes)
+#
+#    - alarm_consecutive_count: The number of failed polls that trigger an
+#      alarm.  Defaults to 2 to allow for running the check locally for
+#      diagnostic purposes and to avoid alerting during a MaaS agent restart.
+#      Either of those events can lock the maas_rally scenario and cause a
+#      single-poll failure. 
+#      Default: 2
+#
+#    - duration_threshold: The percentage of the polling interval used to warn
+#      about potential polling overruns. Example: If a check is configured to
+#      with a 300 second (5 minute) polling interface and this threshold is set
+#      at 75%, then we will receive an alert if the performance check takes
+#      more than 225 seconds (3 minutes, 45 seconds) to complete. 
+#      Default: 75 (percent)
+#
+#    - project: The keystone project the scenario runs in.  The playbook will
+#      create this project if it does not exist.
+#      Default: rally_<scenario name>
+#
+#    - user_name: The keystone user that the scenario runs as. The playbook will
+#      create this user if it does not exist.
+#      Default: rally_<scenario name>
+#
+#    - user_password: The password for the keystone user the scenario runs as.
+#      Default: {{ maas_rally_users_password }}
+#
+#  Example:
+#
+#    maas_rally_check_overrides:
+#      cinder:
+#        enabled: true
+#        poll_interval: 300
+#        times: 2
+#        warn_threshold: 75
+#        crit_threshold: 95
+#      glance:
+#        enabled: true
+#        poll_interval: 120
+#        times: 2
+#        warn_threshold: 25
+#        crit_threshold: 45
+#      keystone:
+#        enabled: true
+#        poll_interval: 120
+#        times: 10
+#        warn_threshold: 1.65
+#        crit_threshold: 2.5
+#      neutron_ports:
+#        enabled: true
+#        poll_interval: 120
+#        times: 2
+#        warn_threshold: 20
+#        crit_threshold: 30
+#      neutron_secgroups:
+#        enabled: true
+#        poll_interval: 120
+#        times: 2
+#        warn_threshold: 24
+#        crit_threshold: 40
+#      nova:
+#        enabled: true
+#        poll_interval: 300
+#        times: 2
+#        warn_threshold: 35
+#        crit_threshold: 50
+#      nova_cinder:
+#        enabled: true
+#        poll_interval: 200
+#        times: 2
+#        warn_threshold: 70
+#        crit_threshold: 90
+#      swift:
+#        enabled: true
+#        poll_interval: 60
+#        warn_threshold: 2.5
+#        crit_threshold: 5
+#        user_name: swift_monitor
+#        user_password: swiftsecrete
+#        extra_user_roles:
+#          - "swiftoperator"
+maas_rally_check_overrides: {}
+
+#
+#  Galera username for rally.  N.B.: maas_rally_galera_password must be set
+#  in user secrets.
+#
+maas_rally_galera_user: maas_rally
+
+#
+#  Name for galera database where Rally data will be stored
+#
+maas_rally_galera_database: maas_rally
+
+#
+#  Address for galera database where Rally data will be stored.
+#
+maas_rally_galera_address: "{{ galera_address }}"
+
+#
+#  How rally deployments communicate with OpenStack endpoints.
+#
+maas_rally_auth_url: "{{ maas_scheme }}://{{ internal_vip_address }}:5000/v3/"
+maas_rally_region_name: "{{ keystone_service_region | default('RegionOne') }}"
+maas_rally_endpoint_type: "internal"
+
+#
+# Admin user variables
+#
+maas_rally_admin_user_name: "{{ keystone_admin_user_name | default('admin') }}"
+maas_rally_admin_project_name: "{{ keystone_admin_tenant_name | default('admin') }}"
+maas_rally_admin_password: "{{ keystone_auth_admin_password }}"
+maas_rally_admin_domain_name: Default
+
+#
+#  NOTE: Variables beyond this point probably do not need to be overridden for
+#  most use cases (e.g. unless you are adding new scenarios or there is
+#  something non-standard in your environment
+#
+
+#
+# Name of the virtual env to deploy maas_rally into
+#
+maas_rally_venv: "/openstack/venvs/maas-rally-{{ maas_release }}"
+maas_rally_venv_bin: "{{ maas_rally_venv }}/bin"
+
+#
+# Repo and commit/tag/branch for rally
+#
+maas_rally_git_repo: "https://github.com/openstack/rally"
+maas_rally_git_version: "stable/0.9"
+
+#
+# Set the pip package state, defaults to present
+#
+maas_rally_pip_package_state: present
+
+#
+# pip packages required for plugin functionality
+#
+maas_rally_pip_packages:
+  - "git+{{ maas_rally_git_repo }}@{{ maas_rally_git_version }}#egg=rally"
+  - numpy
+  - pymysql
+
+#
+#  Default values for performance checks.  They are intentionally conservative
+#  here to reduce the risk of negatively impacting a production environment by
+#  enabling checks without tuning their configurations.  The expectation is
+#  that these are overridden on a per-check basis, using environment- specific
+#  values, in the maas_rally_check_overrides dictionary.
+#
+#  See the documentation block for maas_rally_check_overrides for information
+#  about each variable.
+#
+maas_rally_default_times: 1
+maas_rally_default_concurrency: 1
+maas_rally_default_poll_interval: 1800
+maas_rally_default_duration_threshold: 75
+maas_rally_default_warn_threshold: 300
+maas_rally_default_crit_threshold: 600
+maas_rally_default_alarm_consecutive_count: 2
+
+#
+#  This dictionary is a template containing default values for all checks. In
+#  most cases, deployers should make changes in maas_rally_check_overrides
+#  rather than here.
+#
+#  See the documentation block for maas_rally_check_overrides for information
+#  about each variable.
+#
+maas_rally_check_default_template:
+  enabled: false
+  times: "{{ maas_rally_default_times }}"
+  concurrency: "{{ maas_rally_default_concurrency }}"
+  warn_threshold: "{{ maas_rally_default_warn_threshold }}"
+  crit_threshold: "{{ maas_rally_default_crit_threshold }}"
+  poll_interval: "{{ maas_rally_default_poll_interval }}"
+  duration_threshold: "{{ maas_rally_default_duration_threshold }}"
+  user_password: "{{ maas_rally_users_password }}"
+  alarm_consecutive_count: "{{ maas_rally_default_alarm_consecutive_count }}"
+  extra_user_roles: []
+  extra_vars: {}
+  creates_instances: false
+  per_iter_quotas:    # Resources required per iteration of the scenario. These
+    instances: 0      # values are multipled by the scenario's concurrency.
+    cores: 0
+    ram: 0
+    fixed-ips: 0
+    floating-ips: 0
+    ports: 0
+    snapshots: 0
+    volumes: 0
+    gigabytes: 0
+
+#
+#  Defaults for each check.  These values are merged with
+#  maas_rally_check_default_template for each check, with these values taking
+#  precedence. In most cases, deployers should make changes in
+#  maas_rally_check_overrides rather than here.
+#
+maas_rally_check_defaults:
+  neutron_secgroups: {}
+  glance: {}
+  keystone: {}
+  swift: {}
+  cinder:
+    per_iter_quotas:
+      instances: 1
+      cores: 1
+      ram: 256
+      fixed-ips: 1
+      ports: 4
+      volumes: 2       # Double because rally doesn't seem to wait for cinder
+      gigabytes: 2     # volumes to be scrubbed.
+    creates_instances: true
+  neutron_ports:
+    per_iter_quotas:
+      ports: 1
+  nova_cinder:
+    per_iter_quotas:
+      instances: 1
+      cores: 1
+      ram: 256
+      fixed-ips: 1
+      ports: 4
+      volumes: 2       # Double because rally doesn't seem to wait for cinder
+      gigabytes: 20    # volumes to be scrubbed.
+    creates_instances: true
+  nova:
+    per_iter_quotas:
+      instances: 1
+      cores: 1
+      ram: 256
+      fixed-ips: 1
+      ports: 4
+    creates_instances: true
+
+#
+#  Combine check defaults and overrides.  These are applied on top of the
+#  template defined in maas_rally_check_default_template.
+#
+maas_rally_checks: "{{ maas_rally_check_defaults | combine(maas_rally_check_overrides, recursive=True) }}"
+
+#
+# Disables configuration validation
+#
+maas_rally_skip_config_validation: false
+
+
+#
+# Varibles required to populate clouds.yaml
+#
+
+## Endpoint types
+openrc_clouds_yml_interface: internal
+
+## Default credentials
+openrc_os_username: admin
+openrc_os_tenant_name: admin
+openrc_os_auth_url: "{{ keystone_service_internalurl }}"
+openrc_region_name: "{{ service_region }}"
+
+## Create clouds.yml file
+openrc_openstack_client_config_dir_dest: "{{ ansible_env.HOME }}/.config/openstack"
+openrc_openstack_client_config_dir_owner: "{{ ansible_user_id }}"
+openrc_openstack_client_config_dir_group: "{{ ansible_user_id }}"
+openrc_openstack_client_config_dir_mode: "0700"
+openrc_clouds_yml_file_dest: "{{ openrc_openstack_client_config_dir_dest }}/clouds.yaml"
+openrc_clouds_yml_file_owner: "{{ ansible_user_id }}"
+openrc_clouds_yml_file_group: "{{ ansible_user_id }}"
+openrc_clouds_yml_file_mode: "0600"

--- a/tests/test-ansible-functional.sh
+++ b/tests/test-ansible-functional.sh
@@ -48,7 +48,18 @@ export ANSIBLE_LOG_PATH="${ANSIBLE_LOG_DIR}/ansible-functional.log"
 # Ansible Inventory will be set to OSA
 export ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY:-/opt/openstack-ansible/playbooks/inventory}"
 
-export TEST_PLAYBOOK="${TEST_PLAYBOOK:-$WORKING_DIR/tests/test.yml}"
+# The maas_rally performance monitoring requires a modern (>1.9) version of
+# ansible that is not available in liberty and mitaka.  There is no reason
+# to run it in a ceph context either.
+case $IRR_CONTEXT in
+  liberty|mitaka|ceph)
+    export TEST_PLAYBOOK="${TEST_PLAYBOOK:-$WORKING_DIR/tests/test.yml}"
+    ;;
+  *)
+    export TEST_PLAYBOOK="${TEST_PLAYBOOK:-$WORKING_DIR/tests/test_with_maas_rally.yml}"
+    ;;
+esac
+
 export TEST_SETUP_PLAYBOOK="${TEST_SETUP_PLAYBOOK:-$WORKING_DIR/tests/test-setup.yml}"
 export TEST_CHECK_MODE="${TEST_CHECK_MODE:-false}"
 export TEST_IDEMPOTENCE="${TEST_IDEMPOTENCE:-false}"

--- a/tests/test_with_maas_rally.yml
+++ b/tests/test_with_maas_rally.yml
@@ -1,0 +1,31 @@
+---
+# Copyright 2018, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE:
+# This file is only executed against Newton and more recent environments that
+# support a modern version of ansible (>= 2.0).  If you want to test against
+# Liberty and Mitaka deployments, add the include tasks to test.yml.
+
+# Install rpc-maas
+- include: "../playbooks/site.yml"
+
+# Install maas_rally performance monitoring
+- include: "../playbooks/maas-openstack-rally.yml"
+
+# Ensure all plugins are functional
+- include: "../playbooks/maas-verify.yml"
+
+# Run the tigk stack playbooks
+- include: "../playbooks/maas-tigkstack-all.yml"

--- a/tests/user_ceph_vars.yml
+++ b/tests/user_ceph_vars.yml
@@ -20,3 +20,5 @@ maas_check_period_override:
 maas_excluded_alarms: []
 
 maas_excluded_checks: []
+
+maas_rally_enabled: false

--- a/tests/user_master_vars.yml
+++ b/tests/user_master_vars.yml
@@ -20,3 +20,28 @@ maas_check_period_override:
 maas_excluded_alarms: []
 
 maas_excluded_checks: []
+
+maas_rally_enabled: true
+
+# NOTE(cfarquhar): The scenarios that create instances are disabled for now
+# since public cloud AIOs are unreliable in terms of performance.
+ 
+maas_rally_check_overrides:
+  cinder:
+    enabled: false
+  glance:
+    enabled: true
+  keystone:
+    enabled: true
+  neutron_ports:
+    enabled: true
+  neutron_secgroups:
+    enabled: true
+  nova:
+    enabled: false
+  nova_cinder:
+    enabled: false
+  swift:
+    enabled: true
+    extra_user_roles:
+      - "swiftoperator"

--- a/tests/user_newton_vars.yml
+++ b/tests/user_newton_vars.yml
@@ -23,3 +23,28 @@ maas_excluded_checks: []
 
 # Nova console type is required
 nova_console_type: novnc
+
+maas_rally_enabled: true
+
+# NOTE(cfarquhar): The scenarios that create instances are disabled for now
+# since public cloud AIOs are unreliable in terms of performance.
+
+maas_rally_check_overrides:
+  cinder:
+    enabled: false
+  glance:
+    enabled: true
+  keystone:
+    enabled: true
+  neutron_ports:
+    enabled: true
+  neutron_secgroups:
+    enabled: true
+  nova:
+    enabled: false
+  nova_cinder:
+    enabled: false
+  swift:
+    enabled: true
+    extra_user_roles:
+      - "swiftoperator"

--- a/tests/user_ocata_vars.yml
+++ b/tests/user_ocata_vars.yml
@@ -20,3 +20,28 @@ maas_check_period_override:
 maas_excluded_alarms: []
 
 maas_excluded_checks: []
+
+maas_rally_enabled: true
+
+# NOTE(cfarquhar): The scenarios that create instances are disabled for now
+# since public cloud AIOs are unreliable in terms of performance.
+
+maas_rally_check_overrides:
+  cinder:
+    enabled: false
+  glance:
+    enabled: true
+  keystone:
+    enabled: true
+  neutron_ports:
+    enabled: true
+  neutron_secgroups:
+    enabled: true
+  nova:
+    enabled: false
+  nova_cinder:
+    enabled: false
+  swift:
+    enabled: true
+    extra_user_roles:
+      - "swiftoperator"

--- a/tests/user_pike_vars.yml
+++ b/tests/user_pike_vars.yml
@@ -20,3 +20,28 @@ maas_check_period_override:
 maas_excluded_alarms: []
 
 maas_excluded_checks: []
+
+maas_rally_enabled: true
+
+# NOTE(cfarquhar): The scenarios that create instances are disabled for now
+# since public cloud AIOs are unreliable in terms of performance.
+
+maas_rally_check_overrides:
+  cinder:
+    enabled: false
+  glance:
+    enabled: true
+  keystone:
+    enabled: true
+  neutron_ports:
+    enabled: true
+  neutron_secgroups:
+    enabled: true
+  nova:
+    enabled: false
+  nova_cinder:
+    enabled: false
+  swift:
+    enabled: true
+    extra_user_roles:
+      - "swiftoperator"

--- a/tests/user_rpcm_secrets.yml
+++ b/tests/user_rpcm_secrets.yml
@@ -15,6 +15,8 @@
 
 maas_rabbitmq_password: secrete
 maas_keystone_password: secrete
+maas_rally_users_password: secrete
+maas_rally_galera_password: secrete
 maas_swift_accesscheck_password: secrete
 influxdb_db_root_password: secrete
 influxdb_db_metric_password: secrete


### PR DESCRIPTION
This commit adds the following:

- Playbook to deploy performance monitoring
- MaaS plugin to execute and manage rally tasks
- A set of performance scenarios
  - cinder
    - boot instance from local disk
    - create volume
    - attach volume to instance
    - detach volume from instance
    - delete volume
    - delete instance
  - glance
    - create image
    - delete image
  - keystone
    - fetch token
    - validate token
  - neutron_ports
    - create port
    - delete port
  - neutron_secgroups
    - create security group
    - update security group
    - delete security group
  - nova
    - boot instance from local disk
    - delete instance
  - nova_cinder
    - create cinder volume
    - boot instance from volume
    - delete instance
  - swift
    - create container
    - upload object
    - download object
    - delete object
    - delete container