### PR TITLE
TURTLES-760: Pin openstacksdk for maas_rally venv

### DIFF
--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -222,6 +222,7 @@ maas_rally_pip_packages:
   - "git+{{ maas_rally_git_repo }}@{{ maas_rally_git_version }}#egg=rally"
   - influxdb
   - numpy
+  - "openstacksdk<0.12.0"
   - pymysql
 
 #

--- a/releasenotes/notes/pin-rally-openstacksdk-26126927500afe54.yaml
+++ b/releasenotes/notes/pin-rally-openstacksdk-26126927500afe54.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - openstacksdk has been temporarily pinned to <0.12.0 to
+    work around changes that break maas_rally's resource
+    cleanup


### PR DESCRIPTION
Version 0.12.0 of openstacksdk breaks maas_rally's resource cleanup.  This
change pins openstacksdk<0.12.0 until a newer version fixes the problem.