### PR TITLE
Run bandit twice for extra logging

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,14 @@ commands =
 # about mere usage alone. Specific warnings about those packages will
 # still come through as they're found.
 commands =
-    bandit -s B404,B410 -r playbooks/
+# Until bandit has the ability to log issues at lower severities than it's
+# configured to pass/fail based on, we need to run bandit twice. Run it
+# once with no severity or confidence level set to get everything, but ignore
+# that exit status. Then run it again on the highest severity and confidence
+# levels and get our pass/fail status from that.
+# This is reported to bandit at https://github.com/PyCQA/bandit/issues/341
+    - bandit -s B404,B410 -i -l -r playbooks/
+    bandit -s B404,B410 -iii -lll -r playbooks/
 
 [testenv:docs]
 commands =


### PR DESCRIPTION
Bandit currently is not able to output issues at severities lower than what it's configured to run and evaluate pass/fail status of, but we still need to know about those lower severity issues rather than ignore them. Since bandit runs in a matter of seconds, this change runs bandit at the lowest level to get a log of every possible issue, but it ignores the exit code (the leading '-' does this). The second run of bandit runs at the most strict level, and that's what we pass or fail based on.

See https://github.com/PyCQA/bandit/issues/341 for a feature request entered that would remove the need for us to run twice.