### PR TITLE
CEPHSTORA-116 Exclude nbd devices from disk util checks

### DIFF
--- a/playbooks/vars/maas-host.yml
+++ b/playbooks/vars/maas-host.yml
@@ -57,7 +57,7 @@ maas_filesystem_critical_threshold: 90.0
 _maas_disk_util_devices: |
   ---
   {% for device in ansible_devices.keys() %}
-  {%   if (device not in maas_excluded_devices | default([])) and (ansible_devices[device].model != 'VIRTUAL-DISK') and (ansible_devices[device].model != 'QEMU DVD-ROM') %}
+  {%   if (device not in maas_excluded_devices | default([])) and (ansible_devices[device].model != 'VIRTUAL-DISK') and (ansible_devices[device].model != 'QEMU DVD-ROM') and ('nbd' not in device) %}
   - "{{ device }}"
   {%   endif %}
   {% endfor %}


### PR DESCRIPTION
nbd devices get generated once the benchmark tool is run as part of
Ceph. This creates devices that are then automatically picked up. We
shouldn't monitor these.

Whilst the devices are unmapped, the /dev/nbdx devices stay around, and
can't be removed.