### PR TITLE
TURTLES-313 add ssl support to neutron_api_local_check

### DIFF
--- a/playbooks/files/rax-maas/plugins/neutron_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/neutron_api_local_check.py
@@ -29,12 +29,16 @@ from neutronclient.client import exceptions as exc
 
 def check(args):
 
-    NETWORK_ENDPOINT = 'http://{ip}:9696'.format(ip=args.ip)
+    network_endpoint = '{protocol}://{ip}:{port}'.format(
+        ip=args.ip,
+        protocol=args.protocol,
+        port=args.port
+    )
 
     is_up = False
     try:
         if args.ip:
-            neutron = get_neutron_client(endpoint_url=NETWORK_ENDPOINT)
+            neutron = get_neutron_client(endpoint_url=network_endpoint)
         else:
             neutron = get_neutron_client()
 
@@ -89,6 +93,14 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--port',
+                        action='store',
+                        default='9696',
+                        help='Port for neutron API service')
+    parser.add_argument('--protocol',
+                        action='store',
+                        default='http',
+                        help='Protocol for the neutron API service')
     args = parser.parse_args()
     with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/rax-maas/plugins/neutron_metadata_local_check.py
+++ b/playbooks/files/rax-maas/plugins/neutron_metadata_local_check.py
@@ -42,7 +42,11 @@ def check(args):
     else:
         metric_bool('agents_found', True, m_name='maas_neutron')
 
-    network_endpoint = 'http://{host}:9696'.format(host=args.neutron_host)
+    network_endpoint = '{protocol}://{host}:{port}'.format(
+        host=args.neutron_host,
+        protocol=args.protocol,
+        port=args.port
+    )
     try:
         neutron = get_neutron_client(endpoint_url=network_endpoint)
 
@@ -98,6 +102,14 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--port',
+                        action='store',
+                        default='9696',
+                        help='Port for neutron API service')
+    parser.add_argument('--protocol',
+                        action='store',
+                        default='http',
+                        help='Protocol for the neutron API service')
     args = parser.parse_args()
     with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/templates/rax-maas/neutron_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_api_local_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/neutron_api_local_check.py", "{{ ansible_host }}"]
+    args    : ["{{ maas_plugin_dir }}/neutron_api_local_check.py", "{{ ansible_host }}", "--port", "{{ neutron_client_port }}", "--protocol", "{{ neutron_client_protocol }}"]
 alarms      :
     neutron_api_local_status :
         label                   : neutron_api_local_status--{{ inventory_hostname }}

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -312,6 +312,11 @@ rabbitmq_http_protocol: 'http'
 neutron_client_protocol: 'http'
 
 #
+# neutron_client_port: Port for the neutron API service
+#
+neutron_client_port: '9696'
+
+#
 # cinder_client_protocol: Protocol to use when authenticating for cinder
 #                         service checks. Valid values are "http" or
 #                         "https".


### PR DESCRIPTION
* Adding protocol and port option to local neutron api check.
* Renamed local variable in function to be all lower case per pep8 standards.

add ssl support to neutron_metadata_local_check

* Adding protocol and port option to local neutron api check.

Signed-off-by: Michael Rice <michael@michaelrice.org>