### PR TITLE
Remove - vars/maas-{{ ansible_distribution | lower }}.yml include as it

### DIFF
--- a/playbooks/maas-agent-install.yml
+++ b/playbooks/maas-agent-install.yml
@@ -131,6 +131,5 @@
   vars_files:
     - vars/main.yml
     - vars/maas-agent.yml
-    - vars/maas-{{ ansible_distribution | lower }}.yml
   tags:
     - maas-agent-install

--- a/releasenotes/notes/remove-agent-install-maas-vars-file-include-d4efdbc1496308ca.yaml
+++ b/releasenotes/notes/remove-agent-install-maas-vars-file-include-d4efdbc1496308ca.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Remove - vars/maas-{{ ansible_distribution | lower }}.yml include as 
+    it is redundant and problematic for RPC-R Maas work


### PR DESCRIPTION
is redundant and problematic for RPC-R Maas work