### PR TITLE
Add regex to telegraf_format to allow filtering

### DIFF
--- a/playbooks/maas-tigkstack-telegraf.yml
+++ b/playbooks/maas-tigkstack-telegraf.yml
@@ -64,6 +64,14 @@
         group: "root"
         mode: "0755"
 
+    - name: Drop MaaS telegraf output format config file
+      template:
+        src: "templates/tigkstack/maas_telegraf_format.yml.j2"
+        dest: /etc/maas_telegraf_format.yml
+        owner: "root"
+        group: "root"
+        mode: "0755"
+
   vars_files:
     - vars/main.yml
     - vars/maas-tigkstack.yml

--- a/playbooks/templates/tigkstack/maas_telegraf_format.yml.j2
+++ b/playbooks/templates/tigkstack/maas_telegraf_format.yml.j2
@@ -1,0 +1,1 @@
+include_pattern: {{ maas_telegraf_regex_pat }}

--- a/playbooks/vars/maas-tigkstack.yml
+++ b/playbooks/vars/maas-tigkstack.yml
@@ -628,3 +628,5 @@ grafana_panel_skel:
 
 maas_telegraf_format_pip_packages:
   - "PyYAML"
+
+maas_telegraf_regex_pat: ".*"


### PR DESCRIPTION
Rally plugins should be excluded from execution by telegraf. The TIGK deployment playbooks duplicate each invocation of every plugin. This causes problems especially for rally. 

This change introduces a new config file for the `maas_telegraf_format.py` file which allows a user to define a regex of what to include. By default `.*` is used to maintain current behavior. Excluding the rally plugins is as simple as setting `maas_telegraf_regex_pat: "^(?!rally).*"` In the `/etc/openstack_deploy/user_maas_vars.yml` file and running the `maas-tigkstack-telegraf.yml` playbook.

Signed-off-by: Michael Rice <michael@michaelrice.org>