### PR TITLE
Add rally_diag.sh support helper script

### DIFF
--- a/playbooks/files/rax-maas/tools/rally_diag.sh
+++ b/playbooks/files/rax-maas/tools/rally_diag.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+###outputs all the Rally projects and IDs
+echo -e '\n##################################################################\n'
+echo 'Rally IDs and Projects:'
+tput setaf 2; mysql keystone -e "select id,name from project where name like 'rally%'"; tput sgr0
+echo -e '\n##################################################################\n'
+
+###checks for instances by rally, whether in-progress or stuck
+echo '...Checking for INSTANCES spawned by Rally...'
+tput setaf 1; for PROJECT in `mysql keystone -BNe "select id from project where name like 'rally%'"`; do mysql nova -e "select uuid,display_name,vm_state,task_state,host,launched_at,project_id from instances where project_id='$PROJECT' and deleted=0" ; done; tput sgr0
+echo -e '\n##################################################################\n'
+
+###checks for images by rally, whether in-progress or stuck
+echo '...Checking for IMAGES created by Rally...'
+tput setaf 1; for PROJECT in `mysql keystone -BNe "select id from project where name like 'rally%'"`; do mysql glance -e "select id,name,status,created_at,owner from images where owner='$PROJECT' and deleted=0"; done; tput sgr0
+echo -e '\n##################################################################\n'
+
+###checks for volumes created by rally
+echo '...Checking for VOLUMES created by Rally...'
+tput setaf 1; for PROJECT in `mysql keystone -BNe "select id from project where name like 'rally%'"`; do mysql cinder -e "select id,display_name,host,status,attach_status,created_at,project_id from volumes where project_id='$PROJECT' and deleted=0"; done; tput sgr0
+echo -e '\n##################################################################\n'
+
+###checks for neutron ports
+echo '...Checking for PORTS created by Rally...'
+tput setaf 1; for PROJECT in `mysql keystone -BNe "select id from project where name like 'rally%'"`; do mysql neutron -e "select id,name,status,device_owner from ports where device_owner='$PROJECT'"; done; tput sgr0
+echo -e '\n##################################################################\n'
+
+###checks for neutron secgroups
+echo '...Checking for SECURITY GROUPS created by Rally...'
+tput setaf 1; for PROJECT in `mysql keystone -BNe "select id from project where name like 'rally%'"`; do mysql neutron -e "select id,name,project_id from securitygroups where project_id='$PROJECT' and name like '%rally%'"; done; tput sgr0
+echo -e '\n##################################################################\n'
+
+###checks for swift containers
+echo '...Checking for SWIFT CONTAINERS created by Rally...'
+tput setaf 1; PROJECT=`mysql keystone -BNe "select id from project where name='rally_swift'"`; source openrc; swift list --lh --os-project-id $PROJECT; tput sgr0
+echo -e '\n################################################################################'
+
+###echos an explanation
+echo '###     If there is RED output and the "created_at" date is >5 min old,      ###'
+echo '###       Rally operation may have failed and requires investigation.        ###'
+echo '###         Once investigation is complete, clean-up the scenario,           ###'
+echo '###              replacing <scenario_name> with project name:                ###'
+echo '###              "rm -rf /var/lock/maas_rally/<scenario_name>"               ###'
+echo '###                                                                          ###'
+echo '###                           !!EXCEPTIONS!!                                 ###'
+echo '###        Security Groups dont have dates; delete if no instances           ###'
+echo '###                           !!EXCEPTIONS!!                                 ###'
+echo '################################################################################'

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -225,6 +225,22 @@
       when:
         - item.value.enabled
 
+    - name: Grant admin role to admin user for maas_rally projects
+      os_user_role:
+        user: "{{ openrc_os_username }}"
+        project: "{{ item.value.project }}"
+        role: "admin"
+        state: present
+        cloud: default
+        endpoint_type: "admin"
+        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+      with_dict: "{{ maas_rally_checks }}"
+      vars:
+        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
+      when:
+        - item.value.enabled
+
+
     - name: Create maas_rally users in keystone
       os_user:
         name: "{{ item.value.user_name }}"
@@ -515,3 +531,13 @@
     - vars/main.yml
     - vars/maas-agent.yml
     - vars/maas-rally.yml
+
+- name: Deploy support helper script to utility containers
+  hosts: utility_all
+  gather_facts: false
+  tasks:
+    - name: Copy maas_rally support helper script
+      copy:
+        src: files/rax-maas/tools/rally_diag.sh
+        dest: /root/rally_diag.sh
+        mode: 0770

--- a/releasenotes/notes/add-maas_rally-support-helper-b0dded3554299e7e.yaml
+++ b/releasenotes/notes/add-maas_rally-support-helper-b0dded3554299e7e.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    A `rally_diag.sh` script is now deployed to all utility containers.  This
+    script helps support to quickly identify resources (instances, images,
+    etc) that were created by maas_rally.
+other:
+  - |
+    The user configured in `openrc_os_username` (`admin` by default) will be
+    granted the `admin` role on each project created for maas_rally scenarios.
+    This facilitates listing swift containers in the `rally_diag.sh` script.


### PR DESCRIPTION
This commit adds a `rally_diag.sh` script written by Albert Cardenas to each
utility container.  This script enables support to quickly identify OpenStack
resources created by maas_rally scenarios.

To faciliate listing swift containers without storing the maas_rally user's
credentials, the admin user is now granted the admin role on all projects
created to run maas_rally scenarios.