### PR TITLE
RE-1164 Support replacing Travis with rpc-gating

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -52,10 +52,11 @@ if [ "${RE_JOB_SCENARIO}" = "ceph" ]; then
   export ANSIBLE_INVENTORY="/opt/rpc-ceph/tests/inventory"
   export ANSIBLE_OVERRIDES="/opt/rpc-ceph/tests/test-vars.yml"
 fi
-if [ "${FUNCTIONAL_TEST}" = true ]; then
+if [ "${RE_JOB_ACTION}" != "tox-test" ]; then
   tox -e bindep
   # Run maas functional tests
   tox -e functional
 else
-  tox
+  tmp_tox_dir=$(mktemp -d)
+  tox -e $RE_JOB_SCENARIO --workdir $tmp_tox_dir
 fi


### PR DESCRIPTION
This change adds support for running the tests currently performed by
Travis CI using the standard jobs provided by the RE team.