### PR TITLE
Update maas_influxdata_key variable

### DIFF
--- a/playbooks/vars/maas-tigkstack.yml
+++ b/playbooks/vars/maas-tigkstack.yml
@@ -17,7 +17,8 @@
 # Set the influxdata distro package source & key
 #
 maas_influxdata_key:
-  url: "https://repos.influxdata.com/influxdb.key"
+  keyserver: "keyserver.ubuntu.com"
+  id: "2582E0C5"
 
 maas_influxdata_repo:
   url: "deb https://repos.influxdata.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -21,4 +21,3 @@
 
 # Run the tigk stack playbooks
 - include: "../playbooks/maas-tigkstack-all.yml"
-  when: setup_maas_tigkstack is defined and setup_maas_tigkstack


### PR DESCRIPTION
In #414 we tried making this include conditional, however this playbook
is still being included when run w/ older versions of ansible (1.9.6
as an example).

Instead, we update maas_influxdata_key to have an id and keyserver key.
This allows apt_key to work since it doesn't need to speak to
https://repos.influxdata.com/ directly.  Using ansible's apt_key with
https://repos.influxdata.com/ fails because of SNI and:

1. https://github.com/ansible/ansible/pull/32053/ (not backported to
   2.3.2.0)
2. ansible 1.9.6 doesn't seem to support SNI on Trusty (python < 2.7.9)