### PR TITLE
TURTLES-894: WARN neutron/nova agents/computes/schedulers node if can't reach API

### DIFF
--- a/playbooks/files/rax-maas/plugins/neutron_service_check.py
+++ b/playbooks/files/rax-maas/plugins/neutron_service_check.py
@@ -15,11 +15,13 @@
 # limitations under the License.
 
 import argparse
+import sys
 
 from maas_common import get_neutron_client
 from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
+from maas_common import status_err_no_exit
 from maas_common import status_ok
 
 
@@ -33,7 +35,8 @@ def check(args):
     # not gathering api status metric here so catch any exception
     except Exception as e:
         metric_bool('client_success', False, m_name='maas_neutron')
-        status_err(str(e), m_name='maas_neutron')
+        status_err_no_exit(str(e), m_name='maas_neutron')
+        sys.exit(0)
     else:
         metric_bool('client_success', True, m_name='maas_neutron')
 

--- a/playbooks/files/rax-maas/plugins/nova_service_check.py
+++ b/playbooks/files/rax-maas/plugins/nova_service_check.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import sys
 
 from maas_common import get_auth_ref
 from maas_common import get_keystone_client
@@ -22,6 +23,7 @@ from maas_common import get_nova_client
 from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err
+from maas_common import status_err_no_exit
 from maas_common import status_ok
 
 
@@ -42,7 +44,8 @@ def check(auth_ref, args):
     # not gathering api status metric here so catch any exception
     except Exception as e:
         metric_bool('client_success', False, m_name='maas_nova')
-        status_err(str(e), m_name='maas_nova')
+        status_err_no_exit(str(e), m_name='maas_nova')
+        sys.exit(0)
     else:
         metric_bool('client_success', True, m_name='maas_nova')
 

--- a/playbooks/templates/rax-maas/neutron_dhcp_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_dhcp_agent_check.yaml.j2
@@ -19,6 +19,9 @@ alarms      :
         disabled                : {{ (('neutron_dhcp_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["client_success"] != 1) {
+                return new AlarmStatus(WARNING, "neutron dhcp agent can't reach API");
+            }
             if (metric["neutron-dhcp-agent_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "neutron-dhcp-agent down");
             }

--- a/playbooks/templates/rax-maas/neutron_l3_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_l3_agent_check.yaml.j2
@@ -19,6 +19,9 @@ alarms      :
         disabled                : {{ (('neutron_l3_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["client_success"] != 1) {
+                return new AlarmStatus(WARNING, "neutron l3 agent can't reach API");
+            }
             if (metric["neutron-l3-agent_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "neutron-l3-agent down");
             }

--- a/playbooks/templates/rax-maas/neutron_linuxbridge_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_linuxbridge_agent_check.yaml.j2
@@ -19,6 +19,9 @@ alarms      :
         disabled                : {{ (('neutron_linuxbridge_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["client_success"] != 1) {
+                return new AlarmStatus(WARNING, "neutron linux-agent can't reach API");
+            }
             if (metric["neutron-linuxbridge-agent_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "neutron-linuxbridge-agent down");
             }

--- a/playbooks/templates/rax-maas/neutron_metadata_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_metadata_agent_check.yaml.j2
@@ -19,6 +19,9 @@ alarms      :
         disabled                : {{ (('neutron_metadata_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["client_success"] != 1) {
+                return new AlarmStatus(WARNING, "neutron metadata agent can't reach API");
+            }
             if (metric["neutron-metadata-agent_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "neutron-metadata-agent down");
             }

--- a/playbooks/templates/rax-maas/neutron_metering_agent_check.yaml.j2
+++ b/playbooks/templates/rax-maas/neutron_metering_agent_check.yaml.j2
@@ -19,6 +19,9 @@ alarms      :
         disabled                : {{ (('neutron_metering_agent_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["client_success"] != 1) {
+                return new AlarmStatus(WARNING, "neutron metering agent can't reach API");
+            }
             if (metric["neutron-metering-agent_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "neutron-metering-agent down");
             }

--- a/playbooks/templates/rax-maas/nova_cert_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_cert_check.yaml.j2
@@ -19,6 +19,9 @@ alarms      :
         disabled                : {{ (('nova_cert_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["client_success"] != 1) {
+                return new AlarmStatus(WARNING, "Nova cert service can't reach API");
+            }
             if (metric["nova-cert_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "nova-cert down");
             }

--- a/playbooks/templates/rax-maas/nova_compute_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_compute_check.yaml.j2
@@ -19,6 +19,9 @@ alarms      :
         disabled                : {{ (('nova_compute_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["client_success"] != 1) {
+                return new AlarmStatus(WARNING, "Nova compute service can't reach API");
+            }
             if (metric["nova-compute_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "nova-compute down");
             }

--- a/playbooks/templates/rax-maas/nova_conductor_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_conductor_check.yaml.j2
@@ -19,6 +19,9 @@ alarms      :
         disabled                : {{ (('nova_conductor_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["client_success"] != 1) {
+                return new AlarmStatus(WARNING, "Nova conductor can't reach API");
+            }
             if (metric["nova-conductor_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "nova-conductor down");
             }

--- a/playbooks/templates/rax-maas/nova_consoleauth_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_consoleauth_check.yaml.j2
@@ -19,6 +19,9 @@ alarms      :
         disabled                : {{ (('nova_consoleauth_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["client_success"] != 1) {
+                return new AlarmStatus(WARNING, "Nova consoleauth service can't reach API");
+            }
             if (metric["nova-consoleauth_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "nova-consoleauth down");
             }

--- a/playbooks/templates/rax-maas/nova_scheduler_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_scheduler_check.yaml.j2
@@ -19,6 +19,9 @@ alarms      :
         disabled                : {{ (('nova_scheduler_status--'+inventory_hostname) | match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["client_success"] != 1) {
+                return new AlarmStatus(WARNING, "Nova scheduler service can't reach API");
+            }
             if (metric["nova-scheduler_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "nova-scheduler down");
             }


### PR DESCRIPTION
@npawelek:   As per our conversation,  when the API node can't be reached from agent/computer nodes: https://github.com/rcbops/rpc-maas/blob/master/playbooks/files/rax-maas/plugins/neutron_service_check.py#L35, We generate a warning instead of letting plugin exit(1)