### PR TITLE
TURTLES-313 add ssl support to heat_api_local_check

### DIFF
--- a/playbooks/files/rax-maas/plugins/heat_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/heat_api_local_check.py
@@ -33,12 +33,16 @@ def check(auth_ref, args):
     keystone = get_keystone_client(auth_ref)
     tenant_id = keystone.tenant_id
 
-    HEAT_ENDPOINT = ('http://{ip}:8004/v1/{tenant}'.format
-                     (ip=args.ip, tenant=tenant_id))
+    heat_endpoint = ('{protocol}://{ip}:{port}/v1/{tenant}'.format(
+        ip=args.ip,
+        tenant=tenant_id,
+        protocol=args.protocol,
+        port=args.port
+    ))
 
     try:
         if args.ip:
-            heat = get_heat_client(endpoint=HEAT_ENDPOINT)
+            heat = get_heat_client(endpoint=heat_endpoint)
         else:
             heat = get_heat_client()
 
@@ -83,6 +87,14 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--port',
+                        action='store',
+                        default='8004',
+                        help='Port to use for the local heat API')
+    parser.add_argument('--protocol',
+                        action='store',
+                        default='http',
+                        help='Protocol for the local heat API')
     args = parser.parse_args()
     with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/templates/rax-maas/heat_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/heat_api_local_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/heat_api_local_check.py", "{{ ansible_host }}"]
+    args    : ["{{ maas_plugin_dir }}/heat_api_local_check.py", "{{ ansible_host }}", "--protocol", "{{ heat_local_api_protocol}}", "--port", "{{ heat_local_api_port }}"]
 alarms      :
     heat_api_local_status :
         label                   : heat_api_local_status--{{ inventory_hostname }}

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -391,3 +391,13 @@ glance_local_api_port: '9292'
 #
 glance_local_api_protocol: 'http'
 
+#
+# heat_local_api_port: Port number for the local heat api service
+#
+heat_local_api_port: '8004'
+
+#
+# heat_local_api_protocol: Protocol for the local heat API checks
+#
+heat_local_api_protocol: 'http'
+


### PR DESCRIPTION
* Adding protocol and port option to local heat api check.
* Renamed local variable in function to be all lower case per pep8 standards.

Another commit for #TURTLES-313

Signed-off-by: Michael Rice <michael@michaelrice.org>