### PR TITLE
TURTLES-823: Simplify maas_rally pip dependencies & constraints

### DIFF
--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -77,18 +77,12 @@
   hosts: "{{ maas_rally_target_group }}"
   gather_facts: true
   pre_tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-
     - name: Install maas and maas_rally pip packages to venv
       pip:
-        name: "{{ maas_pip_packages | union(maas_rally_pip_packages) | join(' ') }}"
+        name: "{{ maas_rally_pip_packages | join(' ') }}"
         state: "{{ maas_rally_pip_package_state }}"
         extra_args: >-
           --isolated
-          --constraint /tmp/pip-constraints.txt
           {{ pip_install_options | default('') }}
         virtualenv: "{{ maas_rally_venv }}"
       register: install_pip_packages

--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -219,11 +219,12 @@ maas_rally_pip_package_state: present
 # pip packages required for plugin functionality
 #
 maas_rally_pip_packages:
-  - "git+{{ maas_rally_git_repo }}@{{ maas_rally_git_version }}#egg=rally"
   - influxdb
+  - "keystoneauth1>=3.0.0"
+  - "git+https://github.com/openstack/monitorstack@master#egg=monitorstack"
   - numpy
-  - "openstacksdk<0.12.0"
   - pymysql
+  - "git+{{ maas_rally_git_repo }}@{{ maas_rally_git_version }}#egg=rally"
 
 #
 #  Default values for performance checks.  They are intentionally conservative

--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -103,6 +103,15 @@ neutron_provider_networks:
   fi
 }
 
+function add_lxc_overrides {
+  if [ ! -e /etc/openstack_deploy/user_resolvconf_fix.yml ] ; then
+    touch /etc/openstack_deploy/user_resolvconf_fix.yml
+  fi
+  echo '
+lxc_cache_prep_pre_commands: "rm -f /etc/resolv.conf || true"
+lxc_cache_prep_post_commands: "ln -s ../run/resolvconf/resolv.conf /etc/resolv.conf -f"' | tee -a /etc/openstack_deploy/user_resolvconf_fix.yml
+}
+
 ## Main ----------------------------------------------------------------------
 
 echo "Gate test starting
@@ -172,6 +181,9 @@ pushd /opt/openstack-ansible
   elif [ "${RE_JOB_SCENARIO}" == "newton" ]; then
     git checkout "stable/newton"  # Branch checkout of Newton (Current Stable)
     enable_ironic
+    # NOTE(tonytan4ever): newton needs this to get around gating:
+    # https://rackspace.slack.com/archives/CAD5VFMHU/p1525445460000172
+    add_lxc_overrides
 
   elif [ "${RE_JOB_SCENARIO}" == "ocata" ]; then
     git checkout "stable/ocata"  # Branch checkout of Ocata (Current Stable)


### PR DESCRIPTION
This change removes maas_rally's dependency on the MaaS virtual environment's
pip requirements and constraints.  The catalyst for this was gating failures
related to the version of python-magnumclient pinned in the standard maas
virtual environment.

Troubleshooting revealed that maas_rally only needed monitorstack from the maas
requirements list.

Itemized changes:

- Remove task to copy pip-constraints.txt during maas_rally venv build
- Remove references to pip-constraints.txt from maas_rally venv build
- Remove references to maas_pip_packages ansible var from maas_rally venv build
- Add monitorstack dependency to maas_rally_pip_packages ansible var
- Swap openstacksdk upper constraint for a keystoneauth1 lower constraint (an
  improvement of 551dd6b)