### PR TITLE
Unblock gating

### DIFF
--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -218,6 +218,9 @@
         {% endfor %} \
         {{ item.value.project | default('rally_' + item.key) }}
       with_dict: "{{ maas_rally_checks }}"
+      # The quota is osc can be flaky, even though the command succeeds. For now
+      # we skip failing at this point.
+      failed_when: false
       when:
         - item.value.enabled
 


### PR DESCRIPTION
Gating is failing due to flakey behavior from the `openstack quota` command
in the `maas-openstack-rally.yml` playbook.  Based on a conversation with
@cloudnull, the behavior is intermittent and the failure occurs even when
the quota has been set appropriately.

Gating will fail in the verification stage if the quotas aren't actually set.