### PR TITLE
[RLM-529] Add pre-flight check to ensure all passwords are set

### DIFF
--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -1,0 +1,36 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in witing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Check all passwords are defined
+  hosts: localhost
+  connection: local
+  gather_facts: "true"
+  tasks:
+    - name: Check password is defined
+      fail:
+        msg: >-
+          The password "{{ item.key }}" is undefined. Set this password in an
+          appropriate secrets file before continuing.
+      when:
+        - maas_pre_flight_check_enabled | default(false) | bool
+        - groups['osds'] | default([]) | length > 0
+        - groups['mons'] | default([]) | length > 0
+        - ansible_version.full | version_compare('2.1.0.0', '>=')
+        - hostvars[inventory_hostname][item.key] is undefined
+      with_dict: "{{ maas_pw_check }}"
+  vars:
+    maas_pw_check: "{{ lookup('file', playbook_dir + '/../tests/user_rpcm_secrets.yml') | from_yaml }}"
+  tags:
+    - maas-pre-flight

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: maas-pre-flight.yml
+  tags:
+    - maas
+
 - include: maas-agent-all.yml
   tags:
     - maas

--- a/tests/user_kilo_vars.yml
+++ b/tests/user_kilo_vars.yml
@@ -30,6 +30,8 @@ maas_excluded_alarms:
 maas_excluded_checks:
   - 'swift_time_sync_check'
 
+maas_pre_flight_check_enabled: true
+
 # Ansible 1.9 compatibility
 ansible_host: "{{ ansible_ssh_host }}"
 

--- a/tests/user_liberty_vars.yml
+++ b/tests/user_liberty_vars.yml
@@ -30,6 +30,8 @@ maas_excluded_alarms:
 maas_excluded_checks:
   - 'filebeat_process_check'
 
+maas_pre_flight_check_enabled: true
+
 # Ansible 1.9 compatibility
 ansible_host: "{{ ansible_ssh_host }}"
 

--- a/tests/user_master_vars.yml
+++ b/tests/user_master_vars.yml
@@ -25,7 +25,7 @@ maas_rally_enabled: true
 
 # NOTE(cfarquhar): The scenarios that create instances are disabled for now
 # since public cloud AIOs are unreliable in terms of performance.
- 
+
 maas_rally_check_overrides:
   cinder:
     enabled: false
@@ -45,3 +45,5 @@ maas_rally_check_overrides:
     enabled: true
     extra_user_roles:
       - "swiftoperator"
+
+maas_pre_flight_check_enabled: true

--- a/tests/user_mitaka_vars.yml
+++ b/tests/user_mitaka_vars.yml
@@ -28,6 +28,8 @@ maas_excluded_alarms:
 
 maas_excluded_checks: []
 
+maas_pre_flight_check_enabled: true
+
 # Ansible 1.9 compatibility
 ansible_host: "{{ ansible_ssh_host }}"
 

--- a/tests/user_newton_vars.yml
+++ b/tests/user_newton_vars.yml
@@ -48,3 +48,5 @@ maas_rally_check_overrides:
     enabled: true
     extra_user_roles:
       - "swiftoperator"
+
+maas_pre_flight_check_enabled: true

--- a/tests/user_ocata_vars.yml
+++ b/tests/user_ocata_vars.yml
@@ -45,3 +45,5 @@ maas_rally_check_overrides:
     enabled: true
     extra_user_roles:
       - "swiftoperator"
+
+maas_pre_flight_check_enabled: true

--- a/tests/user_pike_vars.yml
+++ b/tests/user_pike_vars.yml
@@ -45,3 +45,5 @@ maas_rally_check_overrides:
     enabled: true
     extra_user_roles:
       - "swiftoperator"
+
+maas_pre_flight_check_enabled: true


### PR DESCRIPTION
This change adds a pre-flight check to ensure all passwords are set
prior to RPC-MaaS being deployed. A new playbook was created which uses
the example password file to iterate and find if any of the passwords
are unset from the playbook runtime. If a required password is missing
the task will produce a failure which instructs the deployer to set the
required password before continuing.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RLM-529](https://rpc-openstack.atlassian.net/browse/RLM-529)