### PR TITLE
TURTLES-313 add ssl support to octavia_api_local_check

### DIFF
--- a/playbooks/files/rax-maas/plugins/octavia_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/octavia_api_local_check.py
@@ -30,7 +30,11 @@ import requests
 
 
 def check(auth_ref, args):
-    OCTAVIA_ENDPOINT = 'http://{ip}:9876'.format(ip=args.ip,)
+    octavia_endpoint = '{protocol}://{ip}:{port}'.format(
+        ip=args.ip,
+        protocol=args.protocol,
+        port=args.port
+    )
 
     try:
         keystone = get_keystone_client(auth_ref)
@@ -40,7 +44,7 @@ def check(auth_ref, args):
             {'Content-type': 'application/json',
                 'x-auth-token': auth_token})
         if args.ip:
-            endpoint = OCTAVIA_ENDPOINT
+            endpoint = octavia_endpoint
         else:
             endpoint = get_endpoint_url_for_service(
                 'load-balancer', auth_ref, 'internal')
@@ -86,6 +90,12 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help='Set the output format to telegraf')
+    parser.add_argument('--port',
+                        default='9876',
+                        help='Port for the octavia service')
+    parser.add_argument('--protocol',
+                        default='http',
+                        help='Protocol used to contact the octavia service')
     args = parser.parse_args()
     with print_output(print_telegraf=args.telegraf_output):
         main(args)

--- a/playbooks/templates/rax-maas/octavia_api_local_check.yaml.j2
+++ b/playbooks/templates/rax-maas/octavia_api_local_check.yaml.j2
@@ -7,7 +7,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/octavia_api_local_check.py", "{{ ansible_host }}"]
+    args    : ["{{ maas_plugin_dir }}/octavia_api_local_check.py", "{{ ansible_host }}", "--port", "{{ octavia_api_port }}", "--protocol", "{{ octavia_api_protocol }}"]
 alarms      :
     octavia_api_local_status :
         label                   : octavia_api_local_status--{{ inventory_hostname }}

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -357,3 +357,13 @@ cinder_local_api_protocol: 'http'
 #
 cinder_local_api_port: '8776'
 
+# octavia_api_port: Port number for the octavia service
+#
+octavia_api_port: '9876'
+
+#
+# octavia_api_protocol: Protocol used to contact the octavia API service
+#
+octavia_api_protocol: 'http'
+
+


### PR DESCRIPTION
* Adding protocol and port option to local octavia api check.
* Renamed local variable in function to be all lower case per pep8 standards.

Signed-off-by: Michael Rice <michael@michaelrice.org>