### PR TITLE
Split warning and critical to separate alarms

### DIFF
--- a/playbooks/templates/rax-maas/rally_check.yaml.j2
+++ b/playbooks/templates/rax-maas/rally_check.yaml.j2
@@ -23,15 +23,21 @@ details     :
     args    : ["{{ maas_plugin_dir }}/rally_performance.py", "{{ name }}", "-t {{ times }}", "-c {{ concurrency }}" {% if influxdb %}, "--influxdb" {% endif %} {% for k,v in item.value.extra_vars.iteritems() | list %}, "-e {{k}}={{v}}" {% endfor %}]
     timeout : {{ timeout * 1000 | int}}
 alarms      :
-    rally_{{ name }}_total_{{ stat }} :
-        label                   : rally_{{ name }}_total_{{ stat }}--{{ inventory_hostname }}
+    rally_{{ name }}_total_{{ stat }}_warn :
+        label                   : rally_{{ name }}_total_{{ stat }}_warn--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (("rally_{{ name }}_total_{{ stat }}--{{ inventory_hostname }}") | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (("rally_{{ name }}_total_{{ stat }}_warn--{{ inventory_hostname }}") | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ alarm_consecutive_count }}
             if (metric['{{ name }}_total_{{ stat }}'] > {{ warn_threshold }}) {
                 return new AlarmStatus(CRITICAL, "{{ name }} performance metric exceeds warning threshold of {{ warn_threshold }} seconds");
             }
+    rally_{{ name }}_total_{{ stat }}_crit :
+        label                   : rally_{{ name }}_total_{{ stat }}_crit--{{ inventory_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (("rally_{{ name }}_total_{{ stat }}_crit--{{ inventory_hostname }}") | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ alarm_consecutive_count }}
             if (metric['{{ name }}_total_{{ stat }}'] > {{ crit_threshold }}) {
                 return new AlarmStatus(CRITICAL, "{{ name }} performance metric exceeds BREACH threshold of {{ crit_threshold }} seconds");
             }


### PR DESCRIPTION
This PR splits the logical warning and critical states into separate
alerts.

A story is required to understand why this is necessary.  Currently, the
process that transform MaaS events into CORE tickets null routes MaaS events
matching the WARNING status.  To work around this, both the logical warning
and critical states were mapped to the MaaS CRITICAL state to ensure a ticket
was generated in CORE.  This ensured support received a ticket and could
investigate.  However, MaaS also does not re-issue an event just because a
status message (i.e. from warning to BREACH) changed, which is a problem
when you need to distinguish between logical warning and critical states for
reporting.

So, after this change we will receive a NEW alert when a metric transitions
from a logical warning state to a logical critical state.