### PR TITLE
Update maas_checks_util for Python 2, new checks

### DIFF
--- a/doc/utils/README.rst
+++ b/doc/utils/README.rst
@@ -1,9 +1,13 @@
-maas_checks_util.py
-===================
+maas_checks_config.py
+=====================
 
-The ``maas_checks_util`` module includes a ``check_details`` generator
-which yields check names and corresponding details about them. These
-include the alarms within each check as well as the criteria that
+The ``maas_checks_config`` module includes a ``check_details`` generator
+which yields check names and corresponding details about them,
+as well as a ``categorized_check_details`` function which returns check names
+and their corresponding details within a dictionary organized by check
+category.
+
+These include the alarms within each check as well as the criteria that
 MaaS evaluates in order to trigger an alarm status. It additionally
 includes any variables that can be configured to change how a given
 alarm operates. The current use for this module is within the
@@ -12,7 +16,8 @@ documentation so it can be fully automated, rather than hand generated.
 Requirements
 ------------
 
-This module requires at least Python 3.6.
+As the docs build itself requires Python 2.7, this module should
+continue to use 2.7.
 
 See requirements.txt for version requirements of the module's
 dependencies, including Ansible, PyYAML, and Jinja2.
@@ -23,10 +28,10 @@ Usage
 This module is used from within the rcbops/privatecloud-docs repo
 from a Sphinx extension. That extension checks out this repo,
 runs `pip install -r requirements.txt`, and then imports and uses
-the ``check_details`` generator. In order to develop and use this
+the ``categorized_check_details`` function. In order to develop and use this
 module locally while contributing to it, you'll need to create a
 virtualenv and install those same requirements. ::
 
-    python3.6 -m venv maas-util-env
+    virtualenv -p python2.7 maas-util-venv
     source maas-util-env/bin/activate
     pip install -r requirements.txt


### PR DESCRIPTION
Per INTAKERPC-120 and TURTLES-802, this utility needs to be changed to work on Python 2.7 as well as updated to handle newly added checks. Additionally, there was an ask to utilize the categorization that check templates now expose.

This change updates the Jinja undefined handler to work with both Python 2 and Python 3 as well as the necessary changes to stop ignoring some newer checks that we were skipping.

Additionally, the module was renamed slightly so it's easier to talk about both the docs end of this and the rpc-maas end of it.