### PR TITLE
K8S-595 Add MaaS check for Kubernetes API to rpc-maas

### DIFF
--- a/playbooks/files/rax-maas/plugins/managed_k8_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/managed_k8_api_local_check.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import datetime
+
+import subprocess
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+
+RACKSPACE_SYSTEM_NS = "rackspace-system"
+
+
+def check(args):
+    try:
+        start = datetime.datetime.now()
+        # this is lame but the k8 python client did not work
+        ret = subprocess.check_output(
+            ['kubectl', "--kubeconfig=%s" % args.kubeconfig,
+             "--namespace=%s" % RACKSPACE_SYSTEM_NS, 'get', 'pods'])
+        end = datetime.datetime.now()
+        api_is_up = (len(ret.split(
+            '\n')) > 1)  # if rack system is empty something is terribly wrong
+    except subprocess.CalledProcessError as e:
+        api_is_up = False
+        metric_bool('client_success', False, m_name='maas_managed_k8')
+    # Any other exception presumably isn't an API error
+    except Exception as e:
+        metric_bool('client_success', False, m_name='maas_managed_k8')
+        status_err(str(e), m_name='maas_managed_k8')
+    else:
+        metric_bool('client_success', True, m_name='maas_managed_k8')
+        dt = (end - start)
+        milliseconds = (dt.microseconds + dt.seconds * 10 ** 6) / 10 ** 3
+
+    status_ok(m_name='maas_managed_k8')
+    metric_bool('managed_k8_api_local_status', api_is_up,
+                m_name='maas_managed_k8')
+    if api_is_up:
+        # only want to send other metrics if api is up
+        metric('managed_k8_api_local_response_time',
+               'double',
+               '%.3f' % milliseconds,
+               'ms')
+
+
+def main(args):
+    check(args)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Check K8 Cluster API against local or remote address')
+    parser.add_argument('--kubeconfig', nargs='?', required=True,
+                        help="Kube Config file to use")
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
+        main(args)

--- a/playbooks/maas-managed-k8.yml
+++ b/playbooks/maas-managed-k8.yml
@@ -1,0 +1,149 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Gather facts
+  hosts: hosts
+  gather_facts: "{{ gather_facts | default(true) }}"
+  pre_tasks:
+    - include: "common-tasks/maas_excluded_regex.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: k8_all
+
+    - name: Check for mk8s secrets
+      local_action: stat path=/etc/openstack_deploy/mk8s_user_secrets.yml
+      register: maas_k8_secrets
+
+    - name: Include mk8s secrets
+      include_vars: /etc/openstack_deploy/mk8s_user_secrets.yml
+      when: maas_k8_secrets.stat.exists
+
+  tasks:
+    - name: Get clusters from auth service
+      uri:
+        url: "{{ maas_managed_k8_auth_url }}/clusters"
+        headers:
+          x-auth-token: "{{ mk8s_auth_admin_token }}"
+      register:  k8_servers
+      run_once: true
+      when:
+        - mk8s_auth_admin_token is defined
+
+    - name: set fact
+      set_fact: k8_item="{{ item.kubeconfig | from_yaml }}"
+      with_items:
+        - "{{ k8_servers.json | default([]) }}"
+      register: k8_result
+      when:
+         - mk8s_auth_admin_token is defined
+
+    - name: make a list
+      set_fact: k8_config="{{ k8_result.results | map(attribute='ansible_facts.k8_item') | list }}"
+      when:
+         - mk8s_auth_admin_token is defined
+
+  post_tasks:
+    - name: Install kubectl
+      get_url:
+        url: "https://storage.googleapis.com/kubernetes-release/release/{{ maas_managed_k8_kubectl_release }}/bin/linux/amd64/kubectl"
+        dest: /usr/local/bin
+        mode: 0775
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - mk8s_auth_admin_token is defined
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas-managed-k8.yml
+  tags:
+    - maas-managed-k8
+
+- name: Install checks for k8 api
+  hosts: hosts
+  gather_facts: false
+  tasks:
+    - name: Install k8 lb checks
+      template:
+        src: "templates/rax-maas/lb_api_check_managed_k8.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/lb_api_check_managed_k8-{{ item.clusters[0].name }}.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      with_items:
+        - "{{ k8_config }}"
+      when:
+        - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
+        - k8_config is defined
+
+    - name: Install k8 private lb checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_managed_k8.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_managed_k8-{{ item.clusters[0].name }}.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      with_items:
+        - "{{ k8_config }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
+        - k8_config is defined
+
+    - name: Create k8 directory
+      file:
+        path: "{{ maas_managed_k8_kube_config_dir }}"
+        state: "directory"
+        owner: "root"
+        group: "root"
+        mode: "0700"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - k8_config is defined
+
+    - name: Install k8 cluster config
+      copy:
+        content: "{{ item }}"
+        dest: "{{ maas_managed_k8_kube_config_dir }}/kube-config-{{ item.clusters[0].name }}.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0600"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      with_items:
+        - "{{ k8_config }}"
+      when:
+        - k8_config is defined
+
+    - name: Install local checks
+      template:
+        src: "templates/rax-maas/managed_k8_api_local_check.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/managed_k8_api_local_check-{{ item.clusters[0].name }}.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      with_items:
+        - "{{ k8_config }}"
+      when:
+        - k8_config is defined
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas-managed-k8.yml
+  tags:
+    - maas-managed-k8

--- a/playbooks/templates/rax-maas/lb_api_check_managed_k8.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_managed_k8.yaml.j2
@@ -1,0 +1,25 @@
+{% set label = "lb_api_check_managed_k8" %}
+{% set check_name = label+'--'+item.clusters[0].name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ ( check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ item.clusters[0].cluster.server| regex_replace('http[s]://','') | regex_replace(':.*|/.*','') }}" {# replace with url filter beginnging ansible 2.4 #}
+details           :
+    url           : "{{ item.clusters[0].cluster.server }}"
+monitoring_zones_poll:
+{% for zone in maas_monitoring_zones %}
+  - {{ zone }}
+{% endfor %}
+alarms            :
+    lb_api_alarm_keystone   :
+        label               : lb_api_alarm_managed_k8
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('lb_api_alarm_managed_k8' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '200') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/templates/rax-maas/managed_k8_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/managed_k8_api_local_check.yaml.j2
@@ -1,0 +1,21 @@
+{% set label = "managed_k8_api_local_check" %}
+{% set cluster_name = item.clusters[0].name %}
+{% set check_name = label+'--'+cluster_name %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}/managed_k8_api_local_check.py", "{{ maas_managed_k8_kube_config_dir }}/kube-config-{{ cluster_name }}.yaml"]
+alarms      :
+    managed_k8_api_local_status :
+        label                   : managed_k8_api_local_status--{{ cluster_name }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (('managed_k8_api_local_status--'+cluster_name) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["managed_k8_api_local_status"] != 1) {
+                return new AlarmStatus(CRITICAL, "API unavailable");
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_managed_k8.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_managed_k8.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_managed_k8" %}
+{% set check_name = label+'--'+item.clusters[0].name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ item.clusters[0].cluster.server | regex_replace('http[s]://','') | regex_replace(':.*|/.*','') }}" {# replace with url filter beginnging ansible 2.4 #}
+details           :
+    url           : "{{ item.clusters[0].cluster.server }}"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_octavia    :
+        label               : private_lb_api_alarm_managed_k8
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_managed_k8' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '200') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/vars/maas-managed-k8.yml
+++ b/playbooks/vars/maas-managed-k8.yml
@@ -13,40 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: maas-agent-all.yml
-  tags:
-    - maas
+maas_managed_k8_kube_config_dir: /root/.k8
 
-- include: maas-poller-all.yml
-  tags:
-    - maas
+maas_managed_k8_kubectl_release: v1.9.1
 
-- include: maas-ceph-all.yml
-  tags:
-    - maas
+maas_managed_k8_auth_url: "{{ external_vip_address }}:8090"
 
-- include: maas-host-all.yml
-  tags:
-    - maas
-
-- include: maas-infra-all.yml
-  tags:
-    - maas
-
-- include: maas-container-all.yml
-  tags:
-    - maas
-
-- include: maas-openstack-all.yml
-  tags:
-    - maas
-
-- include: maas-hummingbird.yml
-  tags:
-    - maas
-    - hummingbird
-- include: maas-managed-k8.yml
-  tags:
-    - maas
-
-- include: maas-restart.yml


### PR DESCRIPTION
This adds rudimentary checks for the K8 API by reading the endpoints
from the K8 auth DB and parsing them.