### PR TITLE
INSIGHTS-223 Leverage upstream embedded ansible script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "magnanimous-turbo-chainsaw"]
+	path = magnanimous-turbo-chainsaw
+	url = https://github.com/rcbops/magnanimous-turbo-chainsaw.git

--- a/bootstrap-embedded-ansible.sh
+++ b/bootstrap-embedded-ansible.sh
@@ -1,0 +1,1 @@
+magnanimous-turbo-chainsaw/bootstrap-embedded-ansible.sh

--- a/playbooks/generate-environment-vars.yml
+++ b/playbooks/generate-environment-vars.yml
@@ -1,0 +1,1 @@
+../magnanimous-turbo-chainsaw/playbooks/generate-environment-vars.yml

--- a/releasenotes/notes/INSIGHTS-223-add-mtc-submodule-6c584c96ccc456e9.yaml
+++ b/releasenotes/notes/INSIGHTS-223-add-mtc-submodule-6c584c96ccc456e9.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Now that embedded ansible is required to deploy rpc-maas playbooks against
+    RPC-O and/or RPC-R deployments, the magnanimous-turbo-chainsaw (MTC),
+    tooling repo has been added as a submodule of rpc-maas. This repository
+    contains resources intended to be used across all RPC Toolstack components.
+    As part of the initial commit, the generate-environment-vars.yml playbook
+    and bootstrap-embedded-ansible.sh wrapper have been symlinked into the main
+    directory structure.


### PR DESCRIPTION
This change adds the RPC tooling repository, magnanimous-turbo-chainsaw (MTC), as a submodule of rpc-maas. This repo is intended to provide resources to be shared across the toolstack deployments. As part of the initial commit, a few of the resources have been symlinked into the rpc-maas structure.