### PR TITLE
Fix rally vars undefined ansible_host

### DIFF
--- a/playbooks/vars/maas-rally.yml
+++ b/playbooks/vars/maas-rally.yml
@@ -176,7 +176,7 @@ maas_rally_galera_database: maas_rally
 #
 #  Address for galera database where Rally data will be stored.
 #
-maas_rally_galera_address: "{{ hostvars[groups['galera_all'][0]]['ansible_host'] }}"
+maas_rally_galera_address: "{{ hostvars[groups['galera_all'][0]]['ansible_host'] | default(hostvars[groups['galera_all'][0]]['container_address']) }}"
 
 #
 #  How rally deployments communicate with OpenStack endpoints.

--- a/releasenotes/notes/run-tests-rally-fix-ddedf4242415ee2b.yaml
+++ b/releasenotes/notes/run-tests-rally-fix-ddedf4242415ee2b.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a missed instantiation of ansible_host in rally plays without a container_address default.


### PR DESCRIPTION
`ansible_host` was missed in the rally vars which resulted in playbook failure. This resolves the issue using the same fix added in the initial PR: #577.