### PR TITLE
RE-1200 Configurable retries for verify

### DIFF
--- a/playbooks/maas-poller-setup.yml
+++ b/playbooks/maas-poller-setup.yml
@@ -93,12 +93,17 @@
         insertafter: "^[Service]"
         line: "ExecStart=/usr/bin/rackspace-monitoring-poller serve --config $CONFIG_FILE $POLLER_SERVE_OPTS"
 
+      # Skip lint because daemon-reload only is not supported by the systemd
+      # module until ansible 2.4, and this role needs to support older
+      # versions.
     - name: Reload systemd unit configurations on 16.04
       when:
         - maas_private_monitoring_enabled | bool
         - maas_private_monitoring_zone is defined
         - ansible_distribution_version == "16.04"
       command: "systemctl daemon-reload"
+      tags:
+        - skip_ansible_lint
       changed_when: False
 
     - name: Start MaaS poller (systemd)

--- a/playbooks/maas-tigkstack-telegraf.yml
+++ b/playbooks/maas-tigkstack-telegraf.yml
@@ -169,9 +169,14 @@
       when:
         - pid1_name == "systemd"
 
+      # Skip lint because daemon-reload only is not supported by the systemd
+      # module until ansible 2.4, and this role needs to support older
+      # versions.
     - name: Reload systemd daemon
       command: "systemctl daemon-reload"
       changed_when: false
+      tags:
+        - skip_ansible_lint
       when:
         - pid1_name == "systemd"
 

--- a/playbooks/maas-verify.yml
+++ b/playbooks/maas-verify.yml
@@ -61,8 +61,8 @@
         virtualenv: "{{ maas_venv }}"
       register: install_pip_packages
       until: install_pip_packages|success
-      retries: 5
-      delay: 2
+      retries: "{{ maas_verify_retries }}"
+      delay: "{{ maas_verify_delay }}"
 
     - name: "Allow MAAS time to run checks before verifying they're created"
       pause:
@@ -77,8 +77,8 @@
       register: maas_verify
       changed_when: false
       until: maas_verify | success
-      retries: 6
-      delay: 5
+      retries: "{{ maas_verify_retries }}"
+      delay: "{{ maas_verify_delay }}"
 
     - name: "Verify Checks & Alarms are registered"
       command: >
@@ -89,8 +89,8 @@
       register: verify_maas
       changed_when: false
       until: verify_maas.rc == 0
-      retries: 6
-      delay: 20
+      retries: "{{ maas_verify_retries }}"
+      delay: "{{ maas_verify_delay }}"
       when:
         - maas_use_api | bool
         - maas_verify_registration | bool
@@ -103,8 +103,8 @@
       register: verify_status
       changed_when: false
       until: verify_status.rc == 0
-      retries: 6
-      delay: 20
+      retries: "{{ maas_verify_retries }}"
+      delay: "{{ maas_verify_delay }}"
       when:
         - maas_use_api | bool
         - maas_verify_status | bool

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -92,7 +92,15 @@ maas_verify_registration: false
 #
 maas_verify_wait: true
 
+#
+# maas_verify_retries: How many times to retry maas verification tasks
+#
+maas_verify_retries: 15
 
+#
+# maas_verify_delay: How long to wait before retrying verification tasks
+#
+maas_verify_delay: 60
 
 #
 # maas_notification_plan: The Cloud Monitoring notification plan, which defines who will be


### PR DESCRIPTION
This commit adds variables for retries and delays in the verify
playbook. This will allow users to override those values should they
need to.

The impetus for this is deploys into phobos, where it takes longer
than the standard delay for rabbit queues to settle.