### PR TITLE
Remove conflicting nova_console_type override

### DIFF
--- a/playbooks/templates/rax-maas/nova_console_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_console_check.yaml.j2
@@ -1,12 +1,12 @@
 {% from "templates/common/macros.jinja" import get_metadata with context %}
 {% set label = "nova_console_check" %}
 {% set check_name = label+'--'+inventory_hostname %}
-{% if nova_console_type == 'spice' %}
+{% if maas_nova_console_type == 'spice' %}
 {% set console_service_name = 'nova_spice' %}
-{% set nova_console_base_url = 'spice_auto.html' %}
-{% elif nova_console_type == 'novnc' %}
+{% set maas_nova_console_base_url = 'spice_auto.html' %}
+{% elif maas_nova_console_type == 'novnc' %}
 {% set console_service_name = 'nova_novnc' %}
-{% set nova_console_base_url = 'vnc_auto.html' %}
+{% set maas_nova_console_base_url = 'vnc_auto.html' %}
 {% endif %}
 type        : agent.plugin
 label       : "{{ check_name }}"
@@ -15,7 +15,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (check_name | match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/service_api_local_check.py", "{{ console_service_name }}", "{{ ansible_host }}", "{{ nova_console_port }}", "--path", "{{ nova_console_base_url }}"]
+    args    : ["{{ maas_plugin_dir }}/service_api_local_check.py", "{{ console_service_name }}", "{{ ansible_host }}", "{{ maas_nova_console_port }}", "--path", "{{ maas_nova_console_base_url }}"]
     timeout : {{ (maas_check_timeout_override[label] | default(maas_check_timeout) * 1000) }}
 {{ get_metadata(label).strip() }}
 {# Add extra metadata options with two leading white spaces #}
@@ -27,5 +27,5 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (metric["{{ console_service_name }}_api_local_status"] != 1) {
-                return new AlarmStatus(CRITICAL, "nova {{ nova_console_type }} console down");
+                return new AlarmStatus(CRITICAL, "nova {{ maas_nova_console_type }} console down");
             }

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -170,12 +170,12 @@ swift_release: "{{ openstack_release }}"
 swift_recon_path: "/openstack/venvs/swift-{{ swift_release }}/bin"
 
 # Set the nova console type and port
-nova_console_type: novnc
-nova_console_ports:
+maas_nova_console_type: "{{ nova_console_type | default('novnc') }}"
+maas_nova_console_ports:
   novnc: 6080
   spice: 6082
 
-nova_console_port: "{{ nova_console_ports[nova_console_type] }}"
+maas_nova_console_port: "{{ maas_nova_console_ports[maas_nova_console_type] }}"
 
 maas_openstack_octavia_pip_packages:
   - python-keystoneclient

--- a/releasenotes/notes/map-nova-console-to-maas-vars-cdbd5bbe6ce4e6e8.yaml
+++ b/releasenotes/notes/map-nova-console-to-maas-vars-cdbd5bbe6ce4e6e8.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Map nova_console_type and nova_console_port back to a maas_* variable. These are defaults in
+    OSA and aren't pulled in properly from the ansible role. This will allow overrides to be
+    configured in a less obtrusive way.


### PR DESCRIPTION
`nova_console_type` is renamed to `maas_nova_console_type`
along with `nova_console_ports` which is also renamed to
`maas_nova_console_ports` in order to prevent variable
inheritance issues deriving from OSA use.