### PR TITLE
RI-133: Inital MaaS Commit for Designate

### DIFF
--- a/playbooks/files/rax-maas/plugins/designate_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/designate_api_local_check.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+# Copyright 2018, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import datetime
+
+import ipaddr
+from maas_common import get_auth_ref
+from maas_common import get_endpoint_url_for_service
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+import requests
+
+
+def check(auth_ref, args):
+    DESIGNATE_ENDPOINT = '{protocol}://{ip}:9001/'.format(
+        protocol=args.protocol, ip=args.ip)
+
+    try:
+        if args.ip:
+            endpoint = DESIGNATE_ENDPOINT
+        else:
+            endpoint = get_endpoint_url_for_service(
+                'dns', auth_ref, 'internal')
+        # time something arbitrary
+        start = datetime.datetime.now()
+        r = requests.get(endpoint)
+        end = datetime.datetime.now()
+        api_is_up = (r.status_code == 200)
+    except (requests.HTTPError, requests.Timeout, requests.ConnectionError):
+        api_is_up = False
+        metric_bool('client_success', False, m_name='maas_designate')
+    # Any other exception presumably isn't an API error
+    except Exception as e:
+        metric_bool('client_success', False, m_name='maas_designate')
+        status_err(str(e), m_name='maas_designate')
+    else:
+        metric_bool('client_success', True, m_name='maas_designate')
+        dt = (end - start)
+        milliseconds = (dt.microseconds + dt.seconds * 10 ** 6) / 10 ** 3
+
+    status_ok(m_name='maas_designate')
+    metric_bool('designate_api_local_status',
+                api_is_up, m_name='maas_designate')
+    if api_is_up:
+        # only want to send other metrics if api is up
+        metric('designate_api_local_response_time',
+               'double',
+               '%.3f' % milliseconds,
+               'ms')
+
+
+def main(args):
+    auth_ref = get_auth_ref()
+    check(auth_ref, args)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Check Designate API against local or remote address')
+    parser.add_argument('protocol', nargs='?',
+                        help="Protocol for check (http or https)")
+    parser.add_argument('ip', nargs='?', type=ipaddr.IPv4Address,
+                        help="Check Designate API against "
+                        " local or remote address")
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
+        main(args)

--- a/playbooks/files/rax-maas/plugins/designate_mdns_local_check.py
+++ b/playbooks/files/rax-maas/plugins/designate_mdns_local_check.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+# Copyright 2018, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import datetime
+
+import dns.message
+import dns.query
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+
+
+def check(args):
+    try:
+        # attempt a query to example.com
+        # return good check on any valid response
+        start = datetime.datetime.now()
+        message = dns.message.make_query("example.org", "A")
+        answer = dns.query.udp(message, timeout=5, where=args.ip, port=5354)
+        end = datetime.datetime.now()
+        # int of return code
+        mdns_is_up = (answer.rcode() <= 16)
+    except (dns.exception.Timeout):
+        mdns_is_up = False
+        metric_bool('client_success', False, m_name='maas_designate')
+    except Exception as e:
+        metric_bool('client_success', False, m_name='maas_designate')
+        status_err(str(e), m_name='maas_designate')
+    else:
+        metric_bool('client_success', True, m_name='maas_designate')
+        dt = (end - start)
+        milliseconds = (dt.microseconds + dt.seconds * 10 ** 6) / 10 ** 3
+
+    status_ok(m_name='maas_designate')
+    metric_bool('designate_mdns_local_status',
+                mdns_is_up, m_name='maas_designate')
+    if mdns_is_up:
+        # only want to send other metrics if api is up
+        metric('designate_mdns_local_response_time',
+               'double',
+               '%.3f' % milliseconds,
+               'ms')
+
+
+def main(args):
+    check(args)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Check Designate MDNS against local or remote address')
+    parser.add_argument('ip', nargs='?',
+                        help="Check Designate mdns service against "
+                        " local or remote address")
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
+        main(args)

--- a/playbooks/maas-openstack-all.yml
+++ b/playbooks/maas-openstack-all.yml
@@ -17,6 +17,10 @@
   tags:
     - maas-openstack
 
+- include: maas-openstack-designate.yml
+  tags:
+    - maas-openstack
+
 - include: maas-openstack-glance.yml
   tags:
     - maas-openstack

--- a/playbooks/maas-openstack-designate.yml
+++ b/playbooks/maas-openstack-designate.yml
@@ -1,0 +1,104 @@
+---
+# Copyright 2018, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Gather facts
+  hosts: designate_all
+  gather_facts: "{{ gather_facts | default(true) }}"
+  pre_tasks:
+    - include: "common-tasks/maas_excluded_regex.yml"
+    - include: "common-tasks/maas_get_openrc.yml"
+    - name: Set the current group
+      set_fact:
+        maas_current_group: designate_all
+
+  tasks:
+    - name: Copy over pip constraints
+      copy:
+        src: "files/pip-constraints.txt"
+        dest: "/tmp/pip-constraints.txt"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+  post_tasks:
+    - name: Install designate pip packages to venv
+      pip:
+        name: "{{ maas_openstack_designate_pip_packages | join(' ') }}"
+        state: "{{ maas_pip_package_state }}"
+        extra_args: >-
+          --isolated
+          --constraint /tmp/pip-constraints.txt
+          {{ pip_install_options | default('') }}
+        virtualenv: "{{ maas_venv }}"
+      register: install_pip_packages
+      until: install_pip_packages|success
+      retries: 5
+      delay: 2
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas-openstack.yml
+  tags:
+    - maas-openstack-designate
+
+- name: Install checks for openstack designate
+  hosts: designate_all
+  gather_facts: false
+  tasks:
+    - name: Install designate api checks
+      template:
+        src: "templates/rax-maas/designate_api_local_check.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/designate_api_local_check--{{ inventory_hostname }}.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+    - name: Install designate mdns checks
+      template:
+        src: "templates/rax-maas/designate_mdns_local_check.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/designate_mdns_local_check--{{ inventory_hostname }}.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+    - name: Install designate lb checks
+      template:
+        src: "templates/rax-maas/lb_api_check_designate.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/lb_api_check_designate.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_remote_check | bool
+        - not maas_private_monitoring_enabled
+
+    - name: Install designate private lb checks
+      template:
+        src: "templates/rax-maas/private_lb_api_check_designate.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/private_lb_api_check_designate.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - maas_private_monitoring_enabled
+        - maas_private_monitoring_zone is defined
+  vars_files:
+    - vars/main.yml
+    - vars/maas-openstack.yml
+  tags:
+    - maas-openstack-designate

--- a/playbooks/templates/rax-maas/designate_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/designate_api_local_check.yaml.j2
@@ -1,0 +1,20 @@
+{% set label = "designate_api_local_check" %}
+{% set check_name = label+'--'+inventory_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}/designate_api_local_check.py", "http", "{{ ansible_host }}"]
+alarms      :
+    designate_api_local_status :
+        label                   : "designate_api_local_status--{{ inventory_hostname }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (('designate_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["designate_api_local_status"] != 1) {
+                return new AlarmStatus(CRITICAL, "Designate API unavailable");
+            }

--- a/playbooks/templates/rax-maas/designate_mdns_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/designate_mdns_local_check.yaml.j2
@@ -1,0 +1,20 @@
+{% set label = "designate_mdns_local_check" %}
+{% set check_name = label+'--'+inventory_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}/designate_mdns_local_check.py", "{{ ansible_host }}"]
+alarms      :
+    designate_local_status :
+        label                   : "designate_local_status--{{ inventory_hostname }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (('designate_local_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["designate_mdns_local_status"] != 1) {
+                return new AlarmStatus(CRITICAL, "designate mdns unavailable");
+            }

--- a/playbooks/templates/rax-maas/designate_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/designate_process_check.yaml.j2
@@ -1,0 +1,22 @@
+{% set label = "designate_process_check" %}
+{% set check_name = label+'--'+inventory_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}/process_check_{% if inventory_hostname in groups['all_containers'] | default([]) %}container.py", "-c", "{{ inventory_hostname }}", "{% else %}host.py", "{% endif %}{{ designate_process_names|join("\", \"") }}"]
+alarms      :
+{% for process in designate_process_names_sanitized %}
+    {{ process }}_process_status:
+        label                   : {{ process }}_process_status--{{ inventory_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ ((process+'_process_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["{{ process }}_process_status"] != 1 ) {
+                return new AlarmStatus(CRITICAL, "designate process {{ process }} not running on {{ inventory_hostname }}");
+            }
+{% endfor %}

--- a/playbooks/templates/rax-maas/lb_api_check_designate.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_designate.yaml.j2
@@ -1,0 +1,25 @@
+{% set label = "lb_api_check_designate" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (inventory_hostname != groups['designate_all'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ maas_external_ip_address }}"
+details           :
+    url           : "{{ maas_designate_scheme | default(maas_scheme)}}://{{ maas_external_hostname }}:9001"
+monitoring_zones_poll:
+{% for zone in maas_monitoring_zones %}
+  - {{ zone }}
+{% endfor %}
+alarms            :
+    lb_api_alarm_designate       :
+        label               : lb_api_alarm_designate
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('lb_api_alarm_designate' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '200') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/templates/rax-maas/private_lb_api_check_designate.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_designate.yaml.j2
@@ -1,0 +1,23 @@
+{% set label = "private_lb_api_check_designate" %}
+{% set check_name = label+'--'+maas_lb_name %}
+type              : remote.http
+label             : "{{ check_name }}"
+period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled          : "{{ (inventory_hostname != groups['designate_all'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+target_resolver   : "IPv4"
+target_hostname   : "{{ maas_external_ip_address }}"
+details           :
+    url           : "{{ maas_designate_scheme | default(maas_scheme) }}://{{ maas_external_hostname }}:9001"
+monitoring_zones_poll:
+  - "{{ maas_private_monitoring_zone }}"
+alarms            :
+    private_lb_api_alarm_designate     :
+        label               : private_lb_api_alarm_designate
+        notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled            : {{ ('private_lb_api_alarm_designate' | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria            : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric['code'] != '200') {
+                return new AlarmStatus(CRITICAL, 'API unavailable.');
+            }

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -28,6 +28,7 @@ maas_horizon_scheme: https
 # maas_ironic_api_scheme: https
 # maas_maas_swift_proxy_scheme: https
 # maas_octavia_scheme: https
+# maas_designate_scheme: https
 
 #
 # pip installable packages for given services used within maas
@@ -36,6 +37,11 @@ maas_openstack_cinder_pip_packages:
   - python-cinderclient
   - python-keystoneclient
 
+maas_openstack_designate_pip_packages:
+  - python-designateclient
+  - python-keystoneclient
+  - dnspython
+  
 maas_openstack_glance_pip_packages:
   - python-glanceclient
   - python-keystoneclient
@@ -190,3 +196,11 @@ octavia_quota_names:
   - octavia_server_group_quota_usage
   - octavia_volume_gb_quota_usage
   - octavia_num_volume_quota_usage
+
+designate_process_names:
+  - designate-sink
+  - designate-worker
+  - designate-central
+  - designate-producer
+  - designate-api
+  - designate-mdns


### PR DESCRIPTION
Initial commit for monitoring designate services the checks include scripts for performing local checks for the API and the designate-mdns service. Created a template for checking designate service processes but not currently creating a check for those processes. 