### PR TITLE
TURTLES-313 add ssl support to keystone_api_local_check

### DIFF
--- a/playbooks/files/rax-maas/plugins/keystone_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/keystone_api_local_check.py
@@ -29,15 +29,19 @@ from maas_common import status_ok
 
 
 def check(args, auth_details):
-
+    identity_endpoint = '{protocol}://{ip}:{port}/'.format(
+        protocol=args.protocol,
+        port=args.port,
+        ip=args.ip
+    )
     if auth_details['OS_AUTH_VERSION'] == '2':
-        IDENTITY_ENDPOINT = 'http://{ip}:35357/v2.0'.format(ip=args.ip)
+        identity_endpoint += 'v2.0'
     else:
-        IDENTITY_ENDPOINT = 'http://{ip}:35357/v3'.format(ip=args.ip)
+        identity_endpoint += 'v3'
 
     try:
         if args.ip:
-            keystone = get_keystone_client(endpoint=IDENTITY_ENDPOINT)
+            keystone = get_keystone_client(endpoint=identity_endpoint)
         else:
             keystone = get_keystone_client()
 
@@ -94,6 +98,14 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--protocol',
+                        action='store',
+                        default='http',
+                        help='Protocol for keystone API')
+    parser.add_argument('--port',
+                        action='store',
+                        default='35357',
+                        help='Port for the keystone API service')
     args = parser.parse_args()
     with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/templates/rax-maas/keystone_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/keystone_api_local_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/keystone_api_local_check.py", "{{ ansible_host }}"]
+    args    : ["{{ maas_plugin_dir }}/keystone_api_local_check.py", "{{ ansible_host }}", "--port", "{{ keystone_local_api_port }}", "--protocol", "{{ keystone_local_api_protocol }}"]
 alarms      :
     keystone_api_local_status :
         label                   : keystone_api_local_status--{{ inventory_hostname }}

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -323,3 +323,14 @@ cinder_client_protocol: 'http'
 #                        are "http" or "https".
 #
 ceph_radosgw_protocol: 'http'
+
+#
+# keystone_local_api_port: Port number for the local keystone API service
+#
+keystone_local_api_port: '35357'
+
+#
+# keystone_local_api_protocol: Protocol for the local keystone API
+#
+keystone_local_api_protocol: 'http'
+


### PR DESCRIPTION
* Adding protocol and port option to local keystone api check.
* Renamed local variable in function to be all lower case per pep8 standards.

Signed-off-by: Michael Rice <michael@michaelrice.org>