### PR TITLE
RE-1296 Use rpc-ceph gating script for deployment

### DIFF
--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -131,7 +131,7 @@ if [ "${IRR_CONTEXT}" == "ceph" ]; then
   git clone https://github.com/rcbops/rpc-ceph /opt/rpc-ceph
   export RPC_MAAS_DIR="$(pwd)"
   pushd /opt/rpc-ceph
-    bash /opt/rpc-ceph/run_tests.sh
+    RE_JOB_SCENARIO="functional" TEST_RPC_MAAS="False" bash /opt/rpc-ceph/gating/post_merge_test/run
   popd
   exit
 fi


### PR DESCRIPTION
This change replaces the use of the deprecated script run_tests.sh with
gating/post_merge_test/run.