### PR TITLE
TURTLES-313 add ssl support to magnum api checks

### DIFF
--- a/playbooks/files/rax-maas/plugins/magnum_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/magnum_api_local_check.py
@@ -29,11 +29,15 @@ from magnumclient.common.apiclient import exceptions as exc
 
 
 def check(auth_ref, args):
-    MAGNUM_ENDPOINT = 'http://{ip}:9511/v1'.format(ip=args.ip,)
+    magnum_endpoint = '{protocol}://{ip}:{port}/v1'.format(
+        ip=args.ip,
+        protocol=args.protocol,
+        port=args.port
+    )
 
     try:
         if args.ip:
-            magnum = get_magnum_client(endpoint=MAGNUM_ENDPOINT)
+            magnum = get_magnum_client(endpoint=magnum_endpoint)
         else:
             magnum = get_magnum_client()
 
@@ -78,6 +82,14 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--port',
+                        action='store',
+                        default='9511',
+                        help='Port that the magnum API service is running on')
+    parser.add_argument('--protocol',
+                        action='store',
+                        default='http',
+                        help='Protocol for magnum API service')
     args = parser.parse_args()
     with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/rax-maas/plugins/magnum_service_check.py
+++ b/playbooks/files/rax-maas/plugins/magnum_service_check.py
@@ -27,11 +27,15 @@ from magnumclient.common.apiclient import exceptions as exc
 
 
 def check(auth_ref, args):
-    MAGNUM_ENDPOINT = 'http://{ip}:9511/v1'.format(ip=args.ip,)
+    magnum_endpoint = '{protocol}://{ip}:{port}/v1'.format(
+        ip=args.ip,
+        protocol=args.protocol,
+        port=args.port
+    )
 
     try:
         if args.ip:
-            magnum = get_magnum_client(endpoint=MAGNUM_ENDPOINT)
+            magnum = get_magnum_client(endpoint=magnum_endpoint)
         else:
             magnum = get_magnum_client()
 
@@ -70,6 +74,14 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--port',
+                        action='store',
+                        default='9511',
+                        help='Port that the magnum API service is running on')
+    parser.add_argument('--protocol',
+                        action='store',
+                        default='http',
+                        help='Protocol for magnum API service')
     args = parser.parse_args()
     with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/templates/rax-maas/magnum_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/magnum_api_local_check.yaml.j2
@@ -8,7 +8,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/magnum_api_local_check.py", "{{ ansible_host }}"]
+    args    : ["{{ maas_plugin_dir }}/magnum_api_local_check.py", "{{ ansible_host }}", "--port", "{{ magnum_local_api_port }}", "--protocol", "{{ magnum_local_api_protocol }}"]
     timeout : {{ (maas_check_timeout_override[label] | default(maas_check_timeout) * 1000) }}
 {{ get_metadata(label).strip() }}
 {# Add extra metadata options with two leading white spaces #}

--- a/playbooks/templates/rax-maas/magnum_conductor_check.yaml.j2
+++ b/playbooks/templates/rax-maas/magnum_conductor_check.yaml.j2
@@ -8,7 +8,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/magnum_service_check.py", "{{ ansible_host }}"]
+    args    : ["{{ maas_plugin_dir }}/magnum_service_check.py", "{{ ansible_host }}", "--port", "{{ magnum_local_api_port }}", "--protocol", "{{ magnum_local_api_protocol }}"]
     timeout : {{ (maas_check_timeout_override[label] | default(maas_check_timeout) * 1000) }}
 {{ get_metadata(label).strip() }}
 {# Add extra metadata options with two leading white spaces #}

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -447,3 +447,12 @@ mk8s_etg_port: '8888'
 # mk8s_etg_protocol: Protocol used to contact the mk8s etg service
 #
 mk8s_etg_protocol: 'http'
+
+# magnum_local_api_port: Port number for the local magnum API service
+#
+magnum_local_api_port: '9511'
+
+#
+# magnum_local_api_protocol: Protocol for magnum local API service
+#
+magnum_local_api_protocol: 'http'


### PR DESCRIPTION
* Adding protocol and port option to local magnum api check.
* Renamed local variable in function to be all lower case per pep8 standards.

add ssl support to magnum_service_check

* Adding protocol and port option to local magnum api check.
* Renamed local variable in function to be all lower case per pep8 standards.

Signed-off-by: Michael Rice <michael@michaelrice.org>