### PR TITLE
RO-2832 Fix very-maas spacing

### DIFF
--- a/playbooks/maas-verify.yml
+++ b/playbooks/maas-verify.yml
@@ -83,7 +83,7 @@
       command: >
         {{ maas_venv_bin }}/python /opt/rpc-maas-tools/rpc-maas-tool.py --logfile {{ workspace_logs }}/rpc-maas-api-logs.txt verify-created
         --entity {{ maas_entity_name }}
-        {% for ec in maas_excluded_checks %}--excludedcheck "{{ ec }}"{% endfor %}
+        {% for ec in maas_excluded_checks %} --excludedcheck "{{ ec }}" {% endfor %}
       become: true
       register: verify_maas
       changed_when: false


### PR DESCRIPTION
Previously there were no spaces between --excluded check arguments
which lead to a failure to parse the arguments correctly. This
commit corrects that.