### PR TITLE
Set maas_rally default alarm_consecutive_count to 3

### DIFF
--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -222,7 +222,7 @@ maas_rally_default_poll_interval: 1800
 maas_rally_default_duration_threshold: 75
 maas_rally_default_warn_threshold: 300
 maas_rally_default_crit_threshold: 600
-maas_rally_default_alarm_consecutive_count: 2
+maas_rally_default_alarm_consecutive_count: 3
 
 #
 #  This dictionary is a template containing default values for all checks. In


### PR DESCRIPTION
This commit changes the default alarm_consecutive_count for maas_rally from 2
to 3.  This is in line with the default used for other checks.