### PR TITLE
CEPHSTORA-226 Add ceph osd percent used monitor

### DIFF
--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -69,6 +69,12 @@ def get_ceph_osd_dump(client, keyring, fmt='json', container_name=None):
                          container_name=container_name)
 
 
+def get_ceph_osd_df(client, keyring, fmt='json', container_name=None):
+    return check_command(('ceph', '--format', fmt, '--name', client,
+                          '--keyring', keyring, 'osd', 'df'),
+                         container_name=container_name)
+
+
 def get_mon_statistics(client=None, keyring=None, host=None,
                        container_name=None):
     ceph_status = get_ceph_status(client=client,
@@ -113,6 +119,12 @@ def get_osd_statistics(client=None, keyring=None, osd_ids=None,
             if _osd['osd'] == osd_id:
                 osd = _osd
                 break
+
+        for _osd in osd_df['nodes']:
+            if _osd['id'] == osd_id:
+                maas_common.metric("%s_percent_used" % osd_ref,
+                        'uint32',
+                        int(_osd['utilization']))
 
 
 def get_cluster_statistics(client=None, keyring=None, container_name=None):

--- a/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
@@ -29,4 +29,16 @@ alarms      :
             if (metric["osd.{{ osd_id }}_up"] == 0) {
                 return new AlarmStatus(CRITICAL, "Ceph osd error.");
             }
+    osd_percent_used.{{ osd_id }} :
+        label                   : osd_percent_used.{{ osd_id }}--{{ inventory_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (('osd_percent_used.'+osd_id|string+'--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["osd.{{ osd_id }}_percent_used"] >= 85) {
+                return new AlarmStatus(CRITICAL, "Ceph osd is >= 85% full.");
+            }
+            if (metric["osd.{{ osd_id }}_percent_used"] >= 75) {
+                return new AlarmStatus(WARNING, "Ceph osd is >= 75% full.");
+            }
 {% endfor %}


### PR DESCRIPTION
Add alarms for individual ceph osds that are nearing the near full and
full thresholds.  Using static thresholds for now base off the default
thresholds, but ideally these thresholds would be dynamically generated
from the near-full and full ratios.