### PR TITLE
TURTLES-700 - Remove NVA alarms and update default thresholds

### DIFF
--- a/playbooks/templates/rax-maas/cinder_vg_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cinder_vg_check.yaml.j2
@@ -12,7 +12,7 @@ alarms      :
     cinder_vg_space_status :
         label                   : cinder_vg_space_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('cinder_vg_space_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('cinder_vg_space_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('false', 'true') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["{{ cinder_backends[item.key]['volume_group'] }}_vg_used_space"], metric["{{ cinder_backends[item.key]['volume_group'] }}_vg_total_space"]) > {{ maas_cinder_volumes_vg_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/cpu_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cpu_check.yaml.j2
@@ -9,7 +9,7 @@ alarms            :
     idle_percent_average        :
         label                   : idle_percent_average--{{ inventory_hostname|quote }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('idle_percent_average--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('idle_percent_average--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex) or inventory_hostname in (groups['shared-infra_hosts']|default([]))) | ternary('false', 'true') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["idle_percent_average"] <= {{ maas_cpu_idle_percent_avg_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/disk_utilisation.yaml.j2
+++ b/playbooks/templates/rax-maas/disk_utilisation.yaml.j2
@@ -13,7 +13,7 @@ alarms      :
     percentage_disk_utilisation_{{ device }}:
         label                   : percentage_disk_utilisation_{{ device }}--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('percentage_disk_utilisation_'+device+'--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('percentage_disk_utilisation_'+device+'--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex) or inventory_hostname in (groups['shared-infra_hosts']|default([]))) | ternary('false', 'true') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["disk_utilisation_{{ device }}"] > {{ maas_disk_utilisation_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/galera_check.yaml.j2
+++ b/playbooks/templates/rax-maas/galera_check.yaml.j2
@@ -4,7 +4,7 @@ type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled    : "{{ (inventory_hostname != groups['galera_all'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}/galera_check.py", "-H", "{{ ansible_host }}"]

--- a/playbooks/templates/rax-maas/galera_check.yaml.j2
+++ b/playbooks/templates/rax-maas/galera_check.yaml.j2
@@ -87,18 +87,6 @@ alarms      :
             if (rate(metric["access_denied_errors"]) > {{ maas_mysql_access_denied_errors_rate_critical_threshold }}) {
                 return new AlarmStatus(CRITICAL, "Access denied errors rate is greater than {{ maas_mysql_access_denied_errors_rate_critical_threshold }} per {{ (maas_check_period_override[label] | default(maas_check_period)) }} seconds");
             }
-    aborted_clients :
-        label                   : aborted_clients--{{ inventory_hostname }}
-        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('aborted_clients--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
-        criteria                : |
-            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (rate(metric["aborted_clients"]) > {{ maas_mysql_aborted_clients_rate_warning_threshold }}) {
-                return new AlarmStatus(WARNING, "Aborted clients rate is greater than {{ maas_mysql_aborted_clients_rate_warning_threshold }} per {{ (maas_check_period_override[label] | default(maas_check_period)) }} seconds");
-            }
-            if (rate(metric["aborted_clients"]) > {{ maas_mysql_aborted_clients_rate_critical_threshold }}) {
-                return new AlarmStatus(CRITICAL, "Aborted clients rate is greater than {{ maas_mysql_aborted_clients_rate_critical_threshold }} per {{ (maas_check_period_override[label] | default(maas_check_period)) }} seconds");
-            }
     aborted_connects :
         label                   : aborted_connects--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"

--- a/playbooks/templates/rax-maas/ironic_capacity_check.yaml.j2
+++ b/playbooks/templates/rax-maas/ironic_capacity_check.yaml.j2
@@ -12,7 +12,7 @@ alarms      :
     ironic_capacity :
         label                   : ironic_capacity--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('ironic_capacity--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('ironic_capacity--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('false', 'true') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["ironic_up_nodes_count"] , metric["ironic_total_nodes_count"]) <= {{ maas_capacity_percent_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/memory_check.yaml.j2
+++ b/playbooks/templates/rax-maas/memory_check.yaml.j2
@@ -9,7 +9,7 @@ alarms            :
     memory_used                 :
         label                   : memory_check--{{ inventory_hostname|quote }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('memory_check--'+inventory_hostname | quote) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('memory_check--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex) or inventory_hostname in (groups['shared-infra_hosts']|default([]))) | ternary('false', 'true') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["actual_used"], metric["total"]) >= {{ maas_memory_used_percentage_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/network_throughput.yaml.j2
+++ b/playbooks/templates/rax-maas/network_throughput.yaml.j2
@@ -17,7 +17,7 @@ alarms:
     alarm-network-receive:
         label: Network receive rate on {{ item.0.name }}
         notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled            : {{ (('Network receive rate on '+item.0.name) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled            : {{ (('Network receive rate on '+item.0.name) | match(maas_excluded_alarms_regex)) | ternary('false', 'true') }}
         criteria: |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric['rx_bytes']) > {{ rx_crit }}) {
@@ -30,7 +30,7 @@ alarms:
     alarm-network-transmit:
         label: Network transmit rate on {{ item.0.name }}
         notification_plan_id: "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled            : {{ (('Network transmit rate on '+item.0.name) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled            : {{ (('Network transmit rate on '+item.0.name) | match(maas_excluded_alarms_regex)) | ternary('false', 'true') }}
         criteria: |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric['tx_bytes']) > {{ tx_crit }}) {

--- a/playbooks/templates/rax-maas/nova_cloud_stats_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_cloud_stats_check.yaml.j2
@@ -13,7 +13,7 @@ alarms      :
     nova_cloud_memory_status :
         label                   : nova_cloud_memory_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('nova_cloud_memory_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_cloud_memory_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('false', 'true') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["cloud_resource_used_memory"], metric["cloud_resource_total_memory"]) > {{ maas_cloud_resource_critical_memory }}) {
@@ -25,7 +25,7 @@ alarms      :
     nova_cloud_disk_status :
         label                   : nova_cloud_disk_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('nova_cloud_disk_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_cloud_disk_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('false', 'true') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["cloud_resource_used_disk_space"], metric["cloud_resource_total_disk_space"]) > {{ maas_cloud_resource_critical_disk_space }}) {
@@ -37,7 +37,7 @@ alarms      :
     nova_cloud_vcpu_status :
         label                   : nova_cloud_vcpu_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('nova_cloud_vcpu_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('nova_cloud_vcpu_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('false', 'true') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["cloud_resource_used_vcpus"], metric["cloud_resource_total_vcpus"]) > {{ maas_cloud_resource_critical_vcpus }}) {

--- a/playbooks/templates/rax-maas/plugins/rabbitmq_status.py
+++ b/playbooks/templates/rax-maas/plugins/rabbitmq_status.py
@@ -180,19 +180,21 @@ def _get_node_metrics(session, metrics, protocol, host, port, name):
 
 def _get_queue_metrics(session, metrics, protocol, host, port):
     response = _get_rabbit_json(session, QUEUES_URL % (protocol, host, port))
+    msgs_excl_notifications = sum([q['messages'] for q in response
+                                  if q['consumers'] > 0])
     notification_messages = sum([q['messages'] for q in response
                                 if re.match('/^(versioned_)?notifications\.',
                                             q['name']) and
                                 q['consumers'] > 0])
     msgs_without_consumers = sum([q['messages'] for q in response
-                                if q['consumers'] == 0])
+                                 if q['consumers'] == 0])
 
     metrics['notification_messages'] = {
         'value': notification_messages,
         'unit': 'messages'
     }
     metrics['msgs_excl_notifications'] = {
-        'value': metrics['messages']['value'] - notification_messages,
+        'value': msgs_excl_notifications - notification_messages,
         'unit': 'messages'
     }
     metrics['msgs_without_consumers'] = {

--- a/playbooks/templates/rax-maas/plugins/rabbitmq_status.py
+++ b/playbooks/templates/rax-maas/plugins/rabbitmq_status.py
@@ -184,6 +184,8 @@ def _get_queue_metrics(session, metrics, protocol, host, port):
                                 if re.match('/^(versioned_)?notifications\.',
                                             q['name']) and
                                 q['consumers'] > 0])
+    msgs_without_consumers = sum([q['messages'] for q in response
+                                if q['consumers'] == 0])
 
     metrics['notification_messages'] = {
         'value': notification_messages,
@@ -191,6 +193,10 @@ def _get_queue_metrics(session, metrics, protocol, host, port):
     }
     metrics['msgs_excl_notifications'] = {
         'value': metrics['messages']['value'] - notification_messages,
+        'unit': 'messages'
+    }
+    metrics['msgs_without_consumers'] = {
+        'value': msgs_without_consumers,
         'unit': 'messages'
     }
 

--- a/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
+++ b/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
@@ -4,7 +4,7 @@ type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled    : "{{ (inventory_hostname != groups['rabbitmq_all'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : ["{{ maas_plugin_dir }}/rabbitmq_status.py", "-H", "{{ ansible_host }}", "-n", "{{ ansible_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}", "--{{ rabbitmq_http_protocol }}"]

--- a/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
+++ b/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
@@ -18,7 +18,6 @@ alarms      :
             if (metric["rabbitmq_disk_free_alarm_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "rabbitmq_disk_free_alarm_status triggered");
             }
-
     rabbitmq_mem_alarm_status :
         label                   : rabbitmq_mem_alarm_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
@@ -28,7 +27,6 @@ alarms      :
             if (metric["rabbitmq_mem_alarm_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "rabbitmq_mem_alarm_status triggered");
             }
-
     rabbitmq_max_channels_per_conn :
         label                   : rabbitmq_max_channels_per_conn--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
@@ -38,7 +36,6 @@ alarms      :
             if (metric["rabbitmq_max_channels_per_conn"] > {{ maas_rabbitmq_max_channels_per_con_threshold }}) {
                 return new AlarmStatus(CRITICAL, "Detected RabbitMQ connections with > {{ maas_rabbitmq_max_channels_per_con_threshold }} channels, check RabbitMQ and all Openstack consumers");
             }
-
     rabbitmq_fd_used_alarm_status :
         label                   : rabbitmq_fd_used_alarm_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
@@ -48,7 +45,6 @@ alarms      :
             if (percentage(metric["rabbitmq_fd_used"],metric["rabbitmq_fd_total"]) >= {{ maas_rabbitmq_fd_used_threshold }}) {
                 return new AlarmStatus(CRITICAL, "RabbitMQ file descriptors is reaching configured limit. Currently above {{ maas_rabbitmq_fd_used_threshold }} % used");
             }
-
     rabbitmq_proc_used_alarm_status :
         label                   : rabbitmq_proc_used_alarm_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
@@ -58,7 +54,6 @@ alarms      :
             if (percentage(metric["rabbitmq_proc_used"],metric["rabbitmq_proc_total"]) >= {{ maas_rabbitmq_proc_used_threshold }}) {
                 return new AlarmStatus(CRITICAL, "RabbitMQ processes is reaching configured limit. Currently above {{ maas_rabbitmq_proc_used_threshold }} % used");
             }
-
     rabbitmq_socket_used_alarm_status :
         label                   : rabbitmq_socket_used_alarm_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
@@ -75,7 +70,7 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_msgs_excl_notifications"] > {{ maas_rabbitmq_queued_messages_excluding_notifications_threshold }} ) {
-                return new AlarmStatus(CRITICAL, "RabbitMQ sum of queued messages excluding notifications queues is reaching configured limit. Currently above {{ maas_rabbitmq_queued_messages_excluding_notifications_threshold }}");
+                return new AlarmStatus(CRITICAL, "RabbitMQ sum of queued messages excluding notifications queues is #{rabbitmq_msgs_excl_notifications}. Currently above {{ maas_rabbitmq_queued_messages_excluding_notifications_threshold }} threshold.");
             }
     rabbitmq_qgrowth_excl_notifications :
         label                   : rabbitmq_qgrowth_excl_notifications--{{ inventory_hostname }}
@@ -83,16 +78,15 @@ alarms      :
         disabled                : {{ (('rabbitmq_qgrowth_excl_notifications--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (rate(metric["rabbitmq_msgs_excl_notifications"]) > {{ maas_rabbitmq_queue_growth_rate_threshold / maas_check_period}}) {
-                return new AlarmStatus(CRITICAL, "RabbitMQ Queue growth rate is above configured threshold. Currently above {{ maas_rabbitmq_queue_growth_rate_threshold }}");
+            if (rate(metric["rabbitmq_msgs_excl_notifications"]) > {{ maas_rabbitmq_queue_growth_rate_threshold }}) {
+                return new AlarmStatus(CRITICAL, "RabbitMQ Queue growth rate is above configured threshold of {{ maas_rabbitmq_queue_growth_rate_threshold }}.");
             }
-
-    rabbitmq_queues_without_consumers :
-        label                   : rabbitmq_queues_without_consumers--{{ inventory_hostname }}
+    rabbitmq_msgs_without_consumers :
+        label                   : rabbitmq_msgs_without_consumers--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('rabbitmq_queues_without_consumers--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('rabbitmq_msgs_without_consumers--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (metric["rabbitmq_queues_without_consumers"] > {{ maas_rabbitmq_queues_without_consumers_limit }}) {
-                return new AlarmStatus(CRITICAL, "RabbitMQ Queues without consumers is above configured threshold. Currently more than {{ maas_rabbitmq_queues_without_consumers_limit }} queues without consumers");
+            if (metric["rabbitmq_msgs_without_consumers"] > {{ maas_rabbitmq_messages_without_consumers_threshold }}) {
+                return new AlarmStatus(CRITICAL, "RabbitMQ currently has #{rabbitmq_queues_without_consumers} unconsumed queue(s) with a sum of #{rabbitmq_msgs_without_consumers} messages. Currently above {{ maas_rabbitmq_messages_without_consumers_threshold }} threshold. Please investigate and remove any unnecessary queues that are no longer being consumed.");
             }

--- a/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
+++ b/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
@@ -70,7 +70,7 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_msgs_excl_notifications"] > {{ maas_rabbitmq_queued_messages_excluding_notifications_threshold }} ) {
-                return new AlarmStatus(CRITICAL, "RabbitMQ sum of queued messages excluding notifications queues is #{rabbitmq_msgs_excl_notifications}. Currently above {{ maas_rabbitmq_queued_messages_excluding_notifications_threshold }} threshold.");
+                return new AlarmStatus(CRITICAL, "RabbitMQ sum of queued messages excluding notifications queues is #{rabbitmq_msgs_excl_notifications}. Currently above {{ maas_rabbitmq_queued_messages_excluding_notifications_threshold }}.");
             }
     rabbitmq_qgrowth_excl_notifications :
         label                   : rabbitmq_qgrowth_excl_notifications--{{ inventory_hostname }}
@@ -79,7 +79,7 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (rate(metric["rabbitmq_msgs_excl_notifications"]) > {{ maas_rabbitmq_queue_growth_rate_threshold }}) {
-                return new AlarmStatus(CRITICAL, "RabbitMQ Queue growth rate is above configured threshold of {{ maas_rabbitmq_queue_growth_rate_threshold }}.");
+                return new AlarmStatus(CRITICAL, "RabbitMQ queue growth rate is above configured threshold of {{ maas_rabbitmq_queue_growth_rate_threshold }}.");
             }
     rabbitmq_msgs_without_consumers :
         label                   : rabbitmq_msgs_without_consumers--{{ inventory_hostname }}
@@ -88,5 +88,5 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["rabbitmq_msgs_without_consumers"] > {{ maas_rabbitmq_messages_without_consumers_threshold }}) {
-                return new AlarmStatus(CRITICAL, "RabbitMQ currently has #{rabbitmq_queues_without_consumers} unconsumed queue(s) with a sum of #{rabbitmq_msgs_without_consumers} messages. Currently above {{ maas_rabbitmq_messages_without_consumers_threshold }} threshold. Please investigate and remove any unnecessary queues that are no longer being consumed.");
+                return new AlarmStatus(CRITICAL, "RabbitMQ currently has #{rabbitmq_queues_without_consumers} unconsumed queue(s) with a sum of #{rabbitmq_msgs_without_consumers} messages. Currently above {{ maas_rabbitmq_messages_without_consumers_threshold }}. Please investigate and remove any unnecessary queues that are no longer being consumed.");
             }

--- a/playbooks/vars/maas-infra.yml
+++ b/playbooks/vars/maas-infra.yml
@@ -40,9 +40,9 @@ maas_rabbitmq_max_channels_per_con_threshold: 10
 maas_rabbitmq_fd_used_threshold: 90
 maas_rabbitmq_proc_used_threshold: 90
 maas_rabbitmq_socket_used_threshold: 90
-maas_rabbitmq_queued_messages_excluding_notifications_threshold: 100
-maas_rabbitmq_queues_without_consumers_limit: 0
+maas_rabbitmq_queued_messages_excluding_notifications_threshold: 5000
 maas_rabbitmq_queue_growth_rate_threshold: 15
+maas_rabbitmq_messages_without_consumers_threshold: 20000
 
 rsyslogd_process_names:
   - rsyslogd

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -142,7 +142,7 @@ maas_swift_container_quarantine_failed_percentage_threshold: 5.0
 maas_swift_container_quarantine_average_threshold: 25.0
 maas_swift_container_replication_failure_percentage_threshold: 5.0
 maas_swift_container_replication_growth_rate_threshold: 10.0
-maas_swift_container_replication_avg_time_threshold: 50.0
+maas_swift_container_replication_avg_time_threshold: 300.0
 maas_swift_async_pending_failure_percentage_threshold: 5.0
 maas_swift_async_pending_average_threshold: 1000.0
 


### PR DESCRIPTION
Existing work includes:
- Disable capacitive related alarms by default.
- Remove `aborted_clients` alarm from `galera_check`.
- CDM alarms deploy as disabled except for on `shared-infra_hosts` group.

WIP - Reduce noise of rabbitmq_status alarm trifecta. 