### PR TITLE
TURTLES-673: Phase 1 maas_rally improvements

### DIFF
--- a/playbooks/files/rax-maas/plugins/rally_performance.py
+++ b/playbooks/files/rax-maas/plugins/rally_performance.py
@@ -71,56 +71,85 @@ class PluginConfig(object):
 
 
 def cleanup_task_resources(task_uuid, scenario, scenario_config, logger):
-    logger.warn("{} - preparing stale resource cleanup for task {}".format(args.task, task_uuid))
+    logger.warn("{} - preparing stale resource cleanup for "
+                "task {}".format(args.task, task_uuid))
 
-    auth_details = maas_common.get_auth_details()
-    auth_ref = maas_common.get_auth_ref()
-    endpoint_type = maas_common.get_endpoint_type(auth_details)
-
-    auth = { 'project_name': scenario_config['project'],
-             'username': scenario_config['user_name'],
-             'password': scenario_config['user_password'] }
+    auth = {'project_name': scenario_config['project'],
+            'username': scenario_config['user_name'],
+            'password': scenario_config['user_password']}
 
     conn = openstack.connect(cloud='default', auth=auth)
 
-    # this extracts the first part of the task UUID - e.g. AAA from AAA-BBB-CCC-DDD
+    # this extracts the first part of the task UUID - e.g. AAA from
+    # AAA-BBB-CCC-DDD
     resource_tag = 's_rally_' + re.search('(.*?)-.*', task_uuid).group(1)
 
     if 'volume' in scenario_config['primary_resources']:
         for volume in conn.block_storage.volumes():
             if resource_tag in volume.name:
                 if volume.status == 'available':
-                    logger.warn("{} - deleting task {}'s volume {}".format(args.task, task_uuid, volume.name))
-                    conn.block_storage.delete_volume(volume.id, ignore_missing=False)
+                    logger.warn("{} - deleting task {}'s volume "
+                                "{}".format(args.task,
+                                            task_uuid,
+                                            volume.name))
+                    conn.block_storage.delete_volume(volume.id,
+                                                     ignore_missing=False)
                 else:
-                    logger.warn("{} - found stale volume {} for task {}, but it's in '{}' status so we won't try to delete it directly".format(args.task, volume.name, task_uuid, volume.status))
+                    logger.warn("{} - found stale volume {} for task {}, but "
+                                "it's in '{}' status so we won't try to delete"
+                                " it directly".format(args.task,
+                                                      volume.name,
+                                                      task_uuid,
+                                                      volume.status))
 
     if 'compute' in scenario_config['primary_resources']:
         for server in conn.compute.servers():
             if resource_tag in server.name:
-                logger.warn("{} - deleting task {}'s server {}".format(args.task, task_uuid, server.name))
-                target = conn.compute.find_server(server.name, ignore_missing=False)
+                logger.warn("{} - deleting task {}'s server "
+                            "{}".format(args.task,
+                                        task_uuid,
+                                        server.name))
+                target = conn.compute.find_server(server.name,
+                                                  ignore_missing=False)
                 conn.compute.delete_server(target)
 
     if 'image' in scenario_config['primary_resources']:
         for image in conn.image.images():
             if resource_tag in image.name:
-                logger.warn("{} - deleting task {}'s image {} ({}). it was in '{}' state.".format(args.task, task_uuid, image.name, image.id, image.status))
-                conn.image.delete_image(image.id, ignore_missing=False)
+                logger.warn("{} - deleting task {}'s image {} ({}). it was in "
+                            "'{}' state.".format(args.task,
+                                                 task_uuid,
+                                                 image.name,
+                                                 image.id,
+                                                 image.status))
+                conn.image.delete_image(image.id,
+                                        ignore_missing=False)
 
     if 'port' in scenario_config['primary_resources']:
         for port in conn.network.ports():
             if resource_tag in port.name:
-                logger.warn("{} - deleting task {}'s port {} ({}).".format(args.task, task_uuid, port.name, port.id))
-                conn.network.delete_port(port.id, ignore_missing=False)
+                logger.warn("{} - deleting task {}'s port {} "
+                            "{}).".format(args.task,
+                                          task_uuid,
+                                          port.name,
+                                          port.id))
+                conn.network.delete_port(port.id,
+                                         ignore_missing=False)
 
     if 'secgroup' in scenario_config['primary_resources']:
         for secgroup in conn.network.security_groups():
             if resource_tag in secgroup.name:
-                logger.warn("{} - deleting task {}'s secgroup {} ({}).".format(args.task, task_uuid, secgroup.name, secgroup.id))
-                conn.network.delete_security_group(secgroup.id, ignore_missing=False)
+                logger.warn("{} - deleting task {}'s secgroup {} "
+                            "({}).".format(args.task,
+                                           task_uuid,
+                                           secgroup.name,
+                                           secgroup.id))
+                conn.network.delete_security_group(secgroup.id,
+                                                   ignore_missing=False)
 
-    logger.warn("{} - finished stale resource cleanup for task {}".format(args.task, task_uuid))
+    logger.warn("{} - finished stale resource cleanup for "
+                "task {}".format(args.task, task_uuid))
+
 
 def send_metrics_to_influxdb(plugin_config, logger):
     influx_config = plugin_config['influxdb']
@@ -144,7 +173,10 @@ def send_metrics_to_influxdb(plugin_config, logger):
                                  maas_common.TELEGRAF_METRICS['variables']
                                  .iteritems())
 
-    logger.debug("{} - writing metrics to influxdb database '{}' at {}".format(args.task, influx_database, influx_host + ':' + str(influx_port)))
+    logger.debug("{} - writing metrics to influxdb database "
+                 "'{}' at {}".format(args.task,
+                                     influx_database,
+                                     influx_host + ':' + str(influx_port)))
     client.write_points([influx_data])
     logger.debug("{} - sent influx_data: {}".format(args.task, influx_data))
 
@@ -153,6 +185,7 @@ def setup_logging(plugin_config):
     logging.config.dictConfig(plugin_config['logging'])
     logger = logging.getLogger("maas_rally")
     return logger
+
 
 def make_parser():
     parser = argparse.ArgumentParser(
@@ -202,7 +235,10 @@ def parse_task_results(task_uuid, task_result, logger):
 
         # Quota exceeded would be a typical error here
         if task_result['result'][0]['error']:
-            logger.critical("{} - rally task {} encountered an error: {}".format(args.task, task_uuid, task_result['result'][0]['error']))
+            logger.critical("{} - rally task {} encountered an error: "
+                            "{}".format(args.task,
+                                        task_uuid,
+                                        task_result['result'][0]['error']))
             status_err(' '.join(task_result['result'][0]['error']),
                        m_name='maas_rally')
         metric('rally_load_duration', 'double',
@@ -216,8 +252,8 @@ def parse_task_results(task_uuid, task_result, logger):
                '{}'.format(task_result['key']['kw']['runner']['concurrency']))
 
     except KeyError:
-        # The alarms need a value here.  Setting it to 0 allows us to handle plugin
-        # errors without forcing an alarm event.
+        # The alarms need a value here.  Setting it to 0 allows us to handle
+        # plugin errors without forcing an alarm event.
         if not action_data[args.task + '_total']:
             action_data[args.task + '_total'] = [0]
 
@@ -245,7 +281,8 @@ def main():
     logger = setup_logging(plugin_config)
 
     if logger.getEffectiveLevel() == logging.DEBUG:
-        logger.debug("{} - maas_rally plugin started with args {}".format(args.task, args))
+        logger.debug("{} - maas_rally plugin started with args "
+                     "{}".format(args.task, args))
     else:
         logger.info("{} - maas_rally plugin started".format(args.task))
 
@@ -253,12 +290,14 @@ def main():
     tasks_path = os.path.realpath(TASKS_PATH)
     task_file = tasks_path + '/' + args.task + '.yml'
     if not os.path.isfile(task_file):
-        logger.critical("{} - unable to locate task definition file {}".format(args.task, task_file))
+        logger.critical("{} - unable to locate task definition "
+                        "file {}".format(args.task, task_file))
         status_err('Unable to locate task definition '
                    'for {} in {}'.format(args.task, tasks_path),
                    m_name='maas_rally')
     else:
-        logger.debug("{} - using task definition file {}".format(args.task, task_file))
+        logger.debug("{} - using task definition file "
+                     "{}".format(args.task, task_file))
 
     if not os.path.exists(LOCKS_PATH):
         os.makedirs(LOCKS_PATH)
@@ -271,43 +310,67 @@ def main():
 
     logger.debug("{} - checking for locks".format(args.task))
     LOCK_PATH = LOCKS_PATH + '/' + args.task + '/'
-    results = {'result': {} }
+    results = {'result': {}}
     wait_for_lock = False
 
     if os.path.exists(LOCK_PATH):
         lock_uuid = os.listdir(LOCK_PATH)[0]
         lock_mtime = os.stat(LOCK_PATH + lock_uuid)[8]
         lock_duration = time.time() - lock_mtime
-        lock_removal_threshold = plugin_config['scenarios'][args.task]['poll_interval'] * .95
-        logger.warning("{} - found existing lock for rally task {} from {} seconds ago".format(args.task, lock_uuid, lock_duration))
+        interval = plugin_config['scenarios'][args.task]['poll_interval']
+        lock_removal_threshold = interval * .95
+        logger.warning("{} - found existing lock for rally task {} from {} "
+                       "seconds ago".format(args.task,
+                                            lock_uuid,
+                                            lock_duration))
         try:
-            logger.debug("{} - checking status for locking task {})".format(args.task, lock_uuid))
+            logger.debug("{} - checking status for locking task "
+                         "{}".format(args.task, lock_uuid))
             task_status = rapi.task.get(lock_uuid)['status']
-            logger.debug("{} - status for locking task {}: {})".format(args.task, lock_uuid, task_status))
+            logger.debug("{} - status for locking task {}: "
+                         "{}".format(args.task, lock_uuid, task_status))
 
             if task_status == 'finished':
-                logger.warning("{} - task {} was finished - removing lock".format(args.task, lock_uuid))
+                logger.warning("{} - task {} was finished - removing "
+                               "lock".format(args.task, lock_uuid))
             elif task_status == 'init' and lock_duration > 30:
-                logger.warning("{} - task {} was in init state for > 30 seconds - removing lock".format(args.task, lock_uuid))
+                logger.warning("{} - task {} was in init state for > 30 "
+                               "seconds - removing lock".format(args.task,
+                                                                lock_uuid))
             elif lock_duration > lock_removal_threshold:
-                logger.warning("{} - task {} has been locked for more than 95% of poll interval - removing lock".format(args.task, lock_uuid))
+                logger.warning("{} - task {} has been locked for more than 95%"
+                               " of poll interval - removing "
+                               "lock".format(args.task, lock_uuid))
             else:
-                logger.warning("{} - task {} has been locked for {} seconds, which is less than the removal threshold of {} seconds. try again after {} seconds".format(args.task, lock_uuid, lock_duration, lock_removal_threshold, lock_removal_threshold - lock_duration))
+                lock_remaining_time = lock_removal_threshold - lock_duration
+                logger.warning("{} - task {} has been locked for {} seconds, "
+                               "which is less than the removal threshold of "
+                               "{} seconds. try again after {} "
+                               "seconds".format(args.task,
+                                                lock_uuid,
+                                                lock_duration,
+                                                lock_removal_threshold,
+                                                lock_remaining_time))
                 wait_for_lock = True
 
         except rally.exceptions.TaskNotFound:
-            logger.warning("{} - task {} not found in rally db - removing lock".format(args.task, lock_uuid))
+            logger.warning("{} - task {} not found in rally db "
+                           "- removing lock".format(args.task, lock_uuid))
 
-        if  wait_for_lock:
+        if wait_for_lock:
             metric('delayed_by_lock', 'uint32', 1)
             metric('resource_cleanup', 'uint32', 0)
         else:
             metric('delayed_by_lock', 'uint32', 0)
             metric('resource_cleanup', 'uint32', 1)
-            cleanup_task_resources(lock_uuid, args.task, plugin_config['scenarios'][args.task], logger)
+            cleanup_task_resources(lock_uuid,
+                                   args.task,
+                                   plugin_config['scenarios'][args.task],
+                                   logger)
             os.rmdir(LOCK_PATH + '/' + lock_uuid)
             os.rmdir(LOCK_PATH)
-            logger.warning("{} - stale lock for {} removed".format(args.task, lock_uuid))
+            logger.warning("{} - stale lock for {} "
+                           "removed".format(args.task, lock_uuid))
     else:
         logger.debug("{} - no lock found".format(args.task))
         metric('resource_cleanup', 'uint32', 0)
@@ -316,7 +379,8 @@ def main():
     if not wait_for_lock:
         os.mkdir(LOCK_PATH)
         os.mkdir(LOCK_PATH + '/' + task_uuid)
-        logger.debug("{} - acquired lock for task {}".format(args.task, task_uuid))
+        logger.debug("{} - acquired lock for task "
+                     "{}".format(args.task, task_uuid))
 
         task_args = {}
         if args.times is not None:
@@ -338,9 +402,11 @@ def main():
 
         parsed_task = yaml.safe_load(rendered_task)
 
-        logger.debug("{} - discovering rally plugins in {}".format(args.task, PLUGIN_PATH))
+        logger.debug("{} - discovering rally plugins "
+                     "in {}".format(args.task, PLUGIN_PATH))
         rally.common.plugin.discover.load_plugins(PLUGIN_PATH)
-        logger.debug("{} - loading rally plugins from {}".format(args.task, PLUGIN_PATH))
+        logger.debug("{} - loading rally plugins from "
+                     "{}".format(args.task, PLUGIN_PATH))
         rally.plugins.load()
         logger.info("{} - starting rally task {}".format(args.task, task_uuid))
         rapi.task.start(args.task, parsed_task, task_obj)
@@ -356,13 +422,18 @@ def main():
                    for x in task_obj.get_results()][0]
 
         if logger.getEffectiveLevel() == logging.DEBUG:
-            logger.debug("{} - rally task {} completed with results: {}".format(args.task, task_uuid, results))
+            logger.debug("{} - rally task {} completed"
+                         " with results: {}".format(args.task,
+                                                    task_uuid,
+                                                    results))
         else:
-            logger.info("{} - rally task {} completed".format(args.task, task_uuid))
+            logger.info("{} - rally task {} "
+                        "completed".format(args.task, task_uuid))
 
         os.rmdir(LOCK_PATH + '/' + task_uuid)
         os.rmdir(LOCK_PATH)
-        logger.debug("{} - removed lock for rally task {}".format(args.task, task_uuid))
+        logger.debug("{} - removed lock for rally task "
+                     "{}".format(args.task, task_uuid))
 
     parse_task_results(task_uuid, results, logger)
 

--- a/playbooks/files/rax-maas/plugins/rally_performance.py
+++ b/playbooks/files/rax-maas/plugins/rally_performance.py
@@ -300,14 +300,17 @@ def main():
 
         if  wait_for_lock:
             metric('delayed_by_lock', 'uint32', 1)
+            metric('resource_cleanup', 'uint32', 0)
         else:
             metric('delayed_by_lock', 'uint32', 0)
+            metric('resource_cleanup', 'uint32', 1)
             cleanup_task_resources(lock_uuid, args.task, plugin_config['scenarios'][args.task], logger)
             os.rmdir(LOCK_PATH + '/' + lock_uuid)
             os.rmdir(LOCK_PATH)
             logger.warning("{} - stale lock for {} removed".format(args.task, lock_uuid))
     else:
         logger.debug("{} - no lock found".format(args.task))
+        metric('resource_cleanup', 'uint32', 0)
         metric('delayed_by_lock', 'uint32', 0)
 
     if not wait_for_lock:

--- a/playbooks/files/rax-maas/plugins/rally_performance.py
+++ b/playbooks/files/rax-maas/plugins/rally_performance.py
@@ -226,6 +226,9 @@ def main():
             elif task_status == 'init' and lock_duration > 30:
                 logger.warning("{} - task {} was in init state for > 30 seconds - removed lock".format(args.task, lock_uuid))
                 os.rmdir(LOCK_PATH + '/' + lock_uuid)
+            elif lock_duration > plugin_config['scenarios'][args.task]['poll_interval'] * .95:
+                logger.warning("{} - task {} has been locked for more than 95% of poll interval - removed lock".format(args.task, lock_uuid))
+                os.rmdir(LOCK_PATH + '/' + lock_uuid)
             else:
                 logger.critical("{} - unable to remove lock by task ID {}".format(args.task, lock_uuid))
                 lock_mtime_str = time.strftime('%H:%M:%S %Y-%m-%d %Z',

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -172,7 +172,7 @@
 
     - name: Create maas_rally projects
       os_project:
-        name: "{{ item.value.project | default('rally_' + item.key) }}"
+        name: "{{ item.value.project }}"
         state: present
         cloud: default
         endpoint_type: "admin"
@@ -217,7 +217,7 @@
             --{{ quota }} \
             {{ item.value.per_iter_quotas[quota]*item.value.concurrency }} \
         {% endfor %} \
-        {{ item.value.project | default('rally_' + item.key) }}
+        {{ item.value.project }}
       with_dict: "{{ maas_rally_checks }}"
       # The quota is osc can be flaky, even though the command succeeds. For now
       # we skip failing at this point.
@@ -227,9 +227,9 @@
 
     - name: Create maas_rally users in keystone
       os_user:
-        name: "{{ item.value.user_name | default('rally_' + item.key) }}"
+        name: "{{ item.value.user_name }}"
         password: "{{ item.value.user_password }}"
-        default_project: "{{ item.value.project | default('rally_' + item.key) }}"
+        default_project: "{{ item.value.project }}"
         state: present
         cloud: default
         endpoint_type: "admin"
@@ -243,8 +243,8 @@
 
     - name: Grant _member_ role for rally users
       os_user_role:
-        user: "{{ item.value.user_name | default('rally_' + item.key) }}"
-        project: "{{ item.value.project | default('rally_' + item.key) }}"
+        user: "{{ item.value.user_name }}"
+        project: "{{ item.value.project }}"
         role: "_member_"
         state: present
         cloud: default
@@ -258,8 +258,8 @@
 
     - name: Grant extra roles for rally users
       os_user_role:
-        user: "{{ item.0.user_name | default('rally_' + item.0.check_name) }}"
-        project: "{{ item.0.project | default('rally_' + item.0.check_name) }}"
+        user: "{{ item.0.user_name }}"
+        project: "{{ item.0.project }}"
         role: "{{ item.1 }}"
         state: present
         cloud: default
@@ -333,7 +333,7 @@
         state: present
         name: "{{ item.value.net_name | default('rally_net_' + item.key) }}"
         shared: no
-        project: "{{ item.value.project | default('rally_' + item.key) }}"
+        project: "{{ item.value.project }}"
         endpoint_type: "admin"
         validate_certs: "{{ not keystone_service_adminuri_insecure }}"
         wait: yes
@@ -351,7 +351,7 @@
         name: "{{ item.value.subnet_name | default('rally_subnet_' + item.key) }}"
         network_name: "{{ item.value.net_name | default('rally_net_' + item.key) }}"
         cidr: "{{ item.value.subnet_cidr | default('192.168.0.0/24') }}"
-        project: "{{ item.value.project | default('rally_' + item.key) }}"
+        project: "{{ item.value.project }}"
         endpoint_type: "admin"
         validate_certs: "{{ not keystone_service_adminuri_insecure }}"
         wait: yes

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -503,6 +503,14 @@
         group: "root"
         mode: "0600"
 
+    - name: Install logrotate config for maas_rally plugin
+      template:
+        src: "templates/rax-maas/maas_rally_logrotate.j2"
+        dest: "/etc/logrotate.d/maas_rally"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+
   vars_files:
     - vars/main.yml
     - vars/maas-agent.yml

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -215,7 +215,7 @@
         quota set \
         {% for quota in item.value.per_iter_quotas %} \
             --{{ quota }} \
-            {{ item.value.per_iter_quotas[quota]*item.value.concurrency }} \
+            {{ item.value.per_iter_quotas[quota]*item.value.concurrency*item.value.quota_factor }} \
         {% endfor %} \
         {{ item.value.project }}
       with_dict: "{{ maas_rally_checks }}"

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -342,7 +342,7 @@
         - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
       when:
         - item.value.enabled
-        - item.value.creates_instances
+        - "{{ 'compute' in item.value.primary_resources }}"
 
     - name: Create rally subnets
       os_subnet:
@@ -360,7 +360,7 @@
         - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
       when:
         - item.value.enabled
-        - item.value.creates_instances
+        - "{{ 'compute' in item.value.primary_resources }}"
 
     - name: Check for existing maas_rally database initialization
       command: "{{ maas_rally_venv_bin }}/rally-manage db revision"
@@ -470,7 +470,7 @@
       with_dict: "{{ maas_rally_checks }}"
       when:
         - item.value.enabled
-        - item.value.creates_instances
+        - "{{ 'compute' in item.value.primary_resources }}"
         - network_uuids["{{ item.value.net_name | default('rally_net_' + item.key) }}"] is defined
 
     - name: Download cirros image for maas_rally

--- a/playbooks/templates/rax-maas/maas_rally.yaml.j2
+++ b/playbooks/templates/rax-maas/maas_rally.yaml.j2
@@ -1,5 +1,26 @@
-# {{ ansible_managed }}
 ---
+# {{ ansible_managed }}
+
+# See python's logging.config module for details
+logging:
+    version: 1
+    disable_existing_loggers: False
+    root:
+        handlers: []
+    formatters:
+        default:
+            format: '%(asctime)s - %(levelname)s - %(process)d - %(message)s'
+    loggers:
+        maas_rally:
+            level: {{ maas_rally_plugin_log_level }}
+            handlers:
+                - file
+    handlers:
+        file:
+            class: logging.handlers.WatchedFileHandler
+            formatter: default
+            filename: {{ maas_rally_plugin_log_file }}
+
 {% if maas_rally_influxdb_enabled %}
 influxdb:
   host: {{ maas_rally_influxdb_host }}

--- a/playbooks/templates/rax-maas/maas_rally.yaml.j2
+++ b/playbooks/templates/rax-maas/maas_rally.yaml.j2
@@ -1,6 +1,12 @@
 ---
 # {{ ansible_managed }}
 
+scenarios:
+{% for key, value in maas_rally_checks.iteritems() %}
+    {{ key }}:
+        {{ value | to_nice_yaml | indent(8, false) }}
+{% endfor %}
+
 # See python's logging.config module for details
 logging:
     version: 1

--- a/playbooks/templates/rax-maas/maas_rally_logrotate.j2
+++ b/playbooks/templates/rax-maas/maas_rally_logrotate.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+{{ maas_rally_plugin_log_file }} {
+    daily
+    rotate 7
+    missingok
+    copytruncate
+    compress
+    create 640 root adm
+}

--- a/playbooks/templates/rax-maas/rally_check.yaml.j2
+++ b/playbooks/templates/rax-maas/rally_check.yaml.j2
@@ -7,6 +7,7 @@
 {% set concurrency = item.value.concurrency %}
 {% set crit_threshold = item.value.crit_threshold %}
 {% set warn_threshold = item.value.warn_threshold %}
+{% set delayed_by_lock_threshold = item.value.delayed_by_lock_alarm_threshold %}
 {% set alarm_consecutive_count = item.value.alarm_consecutive_count %}
 {% set duration_threshold_percent = item.value.duration_threshold %}
 {% set duration_threshold_seconds = (period*item.value.duration_threshold/100.0)|float %}
@@ -49,4 +50,13 @@ alarms      :
             :set consecutiveCount={{ alarm_consecutive_count }}
             if (metric["maas_check_duration"] > {{ '%0.2f' | format(duration_threshold_seconds|float) }}) {
                 return new AlarmStatus(CRITICAL, "{{ name }} performance test duration exceeds {{ duration_threshold_percent }}% of {{ period }} second polling interval.");
+            }
+    rally_{{ name }}_delayed_by_lock :
+        label                   : rally_{{ name }}_delayed_by_lock--{{ inventory_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (("rally_{{ name }}_delayed_by_lock--{{ inventory_hostname }}") | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ delayed_by_lock_threshold }}
+            if (metric["delayed_by_lock"] > 0) {
+                return new AlarmStatus(CRITICAL, "{{ name }} performance test has been waiting {{ delayed_by_lock_threshold }} or more intervals for a lock.");
             }

--- a/playbooks/templates/rax-maas/rally_check.yaml.j2
+++ b/playbooks/templates/rax-maas/rally_check.yaml.j2
@@ -8,6 +8,7 @@
 {% set crit_threshold = item.value.crit_threshold %}
 {% set warn_threshold = item.value.warn_threshold %}
 {% set delayed_by_lock_threshold = item.value.delayed_by_lock_alarm_threshold %}
+{% set resource_cleanup_threshold = item.value.resource_cleanup_alarm_threshold %}
 {% set alarm_consecutive_count = item.value.alarm_consecutive_count %}
 {% set duration_threshold_percent = item.value.duration_threshold %}
 {% set duration_threshold_seconds = (period*item.value.duration_threshold/100.0)|float %}
@@ -59,4 +60,13 @@ alarms      :
             :set consecutiveCount={{ delayed_by_lock_threshold }}
             if (metric["delayed_by_lock"] > 0) {
                 return new AlarmStatus(CRITICAL, "{{ name }} performance test has been waiting {{ delayed_by_lock_threshold }} or more intervals for a lock.");
+            }
+    rally_{{ name }}_resource_cleanup :
+        label                   : rally_{{ name }}_resource_cleanup--{{ inventory_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (("rally_{{ name }}_resource_cleanup--{{ inventory_hostname }}") | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ resource_cleanup_threshold }}
+            if (metric["resource_cleanup"] > 0) {
+                return new AlarmStatus(CRITICAL, "{{ name }} performance test has required stale resource cleanup for {{ resource_cleanup_threshold }} or more intervals.");
             }

--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -88,6 +88,13 @@ maas_rally_primary_node: "{{ groups[maas_rally_target_group][0] }}"
 #    - user_password: The password for the keystone user the scenario runs as.
 #      Default: {{ maas_rally_users_password }}
 #
+#    - quota_factor: The per_iter_quota values are multiplied by this value
+#      to determine how many concurrent instances of a scenario can run without
+#      exceeding quotas.  This is primarily to provide enough buffer in the
+#      quotas to run a new scenario while a failed scenario is being cleaned
+#      up.
+#      Default: {{ maas_rally_default_quota_factor }}
+#
 #  Example:
 #
 #    maas_rally_check_overrides:
@@ -225,6 +232,7 @@ maas_rally_default_duration_threshold: 75
 maas_rally_default_warn_threshold: 300
 maas_rally_default_crit_threshold: 600
 maas_rally_default_alarm_consecutive_count: 3
+maas_rally_default_quota_factor: 3
 
 #
 #  This dictionary is a template containing default values for all checks. In

--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -268,14 +268,24 @@ maas_rally_check_default_template:
 #
 maas_rally_check_defaults:
   neutron_secgroups:
+    user_name: rally_neutron_secgroups
+    project: rally_neutron_secgroups
     primary_resources:
       - secgroup
   glance:
+    user_name: rally_glance
+    project: rally_glance
     primary_resources:
       - image
-  keystone: {}
-  swift: {}
+  keystone:
+    user_name: rally_keystone
+    project: rally_keystone
+  swift:
+    user_name: rally_swift
+    project: rally_swift
   cinder:
+    user_name: rally_cinder
+    project: rally_cinder
     per_iter_quotas:
       instances: 1
       cores: 1
@@ -288,11 +298,15 @@ maas_rally_check_defaults:
       - compute
       - volume
   neutron_ports:
+    user_name: rally_neutron_ports
+    project: rally_neutron_ports
     per_iter_quotas:
       ports: 1
     primary_resources:
       - port
   nova_cinder:
+    user_name: rally_nova_cinder
+    project: rally_nova_cinder
     per_iter_quotas:
       instances: 1
       cores: 1
@@ -305,6 +319,8 @@ maas_rally_check_defaults:
       - compute
       - volume
   nova:
+    user_name: rally_nova
+    project: rally_nova
     per_iter_quotas:
       instances: 1
       cores: 1

--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -313,6 +313,11 @@ maas_rally_checks: "{{ maas_rally_check_defaults | combine(maas_rally_check_over
 #
 maas_rally_skip_config_validation: false
 
+#
+# Plugin logging configuration
+#
+maas_rally_plugin_log_file: /var/log/maas_rally.log
+maas_rally_plugin_log_level: INFO
 
 #
 # InfluxDB configuration

--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -100,6 +100,10 @@ maas_rally_primary_node: "{{ groups[maas_rally_target_group][0] }}"
 #      acquired.
 #      Default: {{ maas_rally_default_delayed_by_lock_alarm_threshold }}
 #
+#    - resource_cleanup_alarm_threshold: An alarm iwll be generated after this
+#      many consecutive polls were required to clean up scenario resources.
+#      Default: {{ maas_rally_default_resource_cleanup_alarm_threshold }}
+#
 #
 #  Example:
 #
@@ -240,6 +244,7 @@ maas_rally_default_crit_threshold: 600
 maas_rally_default_alarm_consecutive_count: 3
 maas_rally_default_quota_factor: 3
 maas_rally_default_delayed_by_lock_alarm_threshold: 3
+maas_rally_default_resource_cleanup_alarm_threshold: 3
 
 #
 #  This dictionary is a template containing default values for all checks. In
@@ -261,6 +266,7 @@ maas_rally_check_default_template:
   user_password: "{{ maas_rally_users_password }}"
   alarm_consecutive_count: "{{ maas_rally_default_alarm_consecutive_count }}"
   delayed_by_lock_alarm_threshold: "{{ maas_rally_default_delayed_by_lock_alarm_threshold }}"
+  resource_cleanup_alarm_threshold: "{{ maas_rally_default_resource_cleanup_alarm_threshold }}"
   extra_user_roles: []
   extra_vars: {}
   primary_resources: []

--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -95,6 +95,12 @@ maas_rally_primary_node: "{{ groups[maas_rally_target_group][0] }}"
 #      up.
 #      Default: {{ maas_rally_default_quota_factor }}
 #
+#    - delayed_by_lock_alarm_threshold: An alarm will be generated after this
+#      many consecutive polls were delayed because a scenario lock could not be
+#      acquired.
+#      Default: {{ maas_rally_default_delayed_by_lock_alarm_threshold }}
+#
+#
 #  Example:
 #
 #    maas_rally_check_overrides:
@@ -233,6 +239,7 @@ maas_rally_default_warn_threshold: 300
 maas_rally_default_crit_threshold: 600
 maas_rally_default_alarm_consecutive_count: 3
 maas_rally_default_quota_factor: 3
+maas_rally_default_delayed_by_lock_alarm_threshold: 3
 
 #
 #  This dictionary is a template containing default values for all checks. In
@@ -253,6 +260,7 @@ maas_rally_check_default_template:
   duration_threshold: "{{ maas_rally_default_duration_threshold }}"
   user_password: "{{ maas_rally_users_password }}"
   alarm_consecutive_count: "{{ maas_rally_default_alarm_consecutive_count }}"
+  delayed_by_lock_alarm_threshold: "{{ maas_rally_default_delayed_by_lock_alarm_threshold }}"
   extra_user_roles: []
   extra_vars: {}
   primary_resources: []

--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -247,7 +247,8 @@ maas_rally_check_default_template:
   alarm_consecutive_count: "{{ maas_rally_default_alarm_consecutive_count }}"
   extra_user_roles: []
   extra_vars: {}
-  creates_instances: false
+  primary_resources: []
+  quota_factor: "{{ maas_rally_default_quota_factor }}"
   per_iter_quotas:    # Resources required per iteration of the scenario. These
     instances: 0      # values are multipled by the scenario's concurrency.
     cores: 0
@@ -266,8 +267,12 @@ maas_rally_check_default_template:
 #  maas_rally_check_overrides rather than here.
 #
 maas_rally_check_defaults:
-  neutron_secgroups: {}
-  glance: {}
+  neutron_secgroups:
+    primary_resources:
+      - secgroup
+  glance:
+    primary_resources:
+      - image
   keystone: {}
   swift: {}
   cinder:
@@ -279,10 +284,14 @@ maas_rally_check_defaults:
       ports: 4
       volumes: 2       # Double because rally doesn't seem to wait for cinder
       gigabytes: 2     # volumes to be scrubbed.
-    creates_instances: true
+    primary_resources:
+      - compute
+      - volume
   neutron_ports:
     per_iter_quotas:
       ports: 1
+    primary_resources:
+      - port
   nova_cinder:
     per_iter_quotas:
       instances: 1
@@ -292,7 +301,9 @@ maas_rally_check_defaults:
       ports: 4
       volumes: 2       # Double because rally doesn't seem to wait for cinder
       gigabytes: 20    # volumes to be scrubbed.
-    creates_instances: true
+    primary_resources:
+      - compute
+      - volume
   nova:
     per_iter_quotas:
       instances: 1
@@ -300,7 +311,8 @@ maas_rally_check_defaults:
       ram: 256
       fixed-ips: 1
       ports: 4
-    creates_instances: true
+    primary_resources:
+      - compute
 
 #
 #  Combine check defaults and overrides.  These are applied on top of the

--- a/releasenotes/notes/TURTLES-673-ef4f66cdf13e61a0.yaml
+++ b/releasenotes/notes/TURTLES-673-ef4f66cdf13e61a0.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - Detailed logging was added to the maas_rally performance monitoring plugin.
+  - Automatic stale lock and resource cleanup was added to maas_rally.  This
+    makes the plugin more robust and resiliant to transitory environmental
+    problems.
+  - A configurable quota factor was added to the maas_rally plugin.  This
+    allows resource cleanup and performance polling to run asynchronously.
+  - The maas_rally plugin will now generate an alarm event when too many
+    consecutive intervals (default=3) required cleanup of stale resources.
+  - The maas_rally plugin will now generate an alarm event when too many
+    consecutive intervals (default=3) were aborted waiting for immature
+    locks.


### PR DESCRIPTION
This task tracks the following improvements:

```
- Add logging
- Add resiliency to transitory environmental problems
  - Automatically recover from stale locks
  - Automatically clean up stale resources
```

Some prerequisite refactoring for the items above:

```
- Some information from ansible runtime is required during plugin runtime and was moved to the maas_rally.yml plugin config file:
  - Scenario project, username, and password
  - Alert thresholds
  - Primary resources created by each scenario
- Added a quota factor that each scenario project's quotas are multiplied by.  This allows a scenario to call for cleanup without waiting for cleanup to finish.
- Add alarms for:
  - Too many consecutive intervals requiring stale resource cleanup
  - Too many consecutive intervals waiting for immature locks
```
