### PR TITLE
[DNM] Testing with 2 ceph osds

### DIFF
--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -128,7 +128,7 @@ if [ "${IRR_CONTEXT}" == "ceph" ]; then
     rm -rf /opt/rpc-ceph
   fi
 
-  git clone https://github.com/rcbops/rpc-ceph /opt/rpc-ceph
+  git clone https://github.com/andymcc/rpc-ceph /opt/rpc-ceph -b 2osd
   export RPC_MAAS_DIR="$(pwd)"
   pushd /opt/rpc-ceph
     bash /opt/rpc-ceph/run_tests.sh


### PR DESCRIPTION
MaaS tests fail with 2 OSDs, but the rpc-ceph repo is working fine for
that when running MaaS.

This PR is to test that and see what failures occur.