### PR TITLE
CEPHSTORA-106 Update ceph_monitoring.py for Luminous

### DIFF
--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -124,10 +124,15 @@ def get_cluster_statistics(client=None, keyring=None, container_name=None):
                                   keyring=keyring,
                                   container_name=container_name)
     # Get overall cluster health
+    # For luminous+ this is the ceph_status.health.status
+    # For < Luminous this is the ceph_status.health.overall_status
+    ceph_health_status = ceph_status['health']['overall_status']
+    if 'status' in ceph_status['health']:
+        ceph_health_status = ceph_status['health']['status']
     metrics.append({
         'name': 'cluster_health',
         'type': 'uint32',
-        'value': STATUSES[ceph_status['health']['overall_status']]})
+        'value': STATUSES[ceph_health_status]})
 
     # Collect epochs for the mon and osd maps
     metrics.append({'name': "monmap_epoch",


### PR DESCRIPTION
Since Luminous the "overall_status" field in the json output for Ceph
has "HEALTH_WARNING" to alert you to the fact it has changed. With the
following message:

"overall_status":"HEALTH_WARN","detail":["'ceph health' JSON format
has changed in luminous. If you see this your monitoring system is
scraping the wrong fields. Disable this with 'mon health preluminous
compat warning = false'"

We can set the compat warning = false setting, but it would be a better
approach to monitor the correct value.

In order to make this change backwards compatible with Ceph versions
less than Jewel, we will need to use the "overall_status" field when the
"status" field does not exist (e.g. in Jewel).