### PR TITLE
[RO-3395] Limit tests repo for linting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,8 @@ setenv =
     PYTHONPATH={envsitepackagesdir}
     ### OSA specific call back files
     # Set the checkout to any supported tag, branch, or sha.
-    OSA_TESTS_CHECKOUT=master
+    #  Set to the head of stable/pike as of 09.01.2018
+    OSA_TESTS_CHECKOUT=3ed70ba2492d8f4e65b00147f8be5756a725e8a8
     OSA_REQUIREMENTS_CHECKOUT=master
     UPPER_CONSTRAINTS_FILE=https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h={env:OSA_REQUIREMENTS_CHECKOUT:master}
     OSA_TEST_DEPS=https://git.openstack.org/cgit/openstack/openstack-ansible-tests/plain/test-ansible-deps.txt?h={env:OSA_TESTS_CHECKOUT:master}
@@ -90,8 +91,12 @@ ignore=F403,E731
 [testenv:bashate]
 commands =
     {[testenv:tests_clone]commands}
-    bash -c "{toxinidir}/tests/common/test-bashate.sh"
-
+    bash -c "grep --recursive --binary-files=without-match \
+         --files-with-match '^.!.*\(ba\)\?sh$' \
+         --exclude-dir .tox \
+         --exclude-dir .git \
+         --exclude-dir common \
+         "{toxinidir}" | xargs bashate --error . --verbose --ignore=E003,E006,E040"
 
 [testenv:ansible]
 deps =


### PR DESCRIPTION
The RPC-MaaS repo was tracking the head of the openstack-ansible tests
repo. This change sets the checkout of the tests repo to a single SHA
from the stable pike branch which will protect us from upstream change.

The bashate tests have also been updated to ensure we're not linting the
external tests repo which can cause failures unrelated to our systems.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Issue: [RO-3395](https://rpc-openstack.atlassian.net/browse/RO-3395)
  