### PR TITLE
Initial commit of rally/influxdb integration

### DIFF
--- a/contrib/maas_rally_influxdb_grafana_dashboard.json
+++ b/contrib/maas_rally_influxdb_grafana_dashboard.json
@@ -1,0 +1,257 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_MAAS_RALLY_INFLUXDB",
+      "label": "maas_rally_influxdb",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.6.3"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "refresh": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": 268,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_MAAS_RALLY_INFLUXDB}",
+          "decimals": 2,
+          "fill": 1,
+          "id": 2,
+          "interval": "5m",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 275,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "minSpan": 12,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": "scenario",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$col",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "previous"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "/^$scenario$/",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT mean(/.*95pctl/) FROM /^$scenario$/ WHERE (\"environment\" =~ /^$environment$/) AND $timeFilter GROUP BY time($__interval) fill(previous)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "*"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Performance - [[environment]] - [[scenario]]",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_MAAS_RALLY_INFLUXDB}",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "environment",
+        "options": [],
+        "query": "SHOW TAG VALUES WITH KEY = \"environment\"",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_MAAS_RALLY_INFLUXDB}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Scenario",
+        "multi": true,
+        "name": "scenario",
+        "options": [],
+        "query": "SHOW MEASUREMENTS WHERE (\"environment\" =~ /^$environment$/) ",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now-5m"
+  },
+  "timepicker": {
+    "nowDelay": "5m",
+    "refresh_intervals": [
+      "6h",
+      "12h",
+      "1d",
+      "1w",
+      "2w",
+      "1m"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Performance",
+  "version": 1
+}

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -495,6 +495,14 @@
       with_dict: "{{ maas_rally_checks }}"
       when: item.value.enabled
 
+    - name: Install maas_rally plugin configuration file
+      template:
+        src: "templates/rax-maas/rally_config.yaml.j2"
+        dest: "{{ maas_plugin_dir }}/rally/config.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0600"
+
   vars_files:
     - vars/main.yml
     - vars/maas-agent.yml

--- a/playbooks/templates/rax-maas/rally_check.yaml.j2
+++ b/playbooks/templates/rax-maas/rally_check.yaml.j2
@@ -10,6 +10,7 @@
 {% set alarm_consecutive_count = item.value.alarm_consecutive_count %}
 {% set duration_threshold_percent = item.value.duration_threshold %}
 {% set duration_threshold_seconds = (period*item.value.duration_threshold/100.0)|float %}
+{% set influxdb = maas_rally_influxdb_enabled %}
 
 type        : agent.plugin
 label       : "{{ check_name }}"
@@ -18,7 +19,7 @@ timeout     : "{{ timeout }}"
 disabled    : "{{ (inventory_hostname not in maas_rally_primary_node or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_rally_venv.sh
-    args    : ["{{ maas_plugin_dir }}/rally_performance.py", "{{ name }}", "-t {{ times }}", "-c {{ concurrency }}" {% for k,v in item.value.extra_vars.iteritems() | list %}, "-e {{k}}={{v}}" {% endfor %}]
+    args    : ["{{ maas_plugin_dir }}/rally_performance.py", "{{ name }}", "-t {{ times }}", "-c {{ concurrency }}" {% if influxdb %}, "--influxdb" {% endif %} {% for k,v in item.value.extra_vars.iteritems() | list %}, "-e {{k}}={{v}}" {% endfor %}]
     timeout : {{ timeout * 1000 | int}}
 alarms      :
     rally_{{ name }}_total_95pctl :

--- a/playbooks/templates/rax-maas/rally_config.yaml.j2
+++ b/playbooks/templates/rax-maas/rally_config.yaml.j2
@@ -1,0 +1,15 @@
+# {{ ansible_managed }}
+---
+{% if maas_rally_influxdb_enabled %}
+influxdb:
+  host: {{ maas_rally_influxdb_host }}
+  port: {{ maas_rally_influxdb_port }}
+  user: {{ maas_rally_influxdb_user }}
+  password: {{ maas_rally_influxdb_user }}
+  database: {{ maas_rally_influxdb_database }}
+  measurement_name: {{ maas_rally_influxdb_measurement_name }}
+  tags:
+{% for k,v in maas_rally_influxdb_tags.iteritems() %}
+    {{ k }}: {{ v }}
+{% endfor %}
+{% endif %}

--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -203,6 +203,7 @@ maas_rally_pip_package_state: present
 #
 maas_rally_pip_packages:
   - "git+{{ maas_rally_git_repo }}@{{ maas_rally_git_version }}#egg=rally"
+  - influxdb
   - numpy
   - pymysql
 
@@ -310,6 +311,33 @@ maas_rally_checks: "{{ maas_rally_check_defaults | combine(maas_rally_check_over
 #
 maas_rally_skip_config_validation: false
 
+
+#
+# InfluxDB configuration
+#
+# This section allows you to send the results of each poll to an arbitrary
+# influxdb deployment.  This playbook does not handle the deployment of
+# influxdb.
+#
+maas_rally_influxdb_enabled: false
+
+# How to connect to the database
+maas_rally_influxdb_host: localhost
+maas_rally_influxdb_port: 8086
+maas_rally_influxdb_user: maas_rally
+maas_rally_influxdb_password: ''
+maas_rally_influxdb_database: maas_rally
+
+# This value is configured in the 'environment' tag for each data point to
+# support report filtering multiple deployments using the same influxdb backend.
+maas_rally_influxdb_environment_name: OpenStack
+
+# The influxdb measurement name
+maas_rally_influxdb_measurement_name: performance
+
+# If you override this, be sure to include the environment tag
+maas_rally_influxdb_tags:
+  environment: "{{ maas_rally_influxdb_environment_name }}"
 
 #
 # Varibles required to populate clouds.yaml


### PR DESCRIPTION
This commit adds the following:

 - Changes to the maas_rally plugin to send performance data to an arbitrary
   influxdb endpoint
 - A templated grafana dashboard in .json format