### PR TITLE
Add bandit to tox.ini

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,6 +7,7 @@ pyasn1 # BSD
 pyOpenSSL>=0.14 # Apache-2.0
 requests[security]
 ndg-httpsclient>=0.4.2;python_version<'3.0' # BSD
+bandit>=1.4.0
 
 # this is required for the docs build jobs
 sphinx>=1.5.1 # BSD

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.0
 skipsdist = True
-envlist = bindep,docs,linters,functional
+envlist = bindep,docs,linters,bandit,functional
 sitepackages = True
 
 
@@ -44,6 +44,13 @@ deps =
 commands =
     bash -c "{toxinidir}/run-bindep.sh"
 
+[testenv:bandit]
+# Ignore B404 about importing subprocess and B410 about importing lxml.
+# We're knowingly and intentionally using those and don't need a warning
+# about mere usage alone. Specific warnings about those packages will
+# still come through as they're found.
+commands =
+    bandit -s B404,B410 -r playbooks/
 
 [testenv:docs]
 commands =


### PR DESCRIPTION
This change adds support for the bandit security static analyzer tool, per https://rpc-openstack.atlassian.net/browse/TURTLES-1017.

This is currently configured to run bandit against any Python code it finds inside the playbooks directory, which is all of the plugin code that the maas checks run. It is additionally configured to ignore two low severity checks that are about the existence of import statements for subprocess and lxml. We use those libraries intentionally, so we don't need to be warned that their introduction to our codebase are potentially vulnerable to issues. Ignoring those two warnings doesn't ignore warnings emitted around specific vulnerabilities found.