### PR TITLE
Fix usage of OS_IMAGE_API_VERSION for glance in maas_common.py

### DIFF
--- a/playbooks/templates/rax-maas/maasrc.j2
+++ b/playbooks/templates/rax-maas/maasrc.j2
@@ -1,2 +1,2 @@
-OS_IMAGE_API_VERSION={{ os_image_api_version }}
-OS_VOLUME_API_VERSION={{ os_volume_api_version }}
+export OS_IMAGE_API_VERSION={{ os_image_api_version }}
+export OS_VOLUME_API_VERSION={{ os_volume_api_version }}


### PR DESCRIPTION
The usage of OS_IMAGE_API_VERSION in maas_common.py was explicitly obtaining the value from environment variables. This change actually exports the values when maasrc is sourced from maas_common.py.