### PR TITLE
Report conntrack count for all namespaces

### DIFF
--- a/playbooks/templates/rax-maas/conntrack_count.yaml.j2
+++ b/playbooks/templates/rax-maas/conntrack_count.yaml.j2
@@ -20,8 +20,8 @@ alarms      :
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
             if (percentage(metric["nf_conntrack_count"] , metric["nf_conntrack_max"]) > {{ maas_nf_conntrack_critical_threshold }}) {
-                return new AlarmStatus(CRITICAL, "Connection count is > {{ maas_nf_conntrack_critical_threshold }}% of maximum allowed.");
+                return new AlarmStatus(CRITICAL, "Connection tracking count is > {{ maas_nf_conntrack_critical_threshold }}% of the critical threshold. Please check all namespaces listed at /var/run/netns including the host.");
             }
             if (percentage(metric["nf_conntrack_count"] , metric["nf_conntrack_max"]) > {{ maas_nf_conntrack_warning_threshold }}) {
-                return new AlarmStatus(WARNING, "Connection count is > {{ maas_nf_conntrack_warning_threshold }}% of maximum allowed.");
+                return new AlarmStatus(WARNING, "Connection tracking count is > {{ maas_nf_conntrack_warning_threshold }}% of the warning threshold. Please check all namespaces inside listed at /var/run/netns including the host.");
             }

--- a/releasenotes/notes/TURTLES-1006-add-ns-checks-conntack-plugin-5dcd0ff5de96a3b2.yaml
+++ b/releasenotes/notes/TURTLES-1006-add-ns-checks-conntack-plugin-5dcd0ff5de96a3b2.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    * The `conntrack_count.py` plugin is now checking for network namespaces
+      listed at `/var/run/netns` and retreives the iptables connection
+      tracking infomation for each namespace.
+      This ensures that embedded network namespaces are alerted in case
+      connection tracking hashes are about to exceed a configurable threshold.
+      Due to the limited availability of MAAS metrics per alarm, only the
+      namespace with the higest connection tracking count is reported.


### PR DESCRIPTION
In addition to checking the container root namespace,
nested namespaces inside the container are checked against the
container maximum configured connection tracking count.
Only the highest connection tracking count is reported, as
MAAS limites the number of metrics it can process.

Closes-Bug: TURTLES-1006