### PR TITLE
Add pip to InfluxDB container for grafana playbook

### DIFF
--- a/playbooks/maas-tigkstack-grafana.yml
+++ b/playbooks/maas-tigkstack-grafana.yml
@@ -105,6 +105,57 @@
         - groups['galera_all'] | default([]) | length > 0
 
   post_tasks:
+    - name: Copy over pip constraints
+      copy:
+        src: "files/pip-constraints.txt"
+        dest: "/tmp/pip-constraints.txt"
+
+    - name: Check for pip
+      command: pip --version
+      failed_when: false
+      changed_when:
+        - pip_present.rc != 0
+      register: pip_present
+
+    - name: Get Modern PIP
+      get_url:
+        url: "{{ maas_pip_upstream_url }}"
+        dest: "/opt/get-pip.py"
+        force: true
+        validate_certs: "{{ maas_pip_validate_certs }}"
+      register: get_pip
+      until: get_pip | success
+      retries: 5
+      delay: 2
+      when:
+        - pip_present.rc != 0
+
+    - name: Install Modern PIP
+      command: >
+        python /opt/get-pip.py {{ maas_pip_source_install_options }}
+                               {{ maas_pip_get_pip_options }}
+                               {{ maas_pip_install_packages | map('quote') | join (' ') }}
+      changed_when: pip_install.stdout.find('Successfully installed') != -1
+      register: pip_install
+      until: pip_install | success
+      retries: 3
+      delay: 2
+      when:
+        - pip_present.rc != 0
+
+    - name: Install maas_influx pip packages
+      pip:
+        name: "{{ maas_influx_pip_packages | join(' ') }}"
+        state: "{{ maas_pip_package_state }}"
+        extra_args: >-
+          --isolated
+          --constraint /tmp/pip-constraints.txt
+          {{ pip_install_options | default('') }}
+      register: install_pip_packages
+      until: install_pip_packages | success
+      retries: 5
+      delay: 2
+
     - name: Check for the RPC-MaaS InfluxDB connection
       _uri:
         force_basic_auth: yes
@@ -177,5 +228,6 @@
   vars_files:
     - vars/main.yml
     - vars/maas-tigkstack.yml
+    - vars/maas-agent.yml
   tags:
     - maas-tigkstack-grafana

--- a/playbooks/vars/maas-tigkstack.yml
+++ b/playbooks/vars/maas-tigkstack.yml
@@ -630,3 +630,6 @@ maas_telegraf_format_pip_packages:
   - "PyYAML"
 
 maas_telegraf_regex_pat: ".*"
+
+maas_influx_pip_packages:
+  - "requests"


### PR DESCRIPTION
In ansible 1.9, the URI module requires `requests` python module to add the RPC-MaaS connector to InfluxDB. This change adds pip and requests to the container which allows the grafana playbook to create the connector properly.