### PR TITLE
CEPHSTORA-168 Fix Ansible reference for rpc-ceph

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -48,7 +48,7 @@ if which yum; then
     sudo yum -y install redhat-lsb-core epel-release
 fi
 if [ "${RE_JOB_SCENARIO}" = "ceph" ]; then
-  export ANSIBLE_BINARY="ansible-playbook"
+  export ANSIBLE_BINARY="ceph-ansible-playbook"
   export ANSIBLE_INVENTORY="/opt/rpc-ceph/tests/inventory"
   export ANSIBLE_OVERRIDES="/opt/rpc-ceph/tests/test-vars.yml"
 fi


### PR DESCRIPTION
The rpc-ceph job is failing because the ansible-playbook is no longer
configured by rpc-maas, and we should fall back to use the rpc-ceph
"ceph-ansible-playbook" binary instead.