### PR TITLE
Revert limiting enablement of rgw checks to first node of group

### DIFF
--- a/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
@@ -9,7 +9,7 @@ type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled    : "{{ (inventory_hostname != groups['rgws'][0] or check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
     args    : {{ ceph_args }}

--- a/releasenotes/notes/CEPHSTORA-223-18f82d876ee8bc4d.yaml
+++ b/releasenotes/notes/CEPHSTORA-223-18f82d876ee8bc4d.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Revert limiting enablement of rgw checks to first node of each group. This was an incorrect assumption.


### PR DESCRIPTION
Revert limiting enablement of rgw checks to first node of group. This was an incorrect assumption as part of the NVA reduction work.