### PR TITLE
Add type to deploy_osp option in ceph_osd_host_facts module

### DIFF
--- a/playbooks/library/ceph_osd_host_facts
+++ b/playbooks/library/ceph_osd_host_facts
@@ -81,7 +81,8 @@ def main():
             ),
             deploy_osp=dict(
                 required=False,
-                default=False
+                default=False,
+                type='bool'
             )
         ),
         supports_check_mode=False

--- a/playbooks/maas-ceph-osd.yml
+++ b/playbooks/maas-ceph-osd.yml
@@ -20,7 +20,7 @@
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
-        - deploy_osp  | default(False)
+        - deploy_osp | default(False)
 
     - include: "common-tasks/maas_excluded_regex.yml"
     - name: Set the current group
@@ -56,7 +56,7 @@
         - deploy_osp | default(False)
       register: osd_container_name
 
-    - name: Set container name  for osp template
+    - name: Set container name for osp template
       set_fact:
         container_name: "{{ osd_container_name.stdout | trim }}"
       when:
@@ -67,7 +67,7 @@
       ceph_osd_host_facts:
         hostname: "{{ ansible_hostname }}"
         container_name: "{{ container_name | default(inventory_hostname) }}"
-        deploy_osp: "{{ deploy_osp  | default(False) }}"
+        deploy_osp: "{{ deploy_osp | default(False) }}"
       tags:
         - always
 

--- a/releasenotes/notes/INSIGHTS-306-fix-ceph-facts-module-672b20d9aa508e60.yaml
+++ b/releasenotes/notes/INSIGHTS-306-fix-ceph-facts-module-672b20d9aa508e60.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Add boolean type for deploy_osp in custom OSD fact gathering module.


### PR DESCRIPTION
This was preventing fact gathering from succeeding in non-OSP environments. It was causing the deploy_osp option to always be set.