### PR TITLE
Add setup_maas_tigkstack var default to False

### DIFF
--- a/tests/test.yml
+++ b/tests/test.yml
@@ -21,3 +21,4 @@
 
 # Run the tigk stack playbooks
 - include: "../playbooks/maas-tigkstack-all.yml"
+  when: setup_maas_tigkstack is defined and setup_maas_tigkstack


### PR DESCRIPTION
We shouldn't need to install or setup the tigkstack grafana bits unless
we are doing upgrades. As this is causing issues with SNI/SSL on the apt
keys for influxdb we should skip installing this.

A flag is added (defaulting not defined), so that we can easily enable
this for testing downtime on upgrades, setting the
"setup_maas_tigkstack" variable to True.