### PR TITLE
[WIP] Fix logic for CDM alarm regex

### DIFF
--- a/playbooks/templates/rax-maas/cpu_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cpu_check.yaml.j2
@@ -9,7 +9,13 @@ alarms            :
     idle_percent_average        :
         label                   : idle_percent_average--{{ inventory_hostname|quote }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (inventory_hostname in (groups['shared-infra_hosts']|default([])) | ternary('false', 'true')) }}
+{% set is_shared_infra_host = inventory_hostname in (groups['shared-infra_hosts'] | default([])) %}
+{% set full_alarm_name = ('idle_percent_average--' + inventory_hostname | quote) %}
+{% if is_shared_infra_host and full_alarm_name | match(maas_excluded_alarms_regex) %}
+        disabled                : true
+{% else %}
+        disabled                : false
+{% endif %}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["idle_percent_average"] <= {{ maas_cpu_idle_percent_avg_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/cpu_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cpu_check.yaml.j2
@@ -9,7 +9,7 @@ alarms            :
     idle_percent_average        :
         label                   : idle_percent_average--{{ inventory_hostname|quote }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('idle_percent_average--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex) or inventory_hostname in (groups['shared-infra_hosts']|default([])) | ternary('false', 'true')) }}
+        disabled                : {{ (inventory_hostname in (groups['shared-infra_hosts']|default([])) | ternary('false', 'true')) }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["idle_percent_average"] <= {{ maas_cpu_idle_percent_avg_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/cpu_check.yaml.j2
+++ b/playbooks/templates/rax-maas/cpu_check.yaml.j2
@@ -9,7 +9,7 @@ alarms            :
     idle_percent_average        :
         label                   : idle_percent_average--{{ inventory_hostname|quote }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('idle_percent_average--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex) or inventory_hostname in (groups['shared-infra_hosts']|default([]))) | ternary('false', 'true') }}
+        disabled                : {{ (('idle_percent_average--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex) or inventory_hostname in (groups['shared-infra_hosts']|default([])) | ternary('false', 'true')) }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["idle_percent_average"] <= {{ maas_cpu_idle_percent_avg_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/disk_utilisation.yaml.j2
+++ b/playbooks/templates/rax-maas/disk_utilisation.yaml.j2
@@ -14,7 +14,13 @@ alarms      :
     percentage_disk_utilisation_{{ device }}:
         label                   : percentage_disk_utilisation_{{ device }}--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (inventory_hostname in (groups['shared-infra_hosts']|default([])) | ternary('false', 'true')) }}
+{% set is_shared_infra_host = inventory_hostname in (groups['shared-infra_hosts'] | default([])) %}
+{% set full_alarm_name = ('percentage_disk_utilisation_' + device + '--' + inventory_hostname | quote) %}
+{% if is_shared_infra_host and full_alarm_name | match(maas_excluded_alarms_regex) %}
+        disabled                : true
+{% else %}
+        disabled                : false
+{% endif %}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["disk_utilisation_{{ device }}"] > {{ maas_disk_utilisation_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/disk_utilisation.yaml.j2
+++ b/playbooks/templates/rax-maas/disk_utilisation.yaml.j2
@@ -14,7 +14,7 @@ alarms      :
     percentage_disk_utilisation_{{ device }}:
         label                   : percentage_disk_utilisation_{{ device }}--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('percentage_disk_utilisation_'+device+'--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex) or inventory_hostname in (groups['shared-infra_hosts']|default([])) | ternary('false', 'true')) }}
+        disabled                : {{ (inventory_hostname in (groups['shared-infra_hosts']|default([])) | ternary('false', 'true')) }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["disk_utilisation_{{ device }}"] > {{ maas_disk_utilisation_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/disk_utilisation.yaml.j2
+++ b/playbooks/templates/rax-maas/disk_utilisation.yaml.j2
@@ -14,7 +14,7 @@ alarms      :
     percentage_disk_utilisation_{{ device }}:
         label                   : percentage_disk_utilisation_{{ device }}--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('percentage_disk_utilisation_'+device+'--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex) or inventory_hostname in (groups['shared-infra_hosts']|default([]))) | ternary('false', 'true') }}
+        disabled                : {{ (('percentage_disk_utilisation_'+device+'--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex) or inventory_hostname in (groups['shared-infra_hosts']|default([])) | ternary('false', 'true')) }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["disk_utilisation_{{ device }}"] > {{ maas_disk_utilisation_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/memory_check.yaml.j2
+++ b/playbooks/templates/rax-maas/memory_check.yaml.j2
@@ -9,7 +9,13 @@ alarms            :
     memory_used                 :
         label                   : memory_check--{{ inventory_hostname|quote }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (inventory_hostname in (groups['shared-infra_hosts']|default([])) | ternary('false', 'true')) }}
+{% set is_shared_infra_host = inventory_hostname in (groups['shared-infra_hosts'] | default([])) %}
+{% set full_alarm_name = ('memory_check--' + inventory_hostname | quote) %}
+{% if is_shared_infra_host and full_alarm_name | match(maas_excluded_alarms_regex) %}
+        disabled                : true
+{% else %}
+        disabled                : false
+{% endif %}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["actual_used"], metric["total"]) >= {{ maas_memory_used_percentage_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/memory_check.yaml.j2
+++ b/playbooks/templates/rax-maas/memory_check.yaml.j2
@@ -9,7 +9,7 @@ alarms            :
     memory_used                 :
         label                   : memory_check--{{ inventory_hostname|quote }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('memory_check--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex) or inventory_hostname in (groups['shared-infra_hosts']|default([]))) | ternary('false', 'true') }}
+        disabled                : {{ (('memory_check--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex) or inventory_hostname in (groups['shared-infra_hosts']|default([])) | ternary('false', 'true')) }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["actual_used"], metric["total"]) >= {{ maas_memory_used_percentage_critical_threshold }}) {

--- a/playbooks/templates/rax-maas/memory_check.yaml.j2
+++ b/playbooks/templates/rax-maas/memory_check.yaml.j2
@@ -9,7 +9,7 @@ alarms            :
     memory_used                 :
         label                   : memory_check--{{ inventory_hostname|quote }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('memory_check--'+inventory_hostname|quote) | match(maas_excluded_alarms_regex) or inventory_hostname in (groups['shared-infra_hosts']|default([])) | ternary('false', 'true')) }}
+        disabled                : {{ (inventory_hostname in (groups['shared-infra_hosts']|default([])) | ternary('false', 'true')) }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["actual_used"], metric["total"]) >= {{ maas_memory_used_percentage_critical_threshold }}) {

--- a/playbooks/vars/maas-host.yml
+++ b/playbooks/vars/maas-host.yml
@@ -57,7 +57,7 @@ maas_filesystem_critical_threshold: 90.0
 _maas_disk_util_devices: |
   ---
   {% for device in ansible_devices.keys() %}
-  {%   if (device not in maas_excluded_devices | default([])) and (ansible_devices[device].model != 'VIRTUAL-DISK') and (ansible_devices[device].model != 'QEMU DVD-ROM') and ('nbd' not in device) %}
+  {%   if (device not in maas_excluded_devices | default([])) and (ansible_devices[device].model != 'VIRTUAL-DISK') and (ansible_devices[device].model != 'QEMU DVD-ROM') and ('nbd' not in device) and ('sr0' not in device) %}
   - "{{ device }}"
   {%   endif %}
   {% endfor %}

--- a/releasenotes/notes/fix-logic-for-CDM-alarm-regex-ab61a92954460b0e.yaml
+++ b/releasenotes/notes/fix-logic-for-CDM-alarm-regex-ab61a92954460b0e.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fix logic to include ternary statement when disabling CDM alarms.


### PR DESCRIPTION
Fix issue where `maas_excluded_alarms` wasn't disabling properly when defined.