### PR TITLE
[DNM] Troubleshoot gating issues with 'openstack quota set'

### DIFF
--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -210,7 +210,7 @@
     - name: Set quotas for maas_rally projects
       shell: |
         . /root/openrc
-        {{ maas_rally_venv_bin }}/openstack \
+        {{ maas_rally_venv_bin }}/openstack --debug \
         {% if keystone_service_adminuri_insecure %} --insecure \ {% endif %}
         quota set \
         {% for quota in item.value.per_iter_quotas %} \

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -19,6 +19,7 @@
   pre_tasks:
     - name: Pause for gate troubleshooting
       pause:
+        minutes: 240
 
     - name: Safety check - ensure maas_rally is enabled
       fail:

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -177,6 +177,7 @@
         cloud: default
         validate_certs: "{{ not keystone_service_adminuri_insecure }}"
         domain_id: "Default"
+        wait: yes
       with_dict: "{{ maas_rally_checks }}"
       when:
         - item.value.enabled

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -17,6 +17,9 @@
   hosts: "{{ maas_rally_target_group }}[0]"
   gather_facts: false
   pre_tasks:
+    - name: Pause for gate troubleshooting
+      pause:
+
     - name: Safety check - ensure maas_rally is enabled
       fail:
         msg: "Rally performance tests are disabled.  If you really want them please read the documentation and set maas_rally_enabled to true."


### PR DESCRIPTION
This commit adds a wait to os_project.  Some gating jobs fail in the next task
("Set quotas for maas_rally projects") with "'NoneType' object has no attribute
'name'" in stderr from the openstack client.  This is testing the hypothesis
that we are attempting to set a quota on the project before it's fully created.