### PR TITLE
JIRA: REO-218

### DIFF
--- a/playbooks/vars/maas-agent.yml
+++ b/playbooks/vars/maas-agent.yml
@@ -28,6 +28,20 @@ maas_pip_packages:
   - psutil
   - rackspace-monitoring-cli
   - requests
+  - python-memcached
+  - PyYAML
+  - waxeye
+  - httplib2
+  - python-cinderclient
+  - python-glanceclient
+  - python-heatclient
+  - python-ironicclient
+  - python-keystoneclient
+  - python-magnumclient
+  - python-neutronclient
+  - python-novaclient
+  - python-openstackclient
+
 
 ## PIP for maas
 # Path to pip download/installation script.


### PR DESCRIPTION
Fix missing modules in venv

During our upgrades in phobos we found that the script wrapper
was pointing to an old venv.  After upgrading it to the new
maas-1.7.0 venv, we flooded the queue with tickets due to missing
venv modules.  I pulled all of the missing values from
/tmp/pip-constraints.txt and updated the vars/maas-agent.yml to
include them.  After re-running the site.yml all alearts cleared.