### PR TITLE
JIRA: REO-336 Fix octavia playbook issues due to rpc-r additions

### DIFF
--- a/playbooks/maas-openstack-octavia.yml
+++ b/playbooks/maas-openstack-octavia.yml
@@ -72,24 +72,30 @@
 
     - name: Get project id (RPC-O)
       shell: ". {{ maas_openrc|default('/root/openrc') }} && openstack project list --user octavia -c ID -f value"
-      register: octavia_project_return
+      register: octavia_project_return_rpco
       delegate_to: "{{ groups['utility_all'][0] }}"
       when: not deploy_osp|default(false)
       tags:
         - skip_ansible_lint
 
+    - name: Set project id when rpc-o
+      set_fact:
+        octavia_project_id: "{{ octavia_project_return_rpco.stdout }}"
+      when: not deploy_osp|default(false)
+
     - name: Get project id (RPC-R)
       shell: ". {{ director_openrc }} && openstack project show service -c id -f value"
-      register: octavia_project_return
+      register: octavia_project_return_rpcr
       run_once: true
       delegate_to: "localhost"
       when: deploy_osp|default(false)
       tags:
         - skip_ansible_lint
 
-    - name: Set project id
+    - name: Set project id when rpc-r
       set_fact:
-        octavia_project_id: "{{ octavia_project_return.stdout }}"
+        octavia_project_id: "{{ octavia_project_return_rpcr.stdout }}"
+      when: deploy_osp|default(false)
 
     - name: Install octavia quota check
       template:

--- a/releasenotes/notes/fix-octavia-rpc-r-register-issue.yaml
+++ b/releasenotes/notes/fix-octavia-rpc-r-register-issue.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - The rpc-r additions were unsetting a variable causing a set_fact task to fail on rpc-o environments.
+    This is to make sure both checks use a different registered variable and set the fact based on the
+    rpc-o vs rpc-r conditionals.
+


### PR DESCRIPTION
  https://github.com/rcbops/rpc-maas/blob/master/playbooks/maas-openstack-octavia.yml#L73-L92

  It looks like the 'Get project id (RPC-R)' task is overwriting the octavia_project_return
  registered variable even when skipped.  This causes the 'Set project id' task to fail on
  rpc-o environments as it tries to pull from the stdout of the shell command.  This fix just
  sets up a different var and set_fact task for each based on the same conditionals.