### PR TITLE
CEPHSTORA-195 Allow civetweb port to be set

### DIFF
--- a/doc/source/config-ref.rst
+++ b/doc/source/config-ref.rst
@@ -55,3 +55,10 @@ Hummingbird playbook variables
 .. literalinclude:: ../../playbooks/vars/maas-hummingbird.yml
    :language: yaml
    :start-after: under the License.
+
+Ceph playbook variables
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: ../../playbooks/vars/maas-ceph.yml
+   :language: yaml
+   :start-after: under the License.

--- a/playbooks/maas-ceph-rgw.yml
+++ b/playbooks/maas-ceph-rgw.yml
@@ -57,5 +57,6 @@
 
   vars_files:
     - vars/main.yml
+    - vars/maas-ceph.yml
   tags:
     - maas-ceph-rgws

--- a/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
@@ -1,7 +1,7 @@
 {% set label = "ceph_rgw_stats" %}
 {% set check_name = label+'--'+inventory_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
-{% set _ = ceph_args.extend(["rgw", "--rgw_address", ceph_radosgw_protocol + "://" + ansible_host + ":8080"]) %}
+{% set _ = ceph_args.extend(["rgw", "--rgw_address", ceph_radosgw_protocol + "://" + ansible_host + ":" + radosgw_civetweb_port | string ]) %}
 {% set _ceph_args = ceph_args | to_yaml(width=1000) %}
 {% set ceph_args = _ceph_args %}
 

--- a/playbooks/vars/maas-ceph.yml
+++ b/playbooks/vars/maas-ceph.yml
@@ -1,0 +1,17 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This should mirror this var in your ceph-ansible deployment.
+radosgw_civetweb_port: "8080"

--- a/releasenotes/notes/radosgw_civetwebport-409c17bfbbb75373.yaml
+++ b/releasenotes/notes/radosgw_civetwebport-409c17bfbbb75373.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - Add ability to set the port used by the Ceph rados Gateway
+    service.
+    Use the ``radosgw_civetweb_port`` variable to set the port.
+    This defaults to ``8080`` to match the ``ceph-ansible``
+    default, but the ``radosgw_civetweb_port`` variable must
+    be set to the same value in your Ceph and MaaS configurations.


### PR DESCRIPTION
The civetweb port defaults to 8080 in ceph-ansible, but we may want to
change this.

This PR allows the var to be specified and adds a config-ref for ceph
vars.