### PR TITLE
Make lxc import optional

### DIFF
--- a/playbooks/files/rax-maas/plugins/conntrack_count.py
+++ b/playbooks/files/rax-maas/plugins/conntrack_count.py
@@ -16,7 +16,13 @@
 
 import argparse
 import errno
-import lxc
+try:
+    import lxc
+    lxc_module_active = True
+except ImportError:
+    lxc_module_active = False
+    pass
+
 import maas_common
 import tempfile
 
@@ -106,6 +112,10 @@ def main():
         if not args.container:
             metrics = get_metrics()
         else:
+            if not lxc_module_active:
+                raise maas_common.MaaSException('Container monitoring '
+                                                'requested but lxc-python '
+                                                'pip module not installed.')
             metrics = get_metrics_lxc_container(args.container)
 
     except maas_common.MaaSException as e:


### PR DESCRIPTION
Some nodes like compute nodes don't necessarily have lxc installed
but the conntrack monitor expect it for container monitoring.
This fix makes the lxc module optional for bare metal conntrack
checks.