### PR TITLE
Enable http authentication for influxdb and telegraf

### DIFF
--- a/playbooks/maas-tigkstack-influxdb.yml
+++ b/playbooks/maas-tigkstack-influxdb.yml
@@ -86,6 +86,16 @@
         port: "{{ influxdb_port }}"
         delay: 1
 
+    - name: Create influxdb admin user
+      command: >
+        influx -username {{ influxdb_db_root_name }}
+        -password {{ influxdb_db_root_password }}
+        -execute "{{ item }}"
+      changed_when: false
+      no_log: True
+      with_items:
+        - "CREATE USER {{ influxdb_db_root_name }} WITH PASSWORD '{{ influxdb_db_root_password }}' WITH ALL PRIVILEGES"
+
     - name: Create metrics DB
       command: >
         influx -username {{ influxdb_db_root_name }}
@@ -98,6 +108,18 @@
         - "CREATE RETENTION POLICY {{ influxdb_db_retention_policy }} ON {{ influxdb_db_name }} DURATION {{ influxdb_db_retention }} REPLICATION {{ influxdb_db_replication }} DEFAULT"
         - "CREATE USER {{ influxdb_db_metric_user }} WITH PASSWORD '{{ influxdb_db_metric_password }}'"
         - "GRANT ALL ON {{ influxdb_db_name }} TO {{ influxdb_db_metric_user }}"
+
+    - name: Enable influxdb http authentication
+      replace:
+        dest: /etc/influxdb/influxdb.conf
+        regexp: '^  auth-enabled = false'
+        replace: '  auth-enabled = true'
+
+    - name: Restart influxdb to enable authentication
+      service:
+        name: "influxdb"
+        enabled: true
+        state: restarted
 
     - name: Install GOLang
       script: files/tigkstack/deploy_go.sh

--- a/playbooks/templates/tigkstack/telegraf.conf.j2
+++ b/playbooks/templates/tigkstack/telegraf.conf.j2
@@ -32,6 +32,7 @@ takes to get metrics, worst case scenario.
   quiet = true
   hostname = "{{ inventory_hostname }}"
   omit_hostname = false
+  logfile = "/var/log/telegraf/telegraf.log"
 
 {%   set influx_targets = [] %}
 {%   for item in groups['influx_hosts'] | default([]) %}
@@ -46,6 +47,8 @@ takes to get metrics, worst case scenario.
   precision = "s"
   write_consistency = "any"
   timeout = "30s"
+  username = "{{ influxdb_db_metric_user }}"
+  password = "{{ influxdb_db_metric_password }}"
 
 {% if telegraf_outputs_prometheus_client | bool %}
 [[outputs.prometheus_client]]

--- a/playbooks/templates/tigkstack/telegraf.conf.j2
+++ b/playbooks/templates/tigkstack/telegraf.conf.j2
@@ -18,7 +18,7 @@ takes to get metrics, worst case scenario.
 #}
 {% set c_jitter = collection_jitter | default(8) %}
 {% set input_timeout = input_command_timeout | default(5) %}
-{% set f_interval = (interval + (c_jitter + input_timeout)) | int | round + 2 %}
+{% set f_interval = (interval + (c_jitter + input_timeout | int)) | int | round + 2 %}
 
 [agent]
   interval = "{{ interval | round }}s"


### PR DESCRIPTION
Initial commit to enabling authentication between influxdb and telgraf. Requires some additional testing/validation.