### PR TITLE
[RO-3877] Reduce protocol variables down to a single variable

### DIFF
--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -197,8 +197,12 @@ def get_args():
     parser_rgw = subparsers.add_parser('rgw')
     parser_rgw.add_argument('--rgw_port', required=True, help='RGW port')
     parser_rgw.add_argument('--rgw_host', required=True, help='RGW host')
-    parser_rgw.add_argument('--rgw_protocol', type=str, default='http',
-                            help='Protocol to use for radosgw requests')
+    parser_rgw.add_argument('--http',
+                            action='store_true',
+                            help='Use http for checks')
+    parser_rgw.add_argument('--https',
+                            action='store_true',
+                            help='Use https for checks')
     parser.add_argument('--telegraf-output',
                         action='store_true',
                         default=False,
@@ -218,7 +222,7 @@ def main(args):
     if args.subparser_name == 'mon':
         kwargs['host'] = args.host
     if args.subparser_name == 'rgw':
-        kwargs['rgw_protocol'] = args.rgw_protocol
+        kwargs['rgw_protocol'] = 'https' if args.https else 'http'
         kwargs['rgw_port'] = args.rgw_port
         kwargs['rgw_host'] = args.rgw_host
 

--- a/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
@@ -3,7 +3,7 @@
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
 {% set _ = ceph_args.extend(["rgw", "--rgw_port", "8080"]) %}
 {% set _ = ceph_args.extend(["--rgw_host", ansible_host]) %}
-{% set _ = ceph_args.extend(["--rgw_protocol", ceph_radosgw_protocol]) %}
+{% set _ = ceph_args.extend(["--" + ceph_radosgw_protocol]) %}
 {% set _ceph_args = ceph_args | to_yaml(width=1000) %}
 {% set ceph_args = _ceph_args %}
 
@@ -28,4 +28,3 @@ alarms      :
             if (metric["rgw_up"] == 1) {
                 return new AlarmStatus(WARNING, "Ceph rgw warning.");
             }
-


### PR DESCRIPTION
The monitoring agent has an arbitrary limit of 10 args per plugin. This change limits ceph_rgw_stats check from 11 args, down to 10.