### PR TITLE
TURTLES-832: Add example telegraf->Datadog configuration for maas_rally

### DIFF
--- a/contrib/maas_rally_telegraf_datadog_example.conf
+++ b/contrib/maas_rally_telegraf_datadog_example.conf
@@ -1,0 +1,48 @@
+# This is an example telegraf configuration snippet that accepts input from the
+# maas_rally performance monitoring plugin and sends it to the Datadog metrics
+# API.  This file could be copied to /etc/telegraf/telegraf.d/maas_rally.conf
+# on the nodes where maas_rally runs. Note that the telegraf agent would
+# already need to be installed and have basic configuration in place.
+#
+# A corresponding maas_rally configuration example would be (i.e. in
+# /etc/openstack_deploy/user_maas_vars.yml):
+#
+# # Send performance metrics to local telegraf http_listener
+# maas_rally_influxdb_enabled: true
+# maas_rally_influxdb_port: localhost
+# maas_rally_influxdb_port: 8186
+#
+
+# INPUT: Start a listener to accept metrics from the maas_rally performance
+# monitoring plugin.
+[[inputs.http_listener]]
+  # Address and port to listen on.
+  service_address = "127.0.0.1:8186"
+
+  # Prefix all measurements sent to this port with "rally_".  For example, this transforms
+  # "cinder" into "rally_cinder" and makes it easier to filter metrics when
+  # creating Datadog dashboards.
+  name_prefix = "rally_"
+
+  # If you use a single iteration per poll, then there's no reason to send
+  # these metrics to Datadog.
+  fielddrop = ["*_90pctl", "*_95pctl", "*_max", "*_median", "*_min",
+               "*_sample_count", "*_sample_concurrency"]
+
+  # Add a tag so we can identify and filter on measurements that came through
+  # this port.  We'll strip this back off before shipping to the Datadog API.
+  [inputs.http_listener.tags]
+    datadog = "true"
+
+# OUTPUT: Send maas_rally metrics to Datadog.
+[[outputs.datadog]]
+  # This is the API key found on Datadog's "Integrations -> APIs" page.
+  apikey = "aaaa1111bbbb2222cccc3333dddd4444"
+
+  # Discard the datadog tag we added in the input plugin for filtering purposes.
+  tagexclude = ["datadog"]
+
+  # Filter out (don't send to Datadog) any measurements that didn't come from
+  # maas_rally.
+  [outputs.datadog.tagpass]
+    datadog = ["true"]

--- a/playbooks/files/rax-maas/plugins/rally_performance.py
+++ b/playbooks/files/rax-maas/plugins/rally_performance.py
@@ -160,8 +160,6 @@ def send_metrics_to_influxdb(plugin_config, logger):
     influx_password = influx_config['password']
     tags = influx_config['tags']
 
-    tags['influxdb_database'] = influx_database
-
     client = InfluxDBClient(influx_host,
                             influx_port,
                             influx_user,

--- a/releasenotes/notes/tag_influxdb_database-ed7cf8d9fd13e57d.yaml
+++ b/releasenotes/notes/tag_influxdb_database-ed7cf8d9fd13e57d.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    maas_rally now adds an 'influxdb_database' tag to influxdb
-    datapoints, which allows for granular routing to different
-    backend influxdb databases using telegraf.


### PR DESCRIPTION
This PR adds an example telegraf -> Datadog configuration snippet to the
contrib/ directory.  This example can be used by deployers who wish to ship
maas_rally performance metrics to Datadog for visualization and analysis.