### PR TITLE
RE-1276 Add support for rpc-gating standard jobs

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mkdir -p "${RE_HOOK_RESULT_DIR}"
+mkdir -p "${RE_HOOK_ARTIFACT_DIR}"
+
+bash "$(readlink -f $(dirname ${0}))/../../run_tests.sh"

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -218,6 +218,9 @@
         {% endfor %} \
         {{ item.value.project | default('rally_' + item.key) }}
       with_dict: "{{ maas_rally_checks }}"
+      # The quota is osc can be flaky, even though the command succeeds. For now
+      #  we skip failing at this point.
+      failed_when: false
       when:
         - item.value.enabled
 

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -1,0 +1,33 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in witing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Check all passwords are defined
+  hosts: localhost
+  connection: local
+  gather_facts: "true"
+  tasks:
+    - name: Check password is defined
+      fail:
+        msg: >-
+          The password "{{ item.key }}" is undefined. Set this password in an
+          appropriate secrets file before continuing.
+      when:
+        - ansible_version.full | version_compare('2.1.0.0', '>=')
+        - hostvars[inventory_hostname][item.key] is undefined
+      with_dict: "{{ maas_pw_check }}"
+  vars:
+    maas_pw_check: "{{ lookup('file', playbook_dir + '/../tests/user_rpcm_secrets.yml') | from_yaml }}"
+  tags:
+    - maas-pre-flight

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: maas-pre-flight.yml
+  tags:
+    - maas
+
 - include: maas-agent-all.yml
   tags:
     - maas

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -50,7 +50,7 @@ fi
 if [ "${RE_JOB_SCENARIO}" = "ceph" ]; then
   export ANSIBLE_BINARY="ansible-playbook"
   export ANSIBLE_INVENTORY="/opt/rpc-ceph/tests/inventory"
-  export ANSIBLE_OVERRIDES="/opt/rpc-ceph/tests/test-vars.yml"
+  export ANSIBLE_OVERRIDES="/opt/rpc-ceph/tests/test-vars.yml -e @/opt/rpc-ceph/tests/user_rpcm_secrets.yml"
 fi
 if [ "${FUNCTIONAL_TEST}" = true ]; then
   tox -e bindep

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -21,7 +21,7 @@ env
 echo "+-------------------- START ENV VARS --------------------+"
 
 export FUNCTIONAL_TEST=${FUNCTIONAL_TEST:-true}
-export IRR_CONTEXT=${IRR_CONTEXT:-"undefined"}
+export RE_JOB_SCENARIO=${RE_JOB_SCENARIO:-"undefined"}
 
 # Install python2 for Ubuntu 16.04 and CentOS 7
 if which apt-get; then
@@ -47,7 +47,7 @@ sudo pip install bindep tox
 if which yum; then
     sudo yum -y install redhat-lsb-core epel-release
 fi
-if [ "${IRR_CONTEXT}" = "ceph" ]; then
+if [ "${RE_JOB_SCENARIO}" = "ceph" ]; then
   export ANSIBLE_BINARY="ansible-playbook"
   export ANSIBLE_INVENTORY="/opt/rpc-ceph/tests/inventory"
   export ANSIBLE_OVERRIDES="/opt/rpc-ceph/tests/test-vars.yml"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -21,7 +21,7 @@ env
 echo "+-------------------- START ENV VARS --------------------+"
 
 export FUNCTIONAL_TEST=${FUNCTIONAL_TEST:-true}
-export RE_JOB_SCENARIO=${RE_JOB_SCENARIO:-"undefined"}
+export RE_JOB_SCENARIO=${RE_JOB_SCENARIO:-$IRR_CONTEXT}
 
 # Install python2 for Ubuntu 16.04 and CentOS 7
 if which apt-get; then

--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -26,7 +26,7 @@ echo "+-------------------- AIO ENV VARS --------------------+"
 
 ## Vars ----------------------------------------------------------------------
 
-export IRR_CONTEXT="${IRR_CONTEXT:-master}"
+export RE_JOB_SCENARIO="${RE_JOB_SCENARIO:-master}"
 export TESTING_HOME="${TESTING_HOME:-$HOME}"
 export ANSIBLE_LOG_DIR="${TESTING_HOME}/.ansible/logs"
 export ANSIBLE_LOG_PATH="${ANSIBLE_LOG_DIR}/ansible-aio.log"
@@ -107,7 +107,7 @@ neutron_provider_networks:
 
 echo "Gate test starting
 with:
-  IRR_CONTEXT: ${IRR_CONTEXT}
+  RE_JOB_SCENARIO: ${RE_JOB_SCENARIO}
   TESTING_HOME: ${TESTING_HOME}
   ANSIBLE_LOG_PATH: ${ANSIBLE_LOG_PATH}
 "
@@ -122,7 +122,7 @@ fi
 
 mkdir -p "${ANSIBLE_LOG_DIR}"
 
-if [ "${IRR_CONTEXT}" == "ceph" ]; then
+if [ "${RE_JOB_SCENARIO}" == "ceph" ]; then
 
   if [ -d "/opt/rpc-ceph" ]; then
     rm -rf /opt/rpc-ceph
@@ -145,7 +145,7 @@ else
 fi
 
 pushd /opt/openstack-ansible
-  if [ "${IRR_CONTEXT}" == "kilo" ]; then
+  if [ "${RE_JOB_SCENARIO}" == "kilo" ]; then
     git checkout "97e3425871659881201106d3e7fd406dc5bd8ff3"  # Last commit of Kilo
     pin_jinja
     pin_galera "5.5"
@@ -157,27 +157,27 @@ pushd /opt/openstack-ansible
       git clone https://github.com/willshersystems/ansible-sshd /etc/ansible/roles/sshd
     fi
 
-  elif [ "${IRR_CONTEXT}" == "liberty" ]; then
+  elif [ "${RE_JOB_SCENARIO}" == "liberty" ]; then
     git checkout "06d0fd344b5b06456a418745fe9937a3fbedf9b2"  # Last commit of Liberty
     pin_jinja
     pin_galera "10.0"
     # Change Affinity - only create 1 galera/rabbit/keystone/horizon and repo server for testing MaaS
     sed -i 's/\(_container\: \).*/\11/' /opt/openstack-ansible/etc/openstack_deploy/openstack_user_config.yml.aio
 
-  elif [ "${IRR_CONTEXT}" == "mitaka" ]; then
+  elif [ "${RE_JOB_SCENARIO}" == "mitaka" ]; then
     git checkout "fbafe397808ef3ee3447fe8fefa6ac7e5c6ff144"  # Last commit of Mitaka
     pin_jinja
     pin_galera "10.0"
 
-  elif [ "${IRR_CONTEXT}" == "newton" ]; then
+  elif [ "${RE_JOB_SCENARIO}" == "newton" ]; then
     git checkout "stable/newton"  # Branch checkout of Newton (Current Stable)
     enable_ironic
 
-  elif [ "${IRR_CONTEXT}" == "ocata" ]; then
+  elif [ "${RE_JOB_SCENARIO}" == "ocata" ]; then
     git checkout "stable/ocata"  # Branch checkout of Ocata (Current Stable)
     enable_ironic
 
-  elif [ "${IRR_CONTEXT}" == "pike" ]; then
+  elif [ "${RE_JOB_SCENARIO}" == "pike" ]; then
     git checkout "stable/pike"  # Branch checkout of Pike (Current Stable)
     enable_ironic
 

--- a/tests/test-ansible-functional.sh
+++ b/tests/test-ansible-functional.sh
@@ -35,7 +35,7 @@ echo "+-------------------- FUNCTIONAL ENV VARS --------------------+"
 
 ## Vars ----------------------------------------------------------------------
 
-export IRR_CONTEXT="${IRR_CONTEXT:-master}"
+export RE_JOB_SCENARIO="${RE_JOB_SCENARIO:-master}"
 export TESTING_HOME="${TESTING_HOME:-$HOME}"
 export WORKING_DIR="${WORKING_DIR:-$(pwd)}"
 export ROLE_NAME="${ROLE_NAME:-''}"
@@ -51,7 +51,7 @@ export ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY:-/opt/openstack-ansible/playbooks/
 # The maas_rally performance monitoring requires a modern (>1.9) version of
 # ansible that is not available in liberty and mitaka.  There is no reason
 # to run it in a ceph context either.
-case $IRR_CONTEXT in
+case $RE_JOB_SCENARIO in
   liberty|mitaka|ceph)
     export TEST_PLAYBOOK="${TEST_PLAYBOOK:-$WORKING_DIR/tests/test.yml}"
     ;;
@@ -196,10 +196,10 @@ fi
 influx_pin_environment
 
 # Export additional ansible environment variables if running Kilo or Liberty
-if [ "${IRR_CONTEXT}" == "kilo" ]; then
+if [ "${RE_JOB_SCENARIO}" == "kilo" ]; then
   pin_environment
 
-elif [ "${IRR_CONTEXT}" == "liberty" ]; then
+elif [ "${RE_JOB_SCENARIO}" == "liberty" ]; then
   pin_environment
 fi
 

--- a/tests/test-setup.yml
+++ b/tests/test-setup.yml
@@ -21,8 +21,8 @@
   tasks:
     - name: Copy RPC-M vars into place
       copy:
-        src: "user_{{ ansible_env.IRR_CONTEXT | default('master') }}_vars.yml"
-        dest: "/etc/openstack_deploy/user_rpcm_{{ ansible_env.IRR_CONTEXT | default('master') }}_vars.yml"
+        src: "user_{{ ansible_env.RE_JOB_SCENARIO | default('master') }}_vars.yml"
+        dest: "/etc/openstack_deploy/user_rpcm_{{ ansible_env.RE_JOB_SCENARIO | default('master') }}_vars.yml"
     - name: Copy RPC-M secrets into place
       copy:
         src: "user_rpcm_secrets.yml"

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ setenv =
     VIRTUAL_ENV={envdir}
     WORKING_DIR={toxinidir}
     # RPC Gate variables
-    IRR_CONTEXT={env:IRR_CONTEXT:master}
+    RE_JOB_SCENARIO={env:RE_JOB_SCENARIO:master}
     # bug#1682108
     PYTHONPATH={envsitepackagesdir}
     ### OSA specific call back files


### PR DESCRIPTION
This change switches rpc-maas testing from supporting independent role
repository jobs to the standard rpc-gating jobs.