### PR TITLE
Remove MTC submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "magnanimous-turbo-chainsaw"]
-	path = magnanimous-turbo-chainsaw
-	url = https://github.com/rcbops/magnanimous-turbo-chainsaw.git

--- a/bootstrap-embedded-ansible.sh
+++ b/bootstrap-embedded-ansible.sh
@@ -1,1 +1,0 @@
-magnanimous-turbo-chainsaw/bootstrap-embedded-ansible.sh

--- a/playbooks/generate-environment-vars.yml
+++ b/playbooks/generate-environment-vars.yml
@@ -1,1 +1,0 @@
-../magnanimous-turbo-chainsaw/playbooks/generate-environment-vars.yml


### PR DESCRIPTION
This has essentially been obsoleted with the heavy development to the MTC repo. It doesn't make sense to have it included as a submodule anymore.