### PR TITLE
TURTLES-795: Tag maas_rally metrics with influxdb_database

### DIFF
--- a/playbooks/files/rax-maas/plugins/rally_performance.py
+++ b/playbooks/files/rax-maas/plugins/rally_performance.py
@@ -160,6 +160,8 @@ def send_metrics_to_influxdb(plugin_config, logger):
     influx_password = influx_config['password']
     tags = influx_config['tags']
 
+    tags['influxdb_database'] = influx_database
+
     client = InfluxDBClient(influx_host,
                             influx_port,
                             influx_user,

--- a/releasenotes/notes/tag_influxdb_database-ed7cf8d9fd13e57d.yaml
+++ b/releasenotes/notes/tag_influxdb_database-ed7cf8d9fd13e57d.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    maas_rally now adds an 'influxdb_database' tag to influxdb
+    datapoints, which allows for granular routing to different
+    backend influxdb databases using telegraf.


### PR DESCRIPTION
This change adds an 'influxdb_database' tag to each maas_rally metric sent to
an influxdb endpoint.  This simplifies routing when the influxdb endpoint is
actually an intermediary that ignores the database specified in the write (e.g.
telegraf's http_listener input plugin).

This enables routing to different influxdb databases in telegraf like this:

```
# maas_rally sends points here
[[inputs.http_listener]]
  service_address = ":8186"

# points with no 'influxdb_database' tag go to the 'telegraf' database
# (default case)
[[outputs.influxdb]]
  urls = ["http://localhost:8086"]
  database = "telegraf"
  [outputs.influxdb.tagdrop]
    influxdb_database = ["*"]

# points with a 'influxdb_database=maas_rally' tag go to the 'maas_rally'
# database
[[outputs.influxdb]]
  urls = ["http://localhost:8086"]
  database = "maas_rally"
  tagexclude = ["influxdb_database"]
  [ouputs.influxdb.tagpass]
    influxdb_database = ["maas_rally"]
```