### PR TITLE
Fixes Glance & Cinder API Version Check Issue

### DIFF
--- a/playbooks/files/rax-maas/plugins/maas_common.py
+++ b/playbooks/files/rax-maas/plugins/maas_common.py
@@ -668,7 +668,7 @@ def get_auth_details(openrc_file=OPENRC, maasrc_file=MAASRC):
                         continue
                     k = match.group('key')
                     v = match.group('value').strip('"').strip("'")
-                    if k in auth_details and auth_details[k] is None:
+                    if k in auth_details:
                         auth_details[k] = v
     except IOError as e:
         if e.errno != errno.ENOENT:

--- a/playbooks/files/rax-maas/plugins/maas_common.py
+++ b/playbooks/files/rax-maas/plugins/maas_common.py
@@ -38,8 +38,8 @@ AUTH_DETAILS = {'OS_USERNAME': None,
                 'OS_ENDPOINT_TYPE': 'PublicURL',
                 'OS_IDENTITY_API_VERSION': None,
                 'OS_API_INSECURE': False,
-                'OS_VOLUME_API_VERSION': None,
-                'OS_IMAGE_API_VERSION': None, }
+                'OS_VOLUME_API_VERSION': 1,
+                'OS_IMAGE_API_VERSION': 1}
 
 if 'Ubuntu' in platform.linux_distribution()[0]:
     AUTH_DETAILS.update({

--- a/releasenotes/notes/fix-glance-cinder-api-version-issue.yaml
+++ b/releasenotes/notes/fix-glance-cinder-api-version-issue.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - The maas_common.py is setting OS_VOLUME_API_VERSION and
+    OS_IMAGE_API_VERSION with a default of None.  This caused
+    calls to get_auth_details to fail a key check for 'None'
+    causing nova and neutron checks to fail of those variables
+    are not being set in the environment anywhere. 


### PR DESCRIPTION
 The maas_common.py is setting OS_VOLUME_API_VERSION and
 OS_IMAGE_API_VERSION with a default of None.  This caused
 calls to get_auth_details to fail a key check for 'None'
 causing nova and neutron checks to fail of those variables
 are not being set in the environment anywhere.

JIRA: REO-343