### PR TITLE
[RO-3945] Modify period and timeout overrides to use label instead of check_name

### DIFF
--- a/playbooks/templates/rax-maas/private_ping_check.yaml.j2
+++ b/playbooks/templates/rax-maas/private_ping_check.yaml.j2
@@ -2,8 +2,8 @@
 {% set check_name = label+'--'+inventory_hostname %}
 type              : remote.ping
 label             : "{{ check_name }}"
-period            : "{{ maas_check_period_override[check_name] | default(maas_check_period) }}"
-timeout           : "{{ maas_check_timeout_override[check_name] | default(maas_check_timeout) }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
 disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_hostname   : "{{ ansible_default_ipv4.address }}"
 details           :

--- a/playbooks/templates/rax-maas/private_ssh_check.yaml.j2
+++ b/playbooks/templates/rax-maas/private_ssh_check.yaml.j2
@@ -2,8 +2,8 @@
 {% set check_name = label+'--'+inventory_hostname %}
 type              : remote.tcp
 label             : "{{ check_name }}"
-period            : "{{ maas_check_period_override[check_name] | default(maas_check_period) }}"
-timeout           : "{{ maas_check_timeout_override[check_name] | default(maas_check_timeout) }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
 disabled          : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_hostname   : "{{ ansible_default_ipv4.address }}"
 details           :


### PR DESCRIPTION
Allows overridability of period and timeout values for these checks.