### PR TITLE
TURTLES-769: Add alternate logic in hp_monitoring.py for encrypted volumes

### DIFF
--- a/playbooks/files/rax-maas/plugins/hp_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/hp_monitoring.py
@@ -52,7 +52,7 @@ def get_chassis_status(command, item):
 
 def get_drive_status(command):
     return check_command((command, 'ctrl', 'all', 'show', 'config'),
-                         'logicaldrive', 'OK)')
+                         'logicaldrive', ('OK)', 'OK, Encrypted)'))
 
 
 def get_controller_status(command):

--- a/releasenotes/notes/TURTLES-769-105ac4ec76e36667.yaml
+++ b/releasenotes/notes/TURTLES-769-105ac4ec76e36667.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Properly validate logical volume status if HP volume is encrypted


### PR DESCRIPTION
Properly validate logical volume status if HP volume is encrypted.