### PR TITLE
Parameterize statistic used for Rally alarms

### DIFF
--- a/playbooks/templates/rax-maas/rally_check.yaml.j2
+++ b/playbooks/templates/rax-maas/rally_check.yaml.j2
@@ -11,6 +11,7 @@
 {% set duration_threshold_percent = item.value.duration_threshold %}
 {% set duration_threshold_seconds = (period*item.value.duration_threshold/100.0)|float %}
 {% set influxdb = maas_rally_influxdb_enabled %}
+{% set stat = item.value.alarm_stat %}
 
 type        : agent.plugin
 label       : "{{ check_name }}"
@@ -22,16 +23,16 @@ details     :
     args    : ["{{ maas_plugin_dir }}/rally_performance.py", "{{ name }}", "-t {{ times }}", "-c {{ concurrency }}" {% if influxdb %}, "--influxdb" {% endif %} {% for k,v in item.value.extra_vars.iteritems() | list %}, "-e {{k}}={{v}}" {% endfor %}]
     timeout : {{ timeout * 1000 | int}}
 alarms      :
-    rally_{{ name }}_total_95pctl :
-        label                   : rally_{{ name }}_total_95pctl--{{ inventory_hostname }}
+    rally_{{ name }}_total_{{ stat }} :
+        label                   : rally_{{ name }}_total_{{ stat }}--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (("rally_{{ name }}_total_95pctl--{{ inventory_hostname }}") | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (("rally_{{ name }}_total_{{ stat }}--{{ inventory_hostname }}") | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ alarm_consecutive_count }}
-            if (metric['{{ name }}_total_95pctl'] > {{ warn_threshold }}) {
+            if (metric['{{ name }}_total_{{ stat }}'] > {{ warn_threshold }}) {
                 return new AlarmStatus(CRITICAL, "{{ name }} performance metric exceeds warning threshold of {{ warn_threshold }} seconds");
             }
-            if (metric['{{ name }}_total_95pctl'] > {{ crit_threshold }}) {
+            if (metric['{{ name }}_total_{{ stat }}'] > {{ crit_threshold }}) {
                 return new AlarmStatus(CRITICAL, "{{ name }} performance metric exceeds BREACH threshold of {{ crit_threshold }} seconds");
             }
     rally_{{ name }}_maas_check_duration :

--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -218,6 +218,7 @@ maas_rally_pip_packages:
 #  about each variable.
 #
 maas_rally_default_times: 1
+maas_rally_default_alarm_stat: mean
 maas_rally_default_concurrency: 1
 maas_rally_default_poll_interval: 1800
 maas_rally_default_duration_threshold: 75
@@ -237,6 +238,7 @@ maas_rally_check_default_template:
   enabled: false
   times: "{{ maas_rally_default_times }}"
   concurrency: "{{ maas_rally_default_concurrency }}"
+  alarm_stat: "{{ maas_rally_default_alarm_stat }}"
   warn_threshold: "{{ maas_rally_default_warn_threshold }}"
   crit_threshold: "{{ maas_rally_default_crit_threshold }}"
   poll_interval: "{{ maas_rally_default_poll_interval }}"


### PR DESCRIPTION
This commit makes the following changes parameterizes the description statistic that is used for alarm criteria.  The default metric also changes from '95pctl' to 'mean', which makes more sense for the default setting of concurrency = 1.