### PR TITLE
CEPHSTORA-304 Allow MaaS to use a different radosgw_address

### DIFF
--- a/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
@@ -2,7 +2,15 @@
 {% set label = "ceph_rgw_stats" %}
 {% set check_name = label+'--'+inventory_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
-{% set _ = ceph_args.extend(["rgw", "--rgw_address", ceph_radosgw_protocol + "://" + ansible_host + ":" + radosgw_civetweb_port | string ]) %}
+{% if radosgw_address is defined and radosgw_address != 'address' %}
+{%   set _rgw_listen_addr = radosgw_address %}
+{% elif radosgw_address_block is defined and radosgw_address_block != 'subnet' %}
+{%   set _rgw_listen_addr = hostvars[inventory_hostname]['ansible_all_ipv4_addresses'] | ipaddr(radosgw_address_block) | first %}
+{% elif radosgw_interface is defined and radosgw_interface != 'interface' %}
+{%   set _rgw_interface_name = 'ansible_' + (hostvars[inventory_hostname]['radosgw_interface'] | replace('-', '_')) %}
+{%   set _rgw_listen_addr = hostvars[inventory_hostname][_rgw_interface_name]['ipv4']['address'] %}
+{% endif %}
+{% set _ = ceph_args.extend(["rgw", "--rgw_address", ceph_radosgw_protocol + "://" + _rgw_listen_addr | default(ansible_host) + ":" + radosgw_civetweb_port | string ]) %}
 {% set _ceph_args = ceph_args | to_yaml(width=1000) %}
 {% set ceph_args = _ceph_args %}
 

--- a/releasenotes/notes/ceph_rgw_address-6116f3f9c3906afd.yaml
+++ b/releasenotes/notes/ceph_rgw_address-6116f3f9c3906afd.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - Add the ability to specify the Ceph rados Gateway
+    listen address for MaaS monitoring. Using the existing
+    ``ceph-ansible`` vars which are, in order of precedence.
+    ``radosgw_address`` which is used to specify the address.
+    ``radosgw_address_block`` which can be used to specify
+    the address block in CIDR format/
+    ``radosgw_interface`` which can be used to specify the
+    interface on which RadosGW is listening, for example
+    ``br-storage``.
+    If none of these options are specified the ``ansible_host``
+    address will be used.


### PR DESCRIPTION
This PR allows you to use an address for Rados GW that is not the
default ansilbe_host address.

The method utilises the existing ceph-ansible variables to define the
radosgw_address, radosgw_address_block or radosgw_interface, as you
would in ceph-ansible. This is to ensure that ceph-ansible has
configured Rados GW to listen on the same address as we set up MaaS to
monitor against.