### PR TITLE
TURTLES-313 add ssl support to nova_api_local_check

### DIFF
--- a/playbooks/files/rax-maas/plugins/nova_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/nova_api_local_check.py
@@ -36,14 +36,18 @@ def check(auth_ref, args):
     keystone = get_keystone_client(auth_ref)
     tenant_id = keystone.tenant_id
 
-    COMPUTE_ENDPOINT = (
-        'http://{ip}:8774/v2.1/{tenant_id}'
-        .format(ip=args.ip, tenant_id=tenant_id)
+    compute_endpoint = (
+        '{protocol}://{ip}:{port}/v2.1/{tenant_id}'.format(
+            ip=args.ip,
+            tenant_id=tenant_id,
+            protocol=args.protocol,
+            port=args.port
+        )
     )
 
     try:
         if args.ip:
-            nova = get_nova_client(bypass_url=COMPUTE_ENDPOINT)
+            nova = get_nova_client(bypass_url=compute_endpoint)
         else:
             nova = get_nova_client()
 
@@ -96,6 +100,12 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--port',
+                        default='8774',
+                        help='Port for the nova API service')
+    parser.add_argument('--protocol',
+                        default='http',
+                        help='Protocol used to contact the nova API service')
     args = parser.parse_args()
     with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/files/rax-maas/plugins/nova_api_metadata_local_check.py
+++ b/playbooks/files/rax-maas/plugins/nova_api_metadata_local_check.py
@@ -27,7 +27,11 @@ from requests import exceptions as exc
 
 
 def check(args):
-    metadata_endpoint = ('http://{ip}:8775'.format(ip=args.ip))
+    metadata_endpoint = ('{protocol}://{ip}:{port}'.format(
+        ip=args.ip,
+        protocol=args.protocol,
+        port=args.port
+    ))
     is_up = True
 
     s = requests.Session()
@@ -73,6 +77,12 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--port',
+                        default='8775',
+                        help='Port for the nova metadata service')
+    parser.add_argument('--protocol',
+                        default='http',
+                        help='Protocol for the nova metadata service')
     args = parser.parse_args()
     with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/templates/rax-maas/nova_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_api_local_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/nova_api_local_check.py", "{{ ansible_host }}"]
+    args    : ["{{ maas_plugin_dir }}/nova_api_local_check.py", "{{ ansible_host }}", "--protocol", "{{ nova_service_check_protocol }}", "--port", "{{ nova_service_check_port }}"]
 alarms      :
     nova_api_local_status :
         label                   : nova_api_local_status--{{ inventory_hostname }}

--- a/playbooks/templates/rax-maas/nova_api_metadata_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_api_metadata_local_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/nova_api_metadata_local_check.py", "{{ ansible_host }}"]
+    args    : ["{{ maas_plugin_dir }}/nova_api_metadata_local_check.py", "{{ ansible_host }}", "--port", "{{ nova_metadata_api_port }}", "--protocol", "{{ nova_metadata_api_protocol }}"]
 alarms      :
     nova_api_metadata_local_status :
         label                   : nova_api_metadata_local_status--{{ inventory_hostname }}

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -298,6 +298,20 @@ maas_holland_venv_enabled: false
 nova_service_check_protocol: 'http'
 
 #
+# nova_service_check_port: Port used for nova service
+nova_service_check_port: '8774'
+
+#
+# nova_metadata_api_port: Port for the nova metadata service
+#
+nova_metadata_api_port: '8775'
+
+#
+# nova_metadata_api_protocol: Protocol for nova metadata service
+#
+nova_metadata_api_protocol: 'http'
+
+#
 # rabbitmq_http_protocol: Protocol to use when authenticating for rabbitmq
 #                         service checks. Valid values are "http" or
 #                         "https".


### PR DESCRIPTION
* Adding protocol and port option to local nova api check.
* Renamed local variable in function to be all lower case per pep8 standards.

add ssl support to nova_api_metadata_local_check

* Adding protocol and port option to local nova metadata api check.

Signed-off-by: Michael Rice <michael@michaelrice.org>