### PR TITLE
CEPHSTORA-123 Fix rgw_stats checks

### DIFF
--- a/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
@@ -1,9 +1,7 @@
 {% set label = "ceph_rgw_stats" %}
 {% set check_name = label+'--'+inventory_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
-{% set _ = ceph_args.extend(["rgw", "--rgw_port", "8080"]) %}
-{% set _ = ceph_args.extend(["--rgw_host", ansible_host]) %}
-{% set _ = ceph_args.extend(["--rgw_protocol", ceph_radosgw_protocol]) %}
+{% set _ = ceph_args.extend(["rgw", "--rgw_address", ceph_radosgw_protocol + "://" + ansible_host + ":8080"]) %}
 {% set _ceph_args = ceph_args | to_yaml(width=1000) %}
 {% set ceph_args = _ceph_args %}
 


### PR DESCRIPTION
MaaS was having issues adding RGW status checks and alarms. When
attempting to use a minimized number of fields this worked fine. This PR
adjusts it to consolidate all the rgw options (rgw_host, protocol and
port) into 1 rgw_address option which consists of the 3 put together.