### PR TITLE
TURTLES-700 (cont'd):  Limit duplicate mons and rgws checks to the first node of each group

### DIFF
--- a/playbooks/templates/rax-maas/ceph_cluster_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_cluster_stats.yaml.j2
@@ -12,7 +12,7 @@ type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled    : "{{ (inventory_hostname != groups['mons'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : {{ ceph_args }}
@@ -26,7 +26,6 @@ alarms      :
             if (metric["cluster_health"] == 0) {
                 return new AlarmStatus(CRITICAL, "Ceph cluster error.");
             }
-
     ceph_health_warn :
         label                   : ceph_health_warn--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"

--- a/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
@@ -12,7 +12,7 @@ type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled    : "{{ (inventory_hostname != groups['mons'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : {{ ceph_args }}

--- a/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
@@ -9,7 +9,7 @@ type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled    : "{{ (inventory_hostname != groups['rgws'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : {{ ceph_args }}
@@ -26,4 +26,3 @@ alarms      :
             if (metric["rgw_up"] == 1) {
                 return new AlarmStatus(WARNING, "Ceph rgw warning.");
             }
-

--- a/releasenotes/notes/Limit-duplicate-mons-and-rgws-checks-to-the-first-node-of-each-group-90305d7c4a4eb55f.yaml
+++ b/releasenotes/notes/Limit-duplicate-mons-and-rgws-checks-to-the-first-node-of-each-group-90305d7c4a4eb55f.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Limit ceph_cluster_stats and ceph_mons_stats checks to groups['mons'][0] and ceph_rgw_stats to groups['rgws'][0] to prevent duplicate alarms on ceph clusters.

--- a/releasenotes/notes/TURTLES-700-Remove-NVA-alarms-and-update-default-thresholds-a319104c3980a3f7.yaml
+++ b/releasenotes/notes/TURTLES-700-Remove-NVA-alarms-and-update-default-thresholds-a319104c3980a3f7.yaml
@@ -1,0 +1,19 @@
+---
+fixes:
+  - |
+    * Disable capacitive related checks: cinder_vg_check, ironic_capacity_check, and nova_cloud_stats_check.
+    * Disable alarms for CDM checks on all hosts except groups['shared-infra_hosts']. This includes cpu_check, disk_utilisation, and memory_check.
+    * Disable alarms for network_throughput across all hosts.
+    * Changes to galera_check:
+    ** Limit enablement to groups['galera_all'][0].
+    ** Remove alarm for aborted_clients.
+    * Changes to rabbitmq_status:
+    ** Limit enablement to groups['rabbitmq_all'][0].
+    ** Modify metric msgs_excl_notifications to sum messages from consumed queues only.
+    ** Add metric msgs_without_consumers to sum messages from unconsumed queues only.
+    ** Fix bug in rabbitmq_qgrowth_excl_notifications alarm removing the division by check period. This is automatically handled by the rate() function.
+    ** Restructure rabbitmq_queues_without_consumers alarm with rabbitmq_msgs_without_consumers. This will alarm if unconsumed messages reaches the default threshold of 20000.
+    ** Remove default var for unused maas_rabbitmq_queues_without_consumers_limit.
+    ** Update maas_rabbitmq_queued_messages_excluding_notifications_threshold to 5000.
+    ** Add maas_rabbitmq_messages_without_consumers_threshold, defaulting to 20000.
+    * Update maas_swift_container_replication_avg_time_threshold from 50 to 300.


### PR DESCRIPTION
Limit `ceph_cluster_stats` and `ceph_mons_stats` checks to `groups['mons'][0]` and `ceph_rgw_stats` to `groups['rgws'][0]` to prevent duplicate alarms on ceph clusters.

This was missed in TURTLES-700, but is part of noise-reduction work.