### PR TITLE
Fix MaaS with Ocata+

### DIFF
--- a/playbooks/files/rax-maas/plugins/maas_common.py
+++ b/playbooks/files/rax-maas/plugins/maas_common.py
@@ -293,7 +293,9 @@ else:
                 endpoint = '%s/v3' % endpoint
         else:
             k_client = k2_client
-        keystone = k_client.Client(auth_ref=auth_ref, endpoint=endpoint)
+        keystone = k_client.Client(auth_ref=auth_ref,
+                                   endpoint=endpoint,
+                                   insecure=AUTH_DETAILS['OS_API_INSECURE'])
 
         try:
             # This should be a rather light-weight call that validates we're
@@ -615,10 +617,9 @@ def get_auth_details(openrc_file=OPENRC):
 
 
 def get_url_for_type(endpoint, url_type, auth_version):
-    if auth_version == 'v3':
-        return endpoint['url'] if (endpoint['interface'] == url_type and
-                                   'v3' in endpoint['url']) else None
-    else:
+    try:
+        return endpoint['url']
+    except ValueError:
         return endpoint[url_type + 'URL']
 
 

--- a/tests/user_pike_vars.yml
+++ b/tests/user_pike_vars.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Set overrides for check periods
+maas_check_period_override:
+  disk_utilisation: 900
+
+maas_excluded_alarms: []
+
+maas_excluded_checks: []


### PR DESCRIPTION
This change resolves issues with OpenStack checks using insecure ssl
and versionless endpoints.

This also adds a test pike variable file for consistency.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>