### PR TITLE
Some 1.7.8 checks (nova api) breaks in absence of maasrc file.  This fix

### DIFF
--- a/playbooks/files/rax-maas/plugins/maas_common.py
+++ b/playbooks/files/rax-maas/plugins/maas_common.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 from __future__ import print_function
 
-from itertools import chain
 import contextlib
 import datetime
 import errno
@@ -652,8 +651,8 @@ def get_auth_details(openrc_file=OPENRC, maasrc_file=MAASRC):
     )
 
     try:
-        with open(openrc_file) as openrc, open(maasrc_file) as maasrc:
-            for line in chain(openrc, maasrc):
+        with open(openrc_file) as openrc:
+            for line in openrc:
                 match = pattern.match(line)
                 if match is None:
                     continue
@@ -661,6 +660,16 @@ def get_auth_details(openrc_file=OPENRC, maasrc_file=MAASRC):
                 v = match.group('value').strip('"').strip("'")
                 if k in auth_details and auth_details[k] is None:
                     auth_details[k] = v
+        if os.path.exists(maasrc_file):
+            with open(maasrc_file) as maasrc:
+                for line in maasrc:
+                    match = pattern.match(line)
+                    if match is None:
+                        continue
+                    k = match.group('key')
+                    v = match.group('value').strip('"').strip("'")
+                    if k in auth_details and auth_details[k] is None:
+                        auth_details[k] = v
     except IOError as e:
         if e.errno != errno.ENOENT:
             status_err(str(e), m_name='maas_keystone')

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -79,7 +79,6 @@
     - name: Set MaaS product metadata facts
       set_fact:
         maas_product: "{{ (rendered_maas_metata_test_tmpl | from_yaml).metadata.product }}"
-        maas_product_version: "{{ (rendered_maas_metata_test_tmpl | from_yaml).metadata.product_version }}"
         maas_osa_version: "{{ (rendered_maas_metata_test_tmpl | from_yaml).metadata.osa_version }}"
 
     # For Queens and beyond, use image api version 2 and volume api version 3

--- a/playbooks/templates/rax-maas/run_plugin_in_rally_venv.sh.j2
+++ b/playbooks/templates/rax-maas/run_plugin_in_rally_venv.sh.j2
@@ -4,6 +4,10 @@ if [[ -f ~/openrc ]]; then
   source ~/openrc
 fi
 
+if [[ -f ~/maasrc ]]; then
+  source ~/maasrc
+fi
+
 # NOTE(cloudnull): Hard coded because this was never addressed upstream
 export OS_API_INSECURE=True
 

--- a/playbooks/templates/rax-maas/run_plugin_in_venv.sh.j2
+++ b/playbooks/templates/rax-maas/run_plugin_in_venv.sh.j2
@@ -4,6 +4,10 @@ if [[ -f {{ maas_openrc|default('~/openrc') }} ]]; then
   source {{ maas_openrc|default('~/openrc') }}
 fi
 
+if [[ -f {{ maas_maasrc|default('~/maasrc') }} ]]; then
+  source {{ maas_maasrc|default('~/maasrc') }}
+fi
+
 # NOTE(cloudnull): Hard coded because this was never addressed upstream
 export OS_API_INSECURE={{ maas_os_api_insecure|default('True') }}
 

--- a/releasenotes/notes/fixing-maas-rc-absent-checks-cda74b0d92f4e835.yaml
+++ b/releasenotes/notes/fixing-maas-rc-absent-checks-cda74b0d92f4e835.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Some 1.7.8 checks (nova api) breaks in absence of maasrc file.  This fix it. 
+    


### PR DESCRIPTION
it.