### PR TITLE
JIRA: REO-218

### DIFF
--- a/playbooks/templates/rax-maas/plugins/rabbitmq_status.py
+++ b/playbooks/templates/rax-maas/plugins/rabbitmq_status.py
@@ -181,7 +181,7 @@ def _get_node_metrics(session, metrics, protocol, host, port, name):
 def _get_queue_metrics(session, metrics, protocol, host, port):
     response = _get_rabbit_json(session, QUEUES_URL % (protocol, host, port))
     notification_messages = sum([q['messages'] for q in response
-                                if re.match('/^(versioned_)?notifications\.',
+                                if re.match('^/?(versioned_)?notifications\.',
                                             q['name']) and
                                 q['consumers'] > 0])
 


### PR DESCRIPTION
Fix issue with notifications matching

It looks like if a notifications queue match is currently not matching
notifications causing them not to be excluded. Here is a test of the
current match and a possible fix.  Some messages may or may not start
with '/' and may or may not have 'versioned_'.

root@573958-infra01:/opt/rpc-maas/playbooks# cat test_match.py

import re

test_names = ['notifications.info', 'versioned_notifications.info', '/notifications.info', '/versioned_notifications.info']

for name in test_names:

    if re.match('/^(versioned_)?notifications\.', name):
        print "Current RE matched %s" % name

    if re.match('^/?(versioned_)?notifications\.', name):
        print "Modified RE matched %s" % name

root@573958-infra01:/opt/rpc-maas/playbooks# ./test_match.py
Modified RE matched notifications.info
Modified RE matched versioned_notifications.info
Modified RE matched /notifications.info
Modified RE matched /versioned_notifications.info