### PR TITLE
Update bonding_iface_check.py

### DIFF
--- a/playbooks/files/rax-maas/plugins/bonding_iface_check.py
+++ b/playbooks/files/rax-maas/plugins/bonding_iface_check.py
@@ -36,15 +36,17 @@ def bonding_ifaces_check(_):
         )
 
         has_slave_down = False
+        slave_count = 0
         for idx, line in enumerate(bonding_iface_check_cmd_output_lines):
             if line.startswith("Slave Interface"):
+                slave_count = slave_count + 1
                 slave_inface_mii_status_line = (
                     bonding_iface_check_cmd_output_lines[idx + 1]
                 )
                 slave_inface_mii_status = (
                     slave_inface_mii_status_line.split(":")[1]
                 )
-                if 'down' in slave_inface_mii_status:
+                if not 'up' in slave_inface_mii_status or slave_count < 2:
                     has_slave_down = True
 
         if has_slave_down:

--- a/playbooks/files/rax-maas/plugins/bonding_iface_check.py
+++ b/playbooks/files/rax-maas/plugins/bonding_iface_check.py
@@ -46,7 +46,7 @@ def bonding_ifaces_check(_):
                 slave_inface_mii_status = (
                     slave_inface_mii_status_line.split(":")[1]
                 )
-                if not 'up' in slave_inface_mii_status or slave_count < 2:
+                if 'up' not in slave_inface_mii_status or slave_count < 2:
                     has_slave_down = True
 
         if has_slave_down:

--- a/releasenotes/notes/bonding-interface-update-e5d4d19d8aec74d0.yaml
+++ b/releasenotes/notes/bonding-interface-update-e5d4d19d8aec74d0.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Add slave_count to ensure the bond has redundancy and check explicitly for not "up"
+    This ensures a bond slave that is marked down (should only occur in a maintenance 
+    window) triggers an alert.
+


### PR DESCRIPTION
Add slave_count to ensure the bond has redundancy and check explicitly for not "up"

This ensures a bond slave that is marked down (should only occur in a maintenance window) triggers an alert.