### PR TITLE
Fix non-quoted metric in Octavia quota template

### DIFF
--- a/playbooks/templates/rax-maas/octavia_quota_check.yaml.j2
+++ b/playbooks/templates/rax-maas/octavia_quota_check.yaml.j2
@@ -17,7 +17,7 @@ alarms      :
         disabled                : {{ ((quota+'--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (metric["{{ quota }}] >=90 ) {
+            if (metric["{{ quota }}"] >=90 ) {
                 return new AlarmStatus(CRITICAL, "Octavia quota {{ quota }} almost exceeded");
             }
 {% endfor %}

--- a/releasenotes/notes/fix-octavia-quota-template-1eff1e297338dc94.yaml
+++ b/releasenotes/notes/fix-octavia-quota-template-1eff1e297338dc94.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fix non-quoted metric in Octavia quota template.


### PR DESCRIPTION
Fix non-quoted metric in Octavia quota template