### PR TITLE
TURTLES-313 Adding protocol and port option to cinder API check

### DIFF
--- a/playbooks/templates/rax-maas/cinder_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_api_local_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/cinder_api_local_check.py", "{{ ansible_host }}"]
+    args    : ["{{ maas_plugin_dir }}/cinder_api_local_check.py", "{{ ansible_host }}", "--protocol", "{{ cinder_local_api_protocol }}", "--port", "{{ cinder_local_api_port }}"]
 alarms      :
     cinder_api_local_status :
         label                   : cinder_api_local_status--{{ inventory_hostname }}

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -348,3 +348,12 @@ keystone_local_api_port: '35357'
 #
 keystone_local_api_protocol: 'http'
 
+# cinder_local_api_protocol: Protocol to use for cinder local API checks
+#
+cinder_local_api_protocol: 'http'
+
+#
+# cinder_local_api_port: Port number for the local cinder api service.
+#
+cinder_local_api_port: '8776'
+


### PR DESCRIPTION
Adding protocol and port option to local cinder api check.
Removed comment pointing towards an abandoned lp bug.
Renamed local variable in function to be all lower case per pep8 standards.

A first of many commits to fix #TURTLES-313

Signed-off-by: Michael Rice <michael.rice@rackspace.com>