### PR TITLE
TURTLES-761: Read maas_rally scenario config from file

### DIFF
--- a/playbooks/files/rax-maas/plugins/rally_performance.py
+++ b/playbooks/files/rax-maas/plugins/rally_performance.py
@@ -382,15 +382,7 @@ def main():
         logger.debug("{} - acquired lock for task "
                      "{}".format(args.task, task_uuid))
 
-        task_args = {}
-        if args.times is not None:
-            task_args['times'] = args.times
-        if args.concurrency is not None:
-            task_args['concurrency'] = args.concurrency
-        if args.extra_vars is not None:
-            for extra_var in args.extra_vars:
-                k, v = extra_var.lstrip().split('=')
-                task_args.update({k: v})
+        task_args = plugin_config['scenarios'][args.task]['task_args']
 
         with open(task_file) as f:
             input_task = f.read()

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -39,11 +39,11 @@
 
     - name: Config validation - ensure concurrency <= times
       fail:
-        msg: "Config error for {{ item }}: concurrency ({{ maas_rally_checks[item]['concurrency'] }}) must be less than or equal to times ({{ maas_rally_checks[item]['times'] }})."
+        msg: "Config error for {{ item }}: concurrency ({{ maas_rally_checks[item]['task_args']['concurrency'] }}) must be less than or equal to times ({{ maas_rally_checks[item]['task_args']['times'] }})."
       with_items: "{{ enabled_checks }}"
       when:
         - not maas_rally_skip_config_validation
-        - maas_rally_checks[item]['concurrency'] > maas_rally_checks[item]['times']
+        - maas_rally_checks[item]['task_args']['concurrency'] > maas_rally_checks[item]['task_args']['times']
 
     - name: Config validation - ensure ( times / concurrency ) * crit_threshold < poll_interval
       fail:
@@ -51,7 +51,7 @@
       with_items: "{{ enabled_checks }}"
       when:
         - not maas_rally_skip_config_validation
-        - (maas_rally_checks[item]['times']/maas_rally_checks[item]['concurrency'])*maas_rally_checks[item]['crit_threshold'] >= maas_rally_checks[item]['poll_interval']
+        - (maas_rally_checks[item]['task_args']['times']/maas_rally_checks[item]['task_args']['concurrency'])*maas_rally_checks[item]['crit_threshold'] >= maas_rally_checks[item]['poll_interval']
 
     - name: Config validation - ensure warning threshold < critical threshold
       fail:
@@ -215,7 +215,7 @@
         quota set \
         {% for quota in item.value.per_iter_quotas %} \
             --{{ quota }} \
-            {{ item.value.per_iter_quotas[quota]*item.value.concurrency*item.value.quota_factor }} \
+            {{ item.value.per_iter_quotas[quota]*item.value.task_args.concurrency*item.value.quota_factor }} \
         {% endfor %} \
         {{ item.value.project }}
       with_dict: "{{ maas_rally_checks }}"
@@ -480,9 +480,9 @@
         network_uuids: "{{ network_uuids|default({})|combine({item.name: item.id}) }}"
       with_items: "{{ openstack_networks }}"
 
-    - name: Add network UUIDs to checks' extra_vars
+    - name: Add network UUIDs to checks' task_args
       set_fact:
-        maas_rally_checks: "{{ maas_rally_checks|combine({item.key: {'extra_vars': {'net_id': network_uuids[item.value.net_name | default('rally_net_' + item.key)]}}}, recursive=True) }}"
+        maas_rally_checks: "{{ maas_rally_checks|combine({item.key: {'task_args': {'net_id': network_uuids[item.value.net_name | default('rally_net_' + item.key)]}}}, recursive=True) }}"
       with_dict: "{{ maas_rally_checks }}"
       when:
         - item.value.enabled

--- a/playbooks/templates/rax-maas/rally_check.yaml.j2
+++ b/playbooks/templates/rax-maas/rally_check.yaml.j2
@@ -3,8 +3,6 @@
 {% set check_name = label+'--'+inventory_hostname %}
 {% set period = item.value.poll_interval %}
 {% set timeout = period - 1 %}
-{% set times = item.value.times %}
-{% set concurrency = item.value.concurrency %}
 {% set crit_threshold = item.value.crit_threshold %}
 {% set warn_threshold = item.value.warn_threshold %}
 {% set delayed_by_lock_threshold = item.value.delayed_by_lock_alarm_threshold %}
@@ -22,7 +20,7 @@ timeout     : "{{ timeout }}"
 disabled    : "{{ (inventory_hostname not in maas_rally_primary_node or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_rally_venv.sh
-    args    : ["{{ maas_plugin_dir }}/rally_performance.py", "{{ name }}", "-t {{ times }}", "-c {{ concurrency }}" {% if influxdb %}, "--influxdb" {% endif %} {% for k,v in item.value.extra_vars.iteritems() | list %}, "-e {{k}}={{v}}" {% endfor %}]
+    args    : ["{{ maas_plugin_dir }}/rally_performance.py", "{{ name }}" {% if influxdb %}, "--influxdb" {% endif %}]
     timeout : {{ timeout * 1000 | int}}
 alarms      :
     rally_{{ name }}_total_{{ stat }}_warn :

--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -256,8 +256,6 @@ maas_rally_default_resource_cleanup_alarm_threshold: 3
 #
 maas_rally_check_default_template:
   enabled: false
-  times: "{{ maas_rally_default_times }}"
-  concurrency: "{{ maas_rally_default_concurrency }}"
   alarm_stat: "{{ maas_rally_default_alarm_stat }}"
   warn_threshold: "{{ maas_rally_default_warn_threshold }}"
   crit_threshold: "{{ maas_rally_default_crit_threshold }}"
@@ -268,7 +266,9 @@ maas_rally_check_default_template:
   delayed_by_lock_alarm_threshold: "{{ maas_rally_default_delayed_by_lock_alarm_threshold }}"
   resource_cleanup_alarm_threshold: "{{ maas_rally_default_resource_cleanup_alarm_threshold }}"
   extra_user_roles: []
-  extra_vars: {}
+  task_args:
+    times: "{{ maas_rally_default_times }}"
+    concurrency: "{{ maas_rally_default_concurrency }}"
   primary_resources: []
   quota_factor: "{{ maas_rally_default_quota_factor }}"
   per_iter_quotas:    # Resources required per iteration of the scenario. These

--- a/releasenotes/notes/task-args-to-config-b9463d48f8fea224.yaml
+++ b/releasenotes/notes/task-args-to-config-b9463d48f8fea224.yaml
@@ -1,0 +1,17 @@
+---
+features:
+  - The maas_rally task arguments are now read from the
+    plugin's configuration file (/etc/rally/maas_rally.yml
+    by default).  This eliminates the need to look up things
+    such as network uuids when running a performance scenario
+    manually for troubleshooting purposes.
+upgrade:
+  - Any custom scenarios or overrides setting non-default
+    `times` and/or `concurrency` values will need to move
+    these settings to the `task_args` dictionary.
+  - Any configuration overrides of the `extra_vars`
+    dictionary will need to rename the dictionary to
+    `task_args`.
+  - After running the `maas-openstack-rally.yml` playbook
+    the `rally_*` checks in MaaS will fail until the agent
+    is restarted and check definitions are updated.


### PR DESCRIPTION
This change eases troubleshooting burden by moving scenario configuration items
from the plugin CLI arguments to a configuration file.  This allows operators
to simply run the plugin without first looking up the extra arguments from MaaS
agent configuration files.

- Renamed `extra_vars` dictionary to `task_args`
- Move `times` and `concurrency` variables into the new `task_args` dictionary
- Updated playbooks to account for `times` and `concurrency` moving into
  `task_args`
- Update the plugin to read task arguments (e.g. `times`, `concurrency`, and
  items previously stored in `extra_vars` like network UUIDS) from the config
  file instead of from CLI arguments.