### PR TITLE
TURTLES-1516 Properly enable maas-verify.yml in all situations

### DIFF
--- a/playbooks/files/rax-maas/plugins/nfs_check.py
+++ b/playbooks/files/rax-maas/plugins/nfs_check.py
@@ -30,7 +30,7 @@ def nfs_export_check():
 
     output = subprocess.check_output(
         shlex.split(
-            "awk -F':' '/nfs/ {print $1}' /proc/mounts"
+            "awk -F':' '/ nfs / {print $1}' /proc/mounts"
         )
     )
     nfs_mounts = output.splitlines()

--- a/playbooks/files/rax-maas/tools/rpc-maas-tool.py
+++ b/playbooks/files/rax-maas/tools/rpc-maas-tool.py
@@ -554,7 +554,7 @@ class RpcMassCli(object):
         for check in checks:
             for exclude in self.args.excludedcheck:
                 # ping is a default check and may not have an alarm
-                if exclude in check.label:
+                if exclude in check.label and not check.disabled:
                     present_but_excluded_checks.append(check)
         if present_but_excluded_checks:
             LOGGER.info("The following checks are in the excluded_checks list"

--- a/playbooks/vars/maas-host.yml
+++ b/playbooks/vars/maas-host.yml
@@ -57,7 +57,7 @@ maas_filesystem_critical_threshold: 90.0
 _maas_disk_util_devices: |
   ---
   {% for device in ansible_devices.keys() %}
-  {%   if (device not in maas_excluded_devices | default([])) and (ansible_devices[device].model != 'VIRTUAL-DISK') and (ansible_devices[device].model != 'QEMU DVD-ROM') and ('nbd' not in device) %}
+  {%   if (device not in maas_excluded_devices | default([])) and (ansible_devices[device].model != 'VIRTUAL-DISK') and (ansible_devices[device].model != 'QEMU DVD-ROM') and ('nbd' not in device) and ('loop' not in device) %}
   - "{{ device }}"
   {%   endif %}
   {% endfor %}

--- a/releasenotes/notes/fix-maas-verify-turtles-1516-a34ec4deb64541f2.yaml
+++ b/releasenotes/notes/fix-maas-verify-turtles-1516-a34ec4deb64541f2.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - Fix rpc-maas-tool.py to report excludedchecks as the check will always be created
+  - Gating: Enable 'maas_verify_registration' in gating to validate alarms are created in the api
+  - Gating: Enable 'maas_verify_status' in gating to validate alarms are not critical after deployments
+  - Gating: Tweak existing variable overrides for different gating release versions. Remove alarm
+    exclusions, frequency changes, and update excluded checks to include 'horizon_local_check'
+    in newton and onward.

--- a/releasenotes/notes/fix-maas-verify-turtles-1516-a34ec4deb64541f2.yaml
+++ b/releasenotes/notes/fix-maas-verify-turtles-1516-a34ec4deb64541f2.yaml
@@ -1,6 +1,9 @@
 ---
 fixes:
   - Fix rpc-maas-tool.py to report excludedchecks as the check will always be created.
+  - Gating - Remove 'enable_ironic' from aio-create.sh as the functionality is not
+    currently supported and it is causing numerous critical alarms preventing maas-verify.yml
+    from passing. This can be added back to the necessary release versions when required.
   - Gating - Enable 'maas_verify_registration' in gating to validate alarms are created in the api.
   - Gating - Enable 'maas_verify_status' in gating to validate alarms are not critical after deployments.
   - Gating - Tweak existing variable overrides for different gating release versions and

--- a/releasenotes/notes/fix-maas-verify-turtles-1516-a34ec4deb64541f2.yaml
+++ b/releasenotes/notes/fix-maas-verify-turtles-1516-a34ec4deb64541f2.yaml
@@ -1,9 +1,12 @@
 ---
 fixes:
+  - Fix nfs_check.py to properly detect nfs file systems
   - Fix rpc-maas-tool.py to report excludedchecks as the check will always be created.
   - Gating - Remove 'enable_ironic' from aio-create.sh as the functionality is not
     currently supported and it is causing numerous critical alarms preventing maas-verify.yml
     from passing. This can be added back to the necessary release versions when required.
+  - Gating - Remove maas-tigkstack-all.yml from test playbooks. This functionality is
+    no longer supported as a product addition.
   - Gating - Enable 'maas_verify_registration' in gating to validate alarms are created in the api.
   - Gating - Enable 'maas_verify_status' in gating to validate alarms are not critical after deployments.
   - Gating - Tweak existing variable overrides for different gating release versions and

--- a/releasenotes/notes/fix-maas-verify-turtles-1516-a34ec4deb64541f2.yaml
+++ b/releasenotes/notes/fix-maas-verify-turtles-1516-a34ec4deb64541f2.yaml
@@ -1,8 +1,11 @@
 ---
 fixes:
-  - Fix rpc-maas-tool.py to report excludedchecks as the check will always be created
-  - Gating: Enable 'maas_verify_registration' in gating to validate alarms are created in the api
-  - Gating: Enable 'maas_verify_status' in gating to validate alarms are not critical after deployments
-  - Gating: Tweak existing variable overrides for different gating release versions. Remove alarm
+  - Fix rpc-maas-tool.py to report excludedchecks as the check will always be created.
+  - Gating - Enable 'maas_verify_registration' in gating to validate alarms are created in the api.
+  - Gating - Enable 'maas_verify_status' in gating to validate alarms are not critical after deployments.
+  - Gating - Tweak existing variable overrides for different gating release versions. Remove alarm
     exclusions, frequency changes, and update excluded checks to include 'horizon_local_check'
     in newton and onward.
+  - Gating - Disable 'maas_remote_check' to exclude remote.http checks from testing as
+    they will always fail in AIOs due to private endpoints.
+  - Gating - Run maas-restart.yml after deploying rally performance checks.

--- a/releasenotes/notes/fix-maas-verify-turtles-1516-a34ec4deb64541f2.yaml
+++ b/releasenotes/notes/fix-maas-verify-turtles-1516-a34ec4deb64541f2.yaml
@@ -3,9 +3,12 @@ fixes:
   - Fix rpc-maas-tool.py to report excludedchecks as the check will always be created.
   - Gating - Enable 'maas_verify_registration' in gating to validate alarms are created in the api.
   - Gating - Enable 'maas_verify_status' in gating to validate alarms are not critical after deployments.
-  - Gating - Tweak existing variable overrides for different gating release versions. Remove alarm
-    exclusions, frequency changes, and update excluded checks to include 'horizon_local_check'
-    in newton and onward.
+  - Gating - Tweak existing variable overrides for different gating release versions and
+    actually use these overrides.
+  - Gating - Remove tests/vars alarm exclusions, frequency changes, and update excluded
+    checks to include the proper checks per release version.
   - Gating - Disable 'maas_remote_check' to exclude remote.http checks from testing as
-    they will always fail in AIOs due to private endpoints.
+    they will always fail in AIOs because of private endpoints.
+  - Gating - Properly enable overrides for user_$VERSION_vars.yml based on the gate
+    release.
   - Gating - Run maas-restart.yml after deploying rally performance checks.

--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -156,6 +156,10 @@ apt-get install -y iptables util-linux apt-transport-https netbase
 
 echo 'Debug::Acquire::http "true";' > /etc/apt/apt.conf.d/99debug
 
+if [ ! -d "/etc/openstack_deploy" ]; then
+  mkdir -p /etc/openstack_deploy
+fi
+
 if [ ! -d "/opt/openstack-ansible" ]; then
   git clone https://github.com/openstack/openstack-ansible /opt/openstack-ansible
 else

--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -195,7 +195,6 @@ pushd /opt/openstack-ansible
     git remote add rcbops-fork https://github.com/rcbops/openstack-ansible.git
     git fetch --all
     git checkout -b newton-fix rcbops-fork/stable/newton
-    enable_ironic
     # NOTE(tonytan4ever): newton needs this to get around gating:
     # https://rackspace.slack.com/archives/CAD5VFMHU/p1525445460000172
     add_lxc_overrides
@@ -205,21 +204,16 @@ pushd /opt/openstack-ansible
 
   elif [ "${RE_JOB_SCENARIO}" == "ocata" ]; then
     git checkout "stable/ocata"  # Branch checkout of Ocata (Current Stable)
-    enable_ironic
 
   elif [ "${RE_JOB_SCENARIO}" == "pike" ]; then
     git checkout "a8a809839484105d9cd27463defc19a8a617c64b"  # Branch checkout of Pike (Current Stable)
     # Pin flask so it stops breaking xenial and other versions
     echo "Flask==0.12.2" >> /opt/openstack-ansible/global-requirement-pins.txt
-    enable_ironic
 
   elif [ "${RE_JOB_SCENARIO}" == "queens" ]; then
     git checkout "stable/queens"  # Branch checkout of Queens (Current Stable)
     export ANSIBLE_INVENTORY="/opt/openstack-ansible/inventory"
-    enable_ironic
 
-  else
-    enable_ironic
   fi
 
   # Install ovs agent if applicable

--- a/tests/test-ansible-functional.sh
+++ b/tests/test-ansible-functional.sh
@@ -78,6 +78,10 @@ echo "TEST_PLAYBOOK: ${TEST_PLAYBOOK}"
 echo "TEST_CHECK_MODE: ${TEST_CHECK_MODE}"
 echo "TEST_IDEMPOTENCE: ${TEST_IDEMPOTENCE}"
 
+# Create a file with a unique string to set as maas_fqdn_extension
+echo "Create unique string for maas_fqdn_extension:"
+echo ".$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32})" | tee /tmp/maas_fqdn_extension
+
 ## Functions -----------------------------------------------------------------
 
 function set_ansible_parameters {
@@ -204,9 +208,6 @@ function enable_maas_api {
 ---
 # Enable the API usage
 maas_use_api: true
-
-# Will restart the agent service ONLY once at the end of a site.yml run
-maas_restart_independent: false
 
 # Set the default notification plan, in the gate this is set here
 maas_notification_plan: npTechnicalContactsEmail

--- a/tests/test-ansible-functional.sh
+++ b/tests/test-ansible-functional.sh
@@ -62,7 +62,7 @@ case $RE_JOB_SCENARIO in
     ;;
   *)
     echo "Create a 16 character unique string to set as maas_fqdn_extension"
-    < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-16} | sed 's/^/./' | tee /tmp/maas_fqdn_extension
+    echo $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-16} | sed 's/^/./') | tee /tmp/maas_fqdn_extension
     ;;
 esac
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -19,8 +19,5 @@
 # Ensure all plugins are functional
 - include: "../playbooks/maas-verify.yml"
 
-# Run the tigk stack playbooks
-- include: "../playbooks/maas-tigkstack-all.yml"
-
 # Run the entity deletion playbook
 - include: "test-raxmon-delete-entity.yml"

--- a/tests/test_with_maas_rally.yml
+++ b/tests/test_with_maas_rally.yml
@@ -24,6 +24,9 @@
 # Install maas_rally performance monitoring
 - include: "../playbooks/maas-openstack-rally.yml"
 
+# Restart the rackspace-monitoring-agent after the rally deployment
+- include: "../playbooks/maas-restart.yml"
+
 # Ensure all plugins are functional
 - include: "../playbooks/maas-verify.yml"
 

--- a/tests/test_with_maas_rally.yml
+++ b/tests/test_with_maas_rally.yml
@@ -30,8 +30,5 @@
 # Ensure all plugins are functional
 - include: "../playbooks/maas-verify.yml"
 
-# Run the tigk stack playbooks
-- include: "../playbooks/maas-tigkstack-all.yml"
-
 # Run the entity deletion playbook
 - include: "test-raxmon-delete-entity.yml"

--- a/tests/user_ceph_vars.yml
+++ b/tests/user_ceph_vars.yml
@@ -13,12 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Set overrides for check periods
-maas_check_period_override:
-  disk_utilisation: 900
-
 maas_excluded_alarms: []
-
 maas_excluded_checks: []
 
 maas_rally_enabled: false
+
+# Allow maas-verify to properly validate all issues
+maas_verify_registration: true
+maas_verify_status: true

--- a/tests/user_hummingbird_vars.yml
+++ b/tests/user_hummingbird_vars.yml
@@ -13,13 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Set overrides for check periods
-maas_check_period_override:
-  disk_utilisation: 900
-
 maas_excluded_alarms: []
-
 maas_excluded_checks: []
 
 maas_rally_enabled: false
 
+# Allow maas-verify to properly validate all issues
+maas_verify_registration: true
+maas_verify_status: true

--- a/tests/user_kilo_vars.yml
+++ b/tests/user_kilo_vars.yml
@@ -13,18 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Set overrides for check periods
-maas_check_period_override:
-  disk_utilisation: 900
-
-# Disable the following MaaS alarms
-# Issue: https://github.com/rcbops/u-suk-dev/issues/1081
-maas_excluded_alarms:
-  - '^idle_percent_average.*'
-  - '^memory_check.*'
-  - '^Network receive rate.*'
-  - '^Network transmit rate.*'
-  - '^percentage_disk_utilisation.*'
+maas_excluded_alarms: []
 
 # swift-recon does not have '--time' option in Kilo
 maas_excluded_checks:
@@ -36,11 +25,14 @@ maas_pre_flight_check_enabled: true
 ansible_host: "{{ ansible_ssh_host }}"
 
 # Nova console type is required
-nova_console_type: spice
-nova_console_port: 6082
+maas_nova_console_type: spice
 
 # Repo compatibility for Kilo
 openstack_upstream_domain: "rpc-repo.rackspace.com"
 repo_pip_default_index: "http://{{ openstack_upstream_domain }}/pools"
 
 swift_recon_path: "/usr/local/bin/"
+
+# Allow maas-verify to properly validate all issues
+maas_verify_registration: true
+maas_verify_status: true

--- a/tests/user_kilo_vars.yml
+++ b/tests/user_kilo_vars.yml
@@ -40,3 +40,8 @@ maas_verify_status: true
 # Disable remote.http checks because AIO endpoints will always be private
 # addresses. Private network monitoring will need to be added.
 maas_remote_check: false
+
+# Set metadata explicitly to OSA
+maas_env_product: osa
+maas_product_dir: /opt/openstack-ansible
+maas_product_osa_dir: /opt/openstack-ansible

--- a/tests/user_kilo_vars.yml
+++ b/tests/user_kilo_vars.yml
@@ -36,3 +36,7 @@ swift_recon_path: "/usr/local/bin/"
 # Allow maas-verify to properly validate all issues
 maas_verify_registration: true
 maas_verify_status: true
+
+# Disable remote.http checks because AIO endpoints will always be private
+# addresses. Private network monitoring will need to be added.
+maas_remote_check: false

--- a/tests/user_liberty_vars.yml
+++ b/tests/user_liberty_vars.yml
@@ -13,18 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Set overrides for check periods
-maas_check_period_override:
-  disk_utilisation: 900
-
-# Disable the following MaaS alarms
-# Issue: https://github.com/rcbops/u-suk-dev/issues/1081
-maas_excluded_alarms:
-  - '^idle_percent_average.*'
-  - '^memory_check.*'
-  - '^Network receive rate.*'
-  - '^Network transmit rate.*'
-  - '^percentage_disk_utilisation.*'
+maas_excluded_alarms: []
 
 # swift-recon does not have '--time' option in Liberty
 maas_excluded_checks:
@@ -36,10 +25,14 @@ maas_pre_flight_check_enabled: true
 ansible_host: "{{ ansible_ssh_host }}"
 
 # Nova console type is required
-nova_console_type: spice
+maas_nova_console_type: spice
 
 # Repo compatibility for liberty
 repo_server_port: 8181
 openstack_repo_url: "http://{{ internal_lb_vip_address }}:{{ repo_server_port }}"
 openstack_upstream_domain: "rpc-repo.rackspace.com"
 repo_pip_default_index: "http://{{ openstack_upstream_domain }}/pools"
+
+# Allow maas-verify to properly validate all issues
+maas_verify_registration: true
+maas_verify_status: true

--- a/tests/user_liberty_vars.yml
+++ b/tests/user_liberty_vars.yml
@@ -36,3 +36,7 @@ repo_pip_default_index: "http://{{ openstack_upstream_domain }}/pools"
 # Allow maas-verify to properly validate all issues
 maas_verify_registration: true
 maas_verify_status: true
+
+# Disable remote.http checks because AIO endpoints will always be private
+# addresses. Private network monitoring will need to be added.
+maas_remote_check: false

--- a/tests/user_liberty_vars.yml
+++ b/tests/user_liberty_vars.yml
@@ -40,3 +40,8 @@ maas_verify_status: true
 # Disable remote.http checks because AIO endpoints will always be private
 # addresses. Private network monitoring will need to be added.
 maas_remote_check: false
+
+# Set metadata explicitly to OSA
+maas_env_product: osa
+maas_product_dir: /opt/openstack-ansible
+maas_product_osa_dir: /opt/openstack-ansible

--- a/tests/user_master_vars.yml
+++ b/tests/user_master_vars.yml
@@ -16,8 +16,11 @@
 maas_excluded_alarms: []
 
 # horizon_local_check is functionally broken newton+ due to architecture changes
+# glance_registry_local_check is not used with v2+ glance endpoints
 maas_excluded_checks:
   - horizon_local_check
+  - glance_registry_local_check
+  - glance_api_local_check
 
 maas_rally_enabled: true
 
@@ -54,3 +57,7 @@ maas_verify_status: true
 # other gates. The OSA playbooks reset the hostname to 'aio1' in queens onward
 # so there were overlapping entities.
 maas_fqdn_extension: "{{lookup('file', '/tmp/maas_fqdn_extension') }}"
+
+# Disable remote.http checks because AIO endpoints will always be private
+# addresses. Private network monitoring will need to be added.
+maas_remote_check: false

--- a/tests/user_master_vars.yml
+++ b/tests/user_master_vars.yml
@@ -53,11 +53,6 @@ maas_pre_flight_check_enabled: true
 maas_verify_registration: true
 maas_verify_status: true
 
-# Set fqdn as the original hostname to ensure the entity name is unique across
-# other gates. The OSA playbooks reset the hostname to 'aio1' in queens onward
-# so there were overlapping entities.
-maas_fqdn_extension: "{{lookup('file', '/tmp/maas_fqdn_extension') }}"
-
 # Disable remote.http checks because AIO endpoints will always be private
 # addresses. Private network monitoring will need to be added.
 maas_remote_check: false

--- a/tests/user_master_vars.yml
+++ b/tests/user_master_vars.yml
@@ -56,3 +56,8 @@ maas_verify_status: true
 # Disable remote.http checks because AIO endpoints will always be private
 # addresses. Private network monitoring will need to be added.
 maas_remote_check: false
+
+# Set metadata explicitly to OSA
+maas_env_product: osa
+maas_product_dir: /opt/openstack-ansible
+maas_product_osa_dir: /opt/openstack-ansible

--- a/tests/user_master_vars.yml
+++ b/tests/user_master_vars.yml
@@ -49,3 +49,8 @@ maas_pre_flight_check_enabled: true
 # Allow maas-verify to properly validate all issues
 maas_verify_registration: true
 maas_verify_status: true
+
+# Set fqdn as the original hostname to ensure the entity name is unique across
+# other gates. The OSA playbooks reset the hostname to 'aio1' in queens onward
+# so there were overlapping entities.
+maas_fqdn_extension: "{{lookup('file', '/tmp/maas_fqdn_extension') }}"

--- a/tests/user_master_vars.yml
+++ b/tests/user_master_vars.yml
@@ -13,13 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Set overrides for check periods
-maas_check_period_override:
-  disk_utilisation: 900
-
 maas_excluded_alarms: []
 
-maas_excluded_checks: []
+# horizon_local_check is functionally broken newton+ due to architecture changes
+maas_excluded_checks:
+  - horizon_local_check
 
 maas_rally_enabled: true
 
@@ -47,3 +45,7 @@ maas_rally_check_overrides:
       - "swiftoperator"
 
 maas_pre_flight_check_enabled: true
+
+# Allow maas-verify to properly validate all issues
+maas_verify_registration: true
+maas_verify_status: true

--- a/tests/user_mitaka_vars.yml
+++ b/tests/user_mitaka_vars.yml
@@ -22,7 +22,7 @@ maas_pre_flight_check_enabled: true
 ansible_host: "{{ ansible_ssh_host }}"
 
 # Nova console type is required
-maas_nova_console_type: novnc
+maas_nova_console_type: spice
 
 # Allow maas-verify to properly validate all issues
 maas_verify_registration: true

--- a/tests/user_mitaka_vars.yml
+++ b/tests/user_mitaka_vars.yml
@@ -27,3 +27,7 @@ maas_nova_console_type: novnc
 # Allow maas-verify to properly validate all issues
 maas_verify_registration: true
 maas_verify_status: true
+
+# Disable remote.http checks because AIO endpoints will always be private
+# addresses. Private network monitoring will need to be added.
+maas_remote_check: false

--- a/tests/user_mitaka_vars.yml
+++ b/tests/user_mitaka_vars.yml
@@ -13,19 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Set overrides for check periods
-maas_check_period_override:
-  disk_utilisation: 900
-
-# Disable the following MaaS alarms
-# Issue: https://github.com/rcbops/u-suk-dev/issues/1081
-maas_excluded_alarms:
-  - '^idle_percent_average.*'
-  - '^memory_check.*'
-  - '^Network receive rate.*'
-  - '^Network transmit rate.*'
-  - '^percentage_disk_utilisation.*'
-
+maas_excluded_alarms: []
 maas_excluded_checks: []
 
 maas_pre_flight_check_enabled: true
@@ -34,4 +22,8 @@ maas_pre_flight_check_enabled: true
 ansible_host: "{{ ansible_ssh_host }}"
 
 # Nova console type is required
-nova_console_type: novnc
+maas_nova_console_type: novnc
+
+# Allow maas-verify to properly validate all issues
+maas_verify_registration: true
+maas_verify_status: true

--- a/tests/user_mitaka_vars.yml
+++ b/tests/user_mitaka_vars.yml
@@ -31,3 +31,8 @@ maas_verify_status: true
 # Disable remote.http checks because AIO endpoints will always be private
 # addresses. Private network monitoring will need to be added.
 maas_remote_check: false
+
+# Set metadata explicitly to OSA
+maas_env_product: osa
+maas_product_dir: /opt/openstack-ansible
+maas_product_osa_dir: /opt/openstack-ansible

--- a/tests/user_newton_vars.yml
+++ b/tests/user_newton_vars.yml
@@ -19,9 +19,6 @@ maas_excluded_alarms: []
 maas_excluded_checks:
   - horizon_local_check
 
-# Nova console type is required
-maas_nova_console_type: novnc
-
 maas_rally_enabled: true
 
 # NOTE(cfarquhar): The scenarios that create instances are disabled for now
@@ -52,11 +49,6 @@ maas_pre_flight_check_enabled: true
 # Allow maas-verify to properly validate all issues
 maas_verify_registration: true
 maas_verify_status: true
-
-# Set fqdn as the original hostname to ensure the entity name is unique across
-# other gates. The OSA playbooks reset the hostname to 'aio1' in queens onward
-# so there were overlapping entities.
-maas_fqdn_extension: "{{lookup('file', '/tmp/maas_fqdn_extension') }}"
 
 # Disable remote.http checks because AIO endpoints will always be private
 # addresses. Private network monitoring will need to be added.

--- a/tests/user_newton_vars.yml
+++ b/tests/user_newton_vars.yml
@@ -13,16 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Set overrides for check periods
-maas_check_period_override:
-  disk_utilisation: 900
-
 maas_excluded_alarms: []
 
-maas_excluded_checks: []
+# horizon_local_check is functionally broken newton+ due to architecture changes
+maas_excluded_checks:
+  - horizon_local_check
 
 # Nova console type is required
-nova_console_type: novnc
+maas_nova_console_type: novnc
 
 maas_rally_enabled: true
 
@@ -50,3 +48,7 @@ maas_rally_check_overrides:
       - "swiftoperator"
 
 maas_pre_flight_check_enabled: true
+
+# Allow maas-verify to properly validate all issues
+maas_verify_registration: true
+maas_verify_status: true

--- a/tests/user_newton_vars.yml
+++ b/tests/user_newton_vars.yml
@@ -53,3 +53,8 @@ maas_verify_status: true
 # Disable remote.http checks because AIO endpoints will always be private
 # addresses. Private network monitoring will need to be added.
 maas_remote_check: false
+
+# Set metadata explicitly to OSA
+maas_env_product: osa
+maas_product_dir: /opt/openstack-ansible
+maas_product_osa_dir: /opt/openstack-ansible

--- a/tests/user_newton_vars.yml
+++ b/tests/user_newton_vars.yml
@@ -52,3 +52,8 @@ maas_pre_flight_check_enabled: true
 # Allow maas-verify to properly validate all issues
 maas_verify_registration: true
 maas_verify_status: true
+
+# Set fqdn as the original hostname to ensure the entity name is unique across
+# other gates. The OSA playbooks reset the hostname to 'aio1' in queens onward
+# so there were overlapping entities.
+maas_fqdn_extension: "{{lookup('file', '/tmp/maas_fqdn_extension') }}

--- a/tests/user_ocata_vars.yml
+++ b/tests/user_ocata_vars.yml
@@ -54,3 +54,7 @@ maas_verify_status: true
 # other gates. The OSA playbooks reset the hostname to 'aio1' in queens onward
 # so there were overlapping entities.
 maas_fqdn_extension: "{{lookup('file', '/tmp/maas_fqdn_extension') }}"
+
+# Disable remote.http checks because AIO endpoints will always be private
+# addresses. Private network monitoring will need to be added.
+maas_remote_check: false

--- a/tests/user_ocata_vars.yml
+++ b/tests/user_ocata_vars.yml
@@ -53,3 +53,8 @@ maas_verify_status: true
 # Disable remote.http checks because AIO endpoints will always be private
 # addresses. Private network monitoring will need to be added.
 maas_remote_check: false
+
+# Set metadata explicitly to OSA
+maas_env_product: osa
+maas_product_dir: /opt/openstack-ansible
+maas_product_osa_dir: /opt/openstack-ansible

--- a/tests/user_ocata_vars.yml
+++ b/tests/user_ocata_vars.yml
@@ -50,11 +50,6 @@ maas_pre_flight_check_enabled: true
 maas_verify_registration: true
 maas_verify_status: true
 
-# Set fqdn as the original hostname to ensure the entity name is unique across
-# other gates. The OSA playbooks reset the hostname to 'aio1' in queens onward
-# so there were overlapping entities.
-maas_fqdn_extension: "{{lookup('file', '/tmp/maas_fqdn_extension') }}"
-
 # Disable remote.http checks because AIO endpoints will always be private
 # addresses. Private network monitoring will need to be added.
 maas_remote_check: false

--- a/tests/user_ocata_vars.yml
+++ b/tests/user_ocata_vars.yml
@@ -49,3 +49,8 @@ maas_pre_flight_check_enabled: true
 # Allow maas-verify to properly validate all issues
 maas_verify_registration: true
 maas_verify_status: true
+
+# Set fqdn as the original hostname to ensure the entity name is unique across
+# other gates. The OSA playbooks reset the hostname to 'aio1' in queens onward
+# so there were overlapping entities.
+maas_fqdn_extension: "{{lookup('file', '/tmp/maas_fqdn_extension') }}"

--- a/tests/user_ocata_vars.yml
+++ b/tests/user_ocata_vars.yml
@@ -13,13 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Set overrides for check periods
-maas_check_period_override:
-  disk_utilisation: 900
-
 maas_excluded_alarms: []
 
-maas_excluded_checks: []
+# horizon_local_check is functionally broken newton+ due to architecture changes
+maas_excluded_checks:
+  - horizon_local_check
 
 maas_rally_enabled: true
 
@@ -47,3 +45,7 @@ maas_rally_check_overrides:
       - "swiftoperator"
 
 maas_pre_flight_check_enabled: true
+
+# Allow maas-verify to properly validate all issues
+maas_verify_registration: true
+maas_verify_status: true

--- a/tests/user_pike_vars.yml
+++ b/tests/user_pike_vars.yml
@@ -54,3 +54,7 @@ maas_verify_status: true
 # other gates. The OSA playbooks reset the hostname to 'aio1' in queens onward
 # so there were overlapping entities.
 maas_fqdn_extension: "{{lookup('file', '/tmp/maas_fqdn_extension') }}"
+
+# Disable remote.http checks because AIO endpoints will always be private
+# addresses. Private network monitoring will need to be added.
+maas_remote_check: false

--- a/tests/user_pike_vars.yml
+++ b/tests/user_pike_vars.yml
@@ -53,3 +53,8 @@ maas_verify_status: true
 # Disable remote.http checks because AIO endpoints will always be private
 # addresses. Private network monitoring will need to be added.
 maas_remote_check: false
+
+# Set metadata explicitly to OSA
+maas_env_product: osa
+maas_product_dir: /opt/openstack-ansible
+maas_product_osa_dir: /opt/openstack-ansible

--- a/tests/user_pike_vars.yml
+++ b/tests/user_pike_vars.yml
@@ -50,11 +50,6 @@ maas_pre_flight_check_enabled: true
 maas_verify_registration: true
 maas_verify_status: true
 
-# Set fqdn as the original hostname to ensure the entity name is unique across
-# other gates. The OSA playbooks reset the hostname to 'aio1' in queens onward
-# so there were overlapping entities.
-maas_fqdn_extension: "{{lookup('file', '/tmp/maas_fqdn_extension') }}"
-
 # Disable remote.http checks because AIO endpoints will always be private
 # addresses. Private network monitoring will need to be added.
 maas_remote_check: false

--- a/tests/user_pike_vars.yml
+++ b/tests/user_pike_vars.yml
@@ -49,3 +49,8 @@ maas_pre_flight_check_enabled: true
 # Allow maas-verify to properly validate all issues
 maas_verify_registration: true
 maas_verify_status: true
+
+# Set fqdn as the original hostname to ensure the entity name is unique across
+# other gates. The OSA playbooks reset the hostname to 'aio1' in queens onward
+# so there were overlapping entities.
+maas_fqdn_extension: "{{lookup('file', '/tmp/maas_fqdn_extension') }}"

--- a/tests/user_pike_vars.yml
+++ b/tests/user_pike_vars.yml
@@ -13,13 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Set overrides for check periods
-maas_check_period_override:
-  disk_utilisation: 900
-
 maas_excluded_alarms: []
 
-maas_excluded_checks: []
+# horizon_local_check is functionally broken newton+ due to architecture changes
+maas_excluded_checks:
+  - horizon_local_check
 
 maas_rally_enabled: true
 
@@ -47,3 +45,7 @@ maas_rally_check_overrides:
       - "swiftoperator"
 
 maas_pre_flight_check_enabled: true
+
+# Allow maas-verify to properly validate all issues
+maas_verify_registration: true
+maas_verify_status: true

--- a/tests/user_queens_vars.yml
+++ b/tests/user_queens_vars.yml
@@ -16,11 +16,14 @@
 maas_excluded_alarms: []
 
 # horizon_local_check is functionally broken newton+ due to architecture changes
+# glance_registry_local_check is not used with v2+ glance endpoints
 maas_excluded_checks:
   - horizon_local_check
+  - glance_registry_local_check
+  - glance_api_local_check
 
-# Nova console type is required
-maas_nova_console_type: novnc
+# Exclude disk_utilisation devices created in an OSA AIO
+maas_excluded_devices: ['loop0', 'loop1', 'loop2', 'loop3', 'loop4', 'loop5', 'loop6', 'loop7']
 
 maas_rally_enabled: true
 

--- a/tests/user_queens_vars.yml
+++ b/tests/user_queens_vars.yml
@@ -22,9 +22,6 @@ maas_excluded_checks:
   - glance_registry_local_check
   - glance_api_local_check
 
-# Exclude disk_utilisation devices created in an OSA AIO
-maas_excluded_devices: ['loop0', 'loop1', 'loop2', 'loop3', 'loop4', 'loop5', 'loop6', 'loop7']
-
 maas_rally_enabled: true
 
 # NOTE(cfarquhar): The scenarios that create instances are disabled for now
@@ -55,11 +52,6 @@ maas_pre_flight_check_enabled: true
 # Allow maas-verify to properly validate all issues
 maas_verify_registration: true
 maas_verify_status: true
-
-# Set fqdn as the original hostname to ensure the entity name is unique across
-# other gates. The OSA playbooks reset the hostname to 'aio1' in queens onward
-# so there were overlapping entities.
-maas_fqdn_extension: "{{lookup('file', '/tmp/maas_fqdn_extension') }}"
 
 # Disable remote.http checks because AIO endpoints will always be private
 # addresses. Private network monitoring will need to be added.

--- a/tests/user_queens_vars.yml
+++ b/tests/user_queens_vars.yml
@@ -56,3 +56,8 @@ maas_verify_status: true
 # Disable remote.http checks because AIO endpoints will always be private
 # addresses. Private network monitoring will need to be added.
 maas_remote_check: false
+
+# Set metadata explicitly to OSA
+maas_env_product: osa
+maas_product_dir: /opt/openstack-ansible
+maas_product_osa_dir: /opt/openstack-ansible


### PR DESCRIPTION
Enable the following variables to enable all functionality of maas-verify.yml:

maas_verify_registration (determine if checks and alarms actually registered with the API)
maas_verify_status (determine if there are any active alarms)