### PR TITLE
Include lb_ssl_expiry_check in the API check category

### DIFF
--- a/playbooks/templates/common/macros.jinja
+++ b/playbooks/templates/common/macros.jinja
@@ -1,5 +1,5 @@
 {% macro get_check_category(check_label) %}
-{% if check_label.startswith('lb_api') or check_label.startswith('private_lb_api') %}
+{% if check_label.startswith('lb_') or check_label.startswith('private_lb_') %}
 api
 {% elif check_label.startswith('managed_k8') %}
 kubernetes

--- a/releasenotes/notes/fix_lb_ssl_metadata-cad42e09e426daf9.yaml
+++ b/releasenotes/notes/fix_lb_ssl_metadata-cad42e09e426daf9.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Update metadata macro to include lb_ssl_expiry_check and private_lb_ssl_expiry_check in the API category.


### PR DESCRIPTION
Update metadata macro to include lb_ssl_expiry_check and private_lb_ssl_expiry_check in the API category.