### PR TITLE
Remove the assumption pip is installed on hosts

### DIFF
--- a/playbooks/common-tasks/maas-infra-redhat-install.yml
+++ b/playbooks/common-tasks/maas-infra-redhat-install.yml
@@ -14,5 +14,6 @@
 # limitations under the License.
 
 - name: Show notice
-  debug: >-
-    This task file is a place holder at this time.
+  debug:
+    msg: >-
+      This task file is a place holder at this time.

--- a/playbooks/common-tasks/maas-venv-create.yml
+++ b/playbooks/common-tasks/maas-venv-create.yml
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Copy over pip constraints
+  copy:
+    src: "files/pip-constraints.txt"
+    dest: "/tmp/pip-constraints.txt"
+
 - name: Install requires pip packages
   package:
     name: "{{ maas_agent_distro_packages }}"
@@ -49,6 +54,5 @@
         virtualenv: "{{ target_venv | default(maas_venv) }}"
       register: install_pip_packages
       until: install_pip_packages is success
-      become: yes
       retries: 5
       delay: 2

--- a/playbooks/common-tasks/maas-venv-create.yml
+++ b/playbooks/common-tasks/maas-venv-create.yml
@@ -22,31 +22,31 @@
   delay: 2
 
 - name: Create MaaS venv
-  command: "virtualenv --no-site-packages --no-setuptools {{ maas_venv }}"
+  command: "virtualenv --no-site-packages --no-setuptools {{ target_venv | default(maas_venv) }}"
   args:
-    creates: "{{ maas_venv }}/bin/python"
-
-- name: Setup MaaS venv
-  pip:
-    name:
-      - pip
-      - setuptools
-    extra_args: "-U"
-    virtualenv: "{{ maas_venv }}"
+    creates: "{{ target_venv | default(maas_venv) }}/bin/python"
 
 - name: Create MaaS virtualenv
   vars:
-    ansible_python_interpreter: "{{ maas_venv }}/bin/python"
+    ansible_python_interpreter: "{{ target_venv | default(maas_venv) }}/bin/python"
   block:
+    - name: Setup MaaS venv
+      pip:
+        name:
+          - pip
+          - setuptools
+        extra_args: "-U"
+        virtualenv: "{{ target_venv | default(maas_venv) }}"
+
     - name: Ensure MaaS pip packages are installed
       pip:
-        name: "{{ maas_pip_container_packages | union(maas_verify_pip_packages) | union(maas_pip_packages) }}"
-        state: "{{ maas_pip_package_state }}"
+        name: "{{ pip_package_list | default(maas_pip_container_packages | union(maas_pip_verify_packages) | union(maas_pip_packages) | union(maas_pip_openstack_packages)) }}"
+        state: "{{ pip_package_state | default(maas_pip_package_state) }}"
         extra_args: >-
           --isolated
-          --constraint /tmp/pip-constraints.txt
+          --constraint "{{ pip_package_constraint | default('/tmp/pip-constraints.txt') }}"
           {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
+        virtualenv: "{{ target_venv | default(maas_venv) }}"
       register: install_pip_packages
       until: install_pip_packages is success
       become: yes

--- a/playbooks/common-tasks/maas_get_maasrc.yml
+++ b/playbooks/common-tasks/maas_get_maasrc.yml
@@ -18,19 +18,30 @@
 # (This playbook could be removed when upstream decides to include
 # OS_IMAGE_API_VERSION and OS_VOLUME_API_VERSION in openrc
 #
-- name: Retrieve maasrc file
-  slurp:
-    src: /root/maasrc
-  register: maasrc_data
+
+- name: Locate openrc file
+  stat:
+    path: "/root/maasrc"
+  register: maasrc_file_check
   delegate_to: "{{ groups['utility_all'][0] }}"
+  run_once: true
 
-- name: Register a fact for the maasrc
-  set_fact:
-     maasrc_fact: "{{ maasrc_data.content }}"
+- name: Get openrc
+  block:
+    - name: Retrieve maasrc file
+      slurp:
+        src: /root/maasrc
+      register: maasrc_data
+      delegate_to: "{{ groups['utility_all'][0] }}"
 
-- name: Distribute maasrc
-  copy:
-    dest: "/root/maasrc"
-    content: "{{ maasrc_fact | b64decode }}"
-    mode: "0640"
-  delegate_to: "{{ physical_host | default(ansible_host) }}"
+    - name: Register a fact for the maasrc
+      set_fact:
+        maasrc_fact: "{{ maasrc_data.content }}"
+
+    - name: Distribute maasrc
+      copy:
+        dest: "/root/maasrc"
+        content: "{{ maasrc_fact | b64decode }}"
+        mode: "0640"
+  when:
+    - maasrc_file_check.stat.exists | bool

--- a/playbooks/common-tasks/maas_get_maasrc.yml
+++ b/playbooks/common-tasks/maas_get_maasrc.yml
@@ -43,5 +43,7 @@
         dest: "/root/maasrc"
         content: "{{ maasrc_fact | b64decode }}"
         mode: "0640"
+      when:
+        - (inventory_hostname | default(ansible_host)) != groups['utility_all'][0]
   when:
     - maasrc_file_check.stat.exists | bool

--- a/playbooks/common-tasks/maas_get_openrc.yml
+++ b/playbooks/common-tasks/maas_get_openrc.yml
@@ -13,20 +13,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Retrieve openrc file
-  slurp:
-    src: "{{ maas_stackrc | default('/root/openrc') }}"
-  register: openrc_data
-  delegate_to: "{{ groups['utility_all'][0] }}"
+- name: Locate openrc file
+  stat: "{{ maas_stackrc | default('/root/openrc') }}"
+  register: openrc_file_check
 
-- name: Register a fact for the openrc
-  set_fact:
-     openrc_fact: "{{ openrc_data.content }}"
+- name: Get openrc
+  block:
+    - name: Retrieve openrc file
+      slurp:
+        src: "{{ maas_stackrc | default('/root/openrc') }}"
+      register: openrc_data
+      delegate_to: "{{ groups['utility_all'][0] }}"
 
-- name: Distribute openrc
-  copy:
-    dest: "/root/openrc"
-    content: "{{ openrc_fact | b64decode }}"
-    mode: "0640"
-  delegate_to: "{{ physical_host | default(ansible_host) }}"
-  become: yes
+    - name: Register a fact for the openrc
+      set_fact:
+        openrc_fact: "{{ openrc_data.content }}"
+
+    - name: Distribute openrc
+      copy:
+        dest: "/root/openrc"
+        content: "{{ openrc_fact | b64decode }}"
+        mode: "0640"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      become: yes
+  when:
+    - openrc_file_check.stat.exists | bool

--- a/playbooks/common-tasks/maas_get_openrc.yml
+++ b/playbooks/common-tasks/maas_get_openrc.yml
@@ -14,8 +14,11 @@
 # limitations under the License.
 
 - name: Locate openrc file
-  stat: "{{ maas_stackrc | default('/root/openrc') }}"
+  stat:
+    path: "{{ maas_stackrc | default('/root/openrc') }}"
   register: openrc_file_check
+  delegate_to: "{{ groups['utility_all'][0] }}"
+  run_once: true
 
 - name: Get openrc
   block:
@@ -34,7 +37,5 @@
         dest: "/root/openrc"
         content: "{{ openrc_fact | b64decode }}"
         mode: "0640"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-      become: yes
   when:
     - openrc_file_check.stat.exists | bool

--- a/playbooks/common-tasks/maas_get_openrc.yml
+++ b/playbooks/common-tasks/maas_get_openrc.yml
@@ -37,5 +37,7 @@
         dest: "/root/openrc"
         content: "{{ openrc_fact | b64decode }}"
         mode: "0640"
+      when:
+        - (inventory_hostname | default(ansible_host)) != groups['utility_all'][0]
   when:
     - openrc_file_check.stat.exists | bool

--- a/playbooks/maas-agent-all.yml
+++ b/playbooks/maas-agent-all.yml
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: maas-agent-install.yml
+- import_playbook: maas-agent-install.yml
   tags:
     - maas-agent
 
-- include: maas-agent-setup.yml
+- import_playbook: maas-agent-setup.yml
   tags:
     - maas-agent

--- a/playbooks/maas-agent-install.yml
+++ b/playbooks/maas-agent-install.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -39,9 +39,14 @@
 
 - name: Install MaaS Agent
   hosts: hosts
-  gather_facts: false
+  gather_facts: true
   become: true
   pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
     - name: Include distro install tasks
       include_tasks: "common-tasks/maas-agent-{{ ansible_distribution | lower }}-install.yml"
 

--- a/playbooks/maas-agent-install.yml
+++ b/playbooks/maas-agent-install.yml
@@ -37,31 +37,13 @@
     - always
 
 
-- name: Gather facts
-  hosts: hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
-  tags:
-    - maas-agent-install
-
-
 - name: Install MaaS Agent
   hosts: hosts
   gather_facts: false
   become: true
   pre_tasks:
     - name: Include distro install tasks
-      include: "common-tasks/maas-agent-{{ ansible_distribution | lower }}-install.yml"
+      include_tasks: "common-tasks/maas-agent-{{ ansible_distribution | lower }}-install.yml"
 
     - name: Ensure rackspace-monitoring-agent config directory exists
       file:

--- a/playbooks/maas-agent-install.yml
+++ b/playbooks/maas-agent-install.yml
@@ -16,28 +16,32 @@
 - name: Gather facts
   hosts: hosts
   gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: hosts
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
+
 
 - name: Gather facts
   hosts: hosts
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
-  pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
-    - name: Set the current group
-      set_fact:
-        maas_current_group: hosts
-
+  become: true
   tasks:
     - name: Copy over pip constraints
       copy:
@@ -45,12 +49,16 @@
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-agent-install
+
 
 - name: Install MaaS Agent
   hosts: hosts
   gather_facts: false
+  become: true
   pre_tasks:
     - name: Include distro install tasks
       include: "common-tasks/maas-agent-{{ ansible_distribution | lower }}-install.yml"
@@ -71,5 +79,6 @@
     - "vars/maas-{{ ansible_distribution | lower }}.yml"
 
   environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-agent-install

--- a/playbooks/maas-agent-setup.yml
+++ b/playbooks/maas-agent-setup.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -43,6 +43,11 @@
   gather_facts: true
   become: true
   pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
     - name: Drop .raxrc file
       template:
         src: "templates/rax-maas/raxrc.j2"

--- a/playbooks/maas-agent-setup.yml
+++ b/playbooks/maas-agent-setup.yml
@@ -23,7 +23,7 @@
       when:
         - deploy_osp | bool
 
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Set the current group
       set_fact:

--- a/playbooks/maas-agent-setup.yml
+++ b/playbooks/maas-agent-setup.yml
@@ -16,19 +16,32 @@
 - name: Gather facts
   hosts: hosts
   gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
   tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
     - include: "common-tasks/maas_excluded_regex.yml"
+
     - name: Set the current group
       set_fact:
         maas_current_group: hosts
 
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+
   tags:
     - maas-agent-setup
+    - always
+
 
 - name: Setup MaaS Agent
   hosts: hosts
   gather_facts: true
-  become: yes
+  become: true
   pre_tasks:
     - name: Drop .raxrc file
       template:
@@ -120,6 +133,8 @@
     - vars/maas.yml
     - vars/maas-auth.yml
     - "vars/maas-{{ ansible_distribution | lower }}.yml"
+
   environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-agent-setup

--- a/playbooks/maas-ceph-all.yml
+++ b/playbooks/maas-ceph-all.yml
@@ -13,14 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: maas-ceph-mon.yml
+- import_playbook: maas-ceph-raxmon.yml
   tags:
     - maas-ceph
 
-- include: maas-ceph-osd.yml
+- import_playbook: maas-ceph-mon.yml
   tags:
     - maas-ceph
 
-- include: maas-ceph-rgw.yml
+- import_playbook: maas-ceph-osd.yml
+  tags:
+    - maas-ceph
+
+- import_playbook: maas-ceph-rgw.yml
   tags:
     - maas-ceph

--- a/playbooks/maas-ceph-all.yml
+++ b/playbooks/maas-ceph-all.yml
@@ -13,10 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- import_playbook: maas-ceph-raxmon.yml
-  tags:
-    - maas-ceph
-
 - import_playbook: maas-ceph-mon.yml
   tags:
     - maas-ceph

--- a/playbooks/maas-ceph-mon.yml
+++ b/playbooks/maas-ceph-mon.yml
@@ -16,6 +16,7 @@
 - name: Gather facts
   hosts: mons
   gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
@@ -27,20 +28,21 @@
     - name: Set the current group
       set_fact:
         maas_current_group: mons
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - maas-ceph-mons
     - always
 
-- include: maas-ceph-raxmon.yml
 
 - name: Install checks for ceph mons
   hosts: mons
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   pre_tasks:
     - name: Write Ceph monitoring client key to file
       copy:
@@ -83,5 +85,8 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-ceph-mons

--- a/playbooks/maas-ceph-mon.yml
+++ b/playbooks/maas-ceph-mon.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: mons
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -38,12 +38,20 @@
     - always
 
 
+- import_playbook: maas-ceph-raxmon.yml
+
+
 - name: Install checks for ceph mons
   hosts: mons
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
     - name: Write Ceph monitoring client key to file
       copy:
         content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"

--- a/playbooks/maas-ceph-mon.yml
+++ b/playbooks/maas-ceph-mon.yml
@@ -23,7 +23,7 @@
       when:
         - deploy_osp | bool
 
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Set the current group
       set_fact:
@@ -48,7 +48,7 @@
       copy:
         content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"
         dest: "/etc/ceph/ceph.client.raxmon.keyring"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
 
     - name: Get the first mon container
       raw: /bin/docker ps -a -f status=running | awk '/ceph-mon/ {print $NF}' | head -1
@@ -77,7 +77,7 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
       with_items:
         - ceph_mon_stats
         - ceph_cluster_stats

--- a/playbooks/maas-ceph-osd.yml
+++ b/playbooks/maas-ceph-osd.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: osds
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -37,12 +37,20 @@
     - always
 
 
+- import_playbook: maas-ceph-raxmon.yml
+
+
 - name: Install checks for ceph mons
   hosts: osds
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
     - name: Write Ceph monitoring client key to file
       copy:
         content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"

--- a/playbooks/maas-ceph-osd.yml
+++ b/playbooks/maas-ceph-osd.yml
@@ -16,6 +16,7 @@
 - name: Gather facts
   hosts: osds
   gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
@@ -27,20 +28,20 @@
     - name: Set the current group
       set_fact:
         maas_current_group: osds
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
-    - maas-ceph-osds
     - always
 
-- include: maas-ceph-raxmon.yml
 
 - name: Install checks for ceph mons
   hosts: osds
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   pre_tasks:
     - name: Write Ceph monitoring client key to file
       copy:
@@ -88,5 +89,8 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-ceph-osds

--- a/playbooks/maas-ceph-osd.yml
+++ b/playbooks/maas-ceph-osd.yml
@@ -23,7 +23,7 @@
       when:
         - deploy_osp | bool
 
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Set the current group
       set_fact:

--- a/playbooks/maas-ceph-raxmon.yml
+++ b/playbooks/maas-ceph-raxmon.yml
@@ -32,6 +32,7 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -43,7 +44,7 @@
   pre_tasks:
     - name: Add ceph command line alias string
       set_fact:
-        ceph_command: "{{ (deploy_osp | bool) | ternary('sudo docker exec ceph-mon-{{inventory_hostname}} ceph --cluster ceph', 'ceph') }}"
+        ceph_command: "{{ (deploy_osp | bool) | ternary('docker exec ceph-mon-{{inventory_hostname}} ceph --cluster ceph', 'ceph') }}"
 
     - name: Create ceph monitoring client
       command: "{{ ceph_command }} auth get-or-create client.raxmon"
@@ -63,6 +64,8 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-ceph

--- a/playbooks/maas-ceph-raxmon.yml
+++ b/playbooks/maas-ceph-raxmon.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: mons
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -39,9 +39,14 @@
 
 - name: Install checks for ceph mons
   hosts: maas_mon_hosts
-  gather_facts: false
+  gather_facts: true
   become: true
   pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
     - name: Add ceph command line alias string
       set_fact:
         ceph_command: "{{ (deploy_osp | bool) | ternary('docker exec ceph-mon-{{inventory_hostname}} ceph --cluster ceph', 'ceph') }}"

--- a/playbooks/maas-ceph-raxmon.yml
+++ b/playbooks/maas-ceph-raxmon.yml
@@ -13,34 +13,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Install checks for ceph mons
-  hosts: mons[0]
-  gather_facts: false
-  pre_tasks:
-    - name: Add ceph command line alias string for osp
-      set_fact:
-        ceph_command: sudo docker exec ceph-mon-{{inventory_hostname}} ceph --cluster ceph
+- name: Gather facts
+  hosts: mons
+  gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
+  tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
 
-    - name: Add ceph command line alias string for other environment
+    - name: Create dynamic ceph osd group
+      add_host:
+        hostname: "{{ item }}"
+        groups: "maas_mon_hosts"
+      with_items: "{{ groups['mons'][0] }}"
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+  tags:
+    - always
+
+
+- name: Install checks for ceph mons
+  hosts: maas_mon_hosts
+  gather_facts: false
+  become: true
+  pre_tasks:
+    - name: Add ceph command line alias string
       set_fact:
-        ceph_command: ceph
-      when:
-        - not (deploy_osp | bool)
+        ceph_command: "{{ (deploy_osp | bool) | ternary('sudo docker exec ceph-mon-{{inventory_hostname}} ceph --cluster ceph', 'ceph') }}"
 
     - name: Create ceph monitoring client
       command: "{{ ceph_command }} auth get-or-create client.raxmon"
       register: _ceph_raxmon_client
       tags:
         - skip_ansible_lint
+
     - name: Add mgr auth for client.raxmon
       command: "{{ ceph_command }} auth caps client.raxmon mon 'allow r' mgr 'allow *'"
       tags:
         - skip_ansible_lint
+
     - name: Set the raxmon_client facts
       set_fact:
         ceph_raxmon_client: "{{ _ceph_raxmon_client }}"
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+
   tags:
     - maas-ceph
     - always

--- a/playbooks/maas-ceph-rgw.yml
+++ b/playbooks/maas-ceph-rgw.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: rgws
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -37,12 +37,20 @@
     - maas-ceph-rgws
 
 
+- import_playbook: maas-ceph-raxmon.yml
+
+
 - name: Install checks for ceph rgws
   hosts: rgws
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
     - name: Write Ceph monitoring client key to file
       copy:
         content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"

--- a/playbooks/maas-ceph-rgw.yml
+++ b/playbooks/maas-ceph-rgw.yml
@@ -16,6 +16,7 @@
 - name: Gather facts
   hosts: rgws
   gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
@@ -32,13 +33,12 @@
   tags:
     - maas-ceph-rgws
 
-- include: maas-ceph-raxmon.yml
 
 - name: Install checks for ceph rgws
   hosts: rgws
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   pre_tasks:
     - name: Write Ceph monitoring client key to file
       copy:
@@ -68,5 +68,6 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - maas-ceph-rgws

--- a/playbooks/maas-ceph-rgw.yml
+++ b/playbooks/maas-ceph-rgw.yml
@@ -23,13 +23,16 @@
       when:
         - deploy_osp | bool
 
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
     - name: Set the current group
       set_fact:
         maas_current_group: rgws
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - maas-ceph-rgws
 
@@ -68,6 +71,8 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-ceph-rgws

--- a/playbooks/maas-container-all.yml
+++ b/playbooks/maas-container-all.yml
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: maas-container-storage.yml
+- import_playbook: maas-container-storage.yml
   tags:
     - maas-container
 
-- include: maas-container-conntrack.yml
+- import_playbook: maas-container-conntrack.yml
   tags:
     - maas-container

--- a/playbooks/maas-container-conntrack.yml
+++ b/playbooks/maas-container-conntrack.yml
@@ -23,40 +23,18 @@
       when:
         - deploy_osp | bool
 
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-  tags:
-    - always
-
-
-- name: Gather facts
-  hosts: neutron_agent
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Set the current group
       set_fact:
         maas_current_group: neutron_agent
 
-  tasks:
-   - name: Copy over pip constraints
-     copy:
-       src: "files/pip-constraints.txt"
-       dest: "/tmp/pip-constraints.txt"
-     delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml
 
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
   tags:
-    - maas-container-conntrack
+    - always
 
 
 - name: Install checks for container conntrack monitoring
@@ -77,6 +55,8 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-container-container

--- a/playbooks/maas-container-conntrack.yml
+++ b/playbooks/maas-container-conntrack.yml
@@ -16,10 +16,28 @@
 - name: Gather facts
   hosts: neutron_agent
   gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
+  tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+  tags:
+    - always
+
+
+- name: Gather facts
+  hosts: neutron_agent
+  gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+
     - name: Set the current group
       set_fact:
         maas_current_group: neutron_agent
@@ -34,15 +52,18 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-container-conntrack
+
 
 - name: Install checks for container conntrack monitoring
   hosts: neutron_agent
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install conntrack count checks
       template:
@@ -56,5 +77,6 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - maas-container-container

--- a/playbooks/maas-container-conntrack.yml
+++ b/playbooks/maas-container-conntrack.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: neutron_agent
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -39,10 +39,15 @@
 
 - name: Install checks for container conntrack monitoring
   hosts: neutron_agent
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
-  tasks:
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
     - name: Install conntrack count checks
       template:
         src: "templates/rax-maas/conntrack_count.yaml.j2"

--- a/playbooks/maas-container-conntrack.yml
+++ b/playbooks/maas-container-conntrack.yml
@@ -31,22 +31,6 @@
        dest: "/tmp/pip-constraints.txt"
      delegate_to: "{{ physical_host | default(ansible_host) }}"
 
-  post_tasks:
-    - name: Install container pip packages to venv
-      pip:
-        name: "{{ maas_container_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-container-storage.yml
+++ b/playbooks/maas-container-storage.yml
@@ -17,18 +17,16 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  become: true
   tasks:
     - name: Create known container hosts fact
       set_fact:
         _known_container_hosts: |-
           {% set _var = [] -%}
-          {% for item in groups['all_containers'] | default([]) -%}
-          {%  if hostvars[item]['physical_host'] | default(false) != item -%}
-          {%   if _var.append(hostvars[item]['physical_host']) -%}
-          {%   endif -%}
-          {%  endif -%}
-          {% endfor -%}
+          {% for item in groups['all_containers'] | default([]) %}
+          {%   if hostvars[item]['physical_host'] | default(false) != item %}
+          {%     set _ = _var.append(hostvars[item]['physical_host']) %}
+          {%   endif %}
+          {% endfor %}
           {{ _var | unique }}
 
     - name: Create dynamic lxc_host group
@@ -48,41 +46,18 @@
       when:
         - deploy_osp | bool
 
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-
-  tags:
-    - always
-
-
-- name: Gather facts
-  hosts: known_container_hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  pre_tasks:
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Set the current group
       set_fact:
         maas_current_group: hosts
 
-  tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml
 
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
   tags:
-    - maas-container-storage
+    - always
 
 
 - name: Install checks for infra memcached
@@ -105,6 +80,8 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-container-storage

--- a/playbooks/maas-container-storage.yml
+++ b/playbooks/maas-container-storage.yml
@@ -16,7 +16,7 @@
 - name: Generate container host list
   hosts: localhost
   connection: local
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Create known container hosts fact
       set_fact:
@@ -38,7 +38,7 @@
 
 - name: Gather facts
   hosts: known_container_hosts
-  gather_facts: false
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -62,9 +62,15 @@
 
 - name: Install checks for infra memcached
   hosts: known_container_hosts
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Install local checks
       template:

--- a/playbooks/maas-container-storage.yml
+++ b/playbooks/maas-container-storage.yml
@@ -17,6 +17,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
+  become: true
   tasks:
     - name: Create known container hosts fact
       set_fact:
@@ -40,14 +41,17 @@
 - name: Gather facts
   hosts: known_container_hosts
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -56,9 +60,10 @@
   hosts: known_container_hosts
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
     - name: Set the current group
       set_fact:
         maas_current_group: hosts
@@ -84,7 +89,7 @@
   hosts: known_container_hosts
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install local checks
       template:

--- a/playbooks/maas-container-storage.yml
+++ b/playbooks/maas-container-storage.yml
@@ -70,22 +70,6 @@
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
-  post_tasks:
-    - name: Install glance pip packages to venv
-      pip:
-        name: "{{ maas_container_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-host-all.yml
+++ b/playbooks/maas-host-all.yml
@@ -13,22 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: maas-host-private-checks.yml
+- import_playbook: maas-host-private-checks.yml
   tags:
     - maas-host
 
-- include: maas-host-cdm.yml
+- import_playbook: maas-host-cdm.yml
   tags:
     - maas-host
 
-- include: maas-host-kernel.yml
+- import_playbook: maas-host-kernel.yml
   tags:
     - maas-host
 
-- include: maas-host-network.yml
+- import_playbook: maas-host-network.yml
   tags:
     - maas-host
 
-- include: maas-host-vendor.yml
+- import_playbook: maas-host-vendor.yml
   tags:
     - maas-host

--- a/playbooks/maas-host-cdm.yml
+++ b/playbooks/maas-host-cdm.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -39,8 +39,14 @@
 
 - name: Install checks for CDM
   hosts: hosts
-  gather_facts: false
+  gather_facts: true
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Install filesystem Checks
       template:

--- a/playbooks/maas-host-cdm.yml
+++ b/playbooks/maas-host-cdm.yml
@@ -16,17 +16,31 @@
 - name: Gather facts
   hosts: hosts
   gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
   tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
     - name: Set the current group
       set_fact:
         maas_current_group: hosts
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+
   tags:
-    - maas-host-cdm
+    - always
+
 
 - name: Install checks for CDM
   hosts: hosts
   gather_facts: false
+  become: true
   tasks:
     - name: Install filesystem Checks
       template:
@@ -73,5 +87,6 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
-    - maas-ceph-osds
+    - maas-hosts-cdm

--- a/playbooks/maas-host-cdm.yml
+++ b/playbooks/maas-host-cdm.yml
@@ -88,5 +88,7 @@
     - vars/main.yml
     - vars/maas.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-hosts-cdm

--- a/playbooks/maas-host-kernel.yml
+++ b/playbooks/maas-host-kernel.yml
@@ -16,6 +16,25 @@
 - name: Gather facts
   hosts: hosts
   gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
+  tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+
+  tags:
+    - always
+
+
+- name: Gather facts
+  hosts: hosts
+  gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
   tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
     - name: Set the current group
@@ -52,5 +71,6 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - maas-hosts-kernel

--- a/playbooks/maas-host-kernel.yml
+++ b/playbooks/maas-host-kernel.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -39,8 +39,13 @@
 
 - name: Install checks for hosts kernel
   hosts: hosts
-  gather_facts: false
+  gather_facts: true
   pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
     - name: Check nf_conntrack status
       stat:
         path: "/proc/sys/net/nf_conntrack_max"

--- a/playbooks/maas-host-kernel.yml
+++ b/playbooks/maas-host-kernel.yml
@@ -23,6 +23,12 @@
       when:
         - deploy_osp | bool
 
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: hosts
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
@@ -30,18 +36,6 @@
   tags:
     - always
 
-
-- name: Gather facts
-  hosts: hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
-  become: true
-  tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
-    - name: Set the current group
-      set_fact:
-        maas_current_group: hosts
-  tags:
-    - maas-hosts-kernel
 
 - name: Install checks for hosts kernel
   hosts: hosts
@@ -71,6 +65,8 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-hosts-kernel

--- a/playbooks/maas-host-network.yml
+++ b/playbooks/maas-host-network.yml
@@ -45,21 +45,6 @@
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
-  post_tasks:
-    - name: Install network pip packages to venv
-      pip:
-        name: "{{ maas_network_check_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-host-network.yml
+++ b/playbooks/maas-host-network.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: hosts
-  gather_facts: false
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -39,9 +39,14 @@
 
 - name: Install checks for hosts network
   hosts: hosts
-  gather_facts: false
+  gather_facts: true
   become: true
   pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
     - name: Test that network interfaces exist
       fail:
         msg: "The specified network interfaces {{ item.name }} doesn't exist, consider setting the 'maas_network_checks_list' variable to override these interfaces"
@@ -73,8 +78,14 @@
 
 - name: Install checks for bonding interfaces
   hosts: hosts
-  gather_facts: false
+  gather_facts: true
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Install checks for bonding interfaces
       template:

--- a/playbooks/maas-host-network.yml
+++ b/playbooks/maas-host-network.yml
@@ -23,40 +23,18 @@
       when:
         - deploy_osp | bool
 
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-
-  tags:
-    - always
-
-
-- name: Gather facts
-  hosts: hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  tasks:
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Set the current group
       set_fact:
         maas_current_group: hosts
 
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml
 
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
   tags:
-    - maas-hosts-network
+    - always
 
 
 - name: Install checks for hosts network
@@ -87,6 +65,8 @@
     - vars/main.yml
     - vars/maas.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-hosts-network
 
@@ -108,6 +88,8 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-hosts-network

--- a/playbooks/maas-host-network.yml
+++ b/playbooks/maas-host-network.yml
@@ -16,14 +16,17 @@
 - name: Gather facts
   hosts: hosts
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -32,9 +35,10 @@
   hosts: hosts
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
     - name: Set the current group
       set_fact:
         maas_current_group: hosts
@@ -58,6 +62,7 @@
 - name: Install checks for hosts network
   hosts: hosts
   gather_facts: false
+  become: true
   pre_tasks:
     - name: Test that network interfaces exist
       fail:
@@ -89,6 +94,7 @@
 - name: Install checks for bonding interfaces
   hosts: hosts
   gather_facts: false
+  become: true
   tasks:
     - name: Install checks for bonding interfaces
       template:

--- a/playbooks/maas-host-private-checks.yml
+++ b/playbooks/maas-host-private-checks.yml
@@ -16,7 +16,7 @@
 
 - name: Gather facts
   hosts: hosts
-  gather_facts: false
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -40,8 +40,14 @@
 
 - name: Install private network monitoring checks
   hosts: hosts
-  gather_facts: false
+  gather_facts: true
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Install private ping and SSH checks
       template:

--- a/playbooks/maas-host-private-checks.yml
+++ b/playbooks/maas-host-private-checks.yml
@@ -61,5 +61,7 @@
     - vars/main.yml
     - vars/maas.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-poller-setup

--- a/playbooks/maas-host-private-checks.yml
+++ b/playbooks/maas-host-private-checks.yml
@@ -13,32 +13,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 - name: Gather facts
   hosts: hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
-  pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
     - name: Set the current group
       set_fact:
         maas_current_group: hosts
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+
   tags:
-    - maas-poller-setup
+    - always
+
 
 - name: Install private network monitoring checks
   hosts: hosts
   gather_facts: false
-
+  become: true
   tasks:
     - name: Install private ping and SSH checks
-      when:
-        - maas_private_monitoring_enabled | bool
-        - maas_private_monitoring_zone is defined
       template:
         src: "templates/rax-maas/{{ item.name }}.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/{{ item.name }}.yaml"
         owner: "root"
         group: "root"
         mode: "0644"
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
       with_items:
         - { name: "private_ping_check" }
         - { name: "private_ssh_check" }
@@ -46,5 +60,6 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - maas-poller-setup

--- a/playbooks/maas-host-vendor.yml
+++ b/playbooks/maas-host-vendor.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: hosts
-  gather_facts: false
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -39,8 +39,14 @@
 
 - name: Gather facts
   hosts: hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Run vendor tasks
       include_tasks: "common-tasks/maas-host-vendor-{{ ansible_system_vendor.split()[0] | lower }}.yml"

--- a/playbooks/maas-host-vendor.yml
+++ b/playbooks/maas-host-vendor.yml
@@ -15,14 +15,33 @@
 
 - name: Gather facts
   hosts: hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: false
+  become: true
   tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
     - name: Set the current group
       set_fact:
         maas_current_group: hosts
 
-  post_tasks:
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+
+  tags:
+    - always
+
+
+- name: Gather facts
+  hosts: hosts
+  gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
+  tasks:
     - name: Run vendor tasks
       include: "common-tasks/maas-host-vendor-{{ ansible_system_vendor.split()[0] | lower }}.yml"
       when:
@@ -31,5 +50,6 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - maas-hosts-vendor

--- a/playbooks/maas-host-vendor.yml
+++ b/playbooks/maas-host-vendor.yml
@@ -43,13 +43,15 @@
   become: true
   tasks:
     - name: Run vendor tasks
-      include: "common-tasks/maas-host-vendor-{{ ansible_system_vendor.split()[0] | lower }}.yml"
+      include_tasks: "common-tasks/maas-host-vendor-{{ ansible_system_vendor.split()[0] | lower }}.yml"
       when:
         - maas_host_check | bool
 
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-hosts-vendor

--- a/playbooks/maas-infra-all.yml
+++ b/playbooks/maas-infra-all.yml
@@ -13,25 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: maas-infra-galera.yml
+- import_playbook: maas-infra-galera.yml
   tags:
     - maas-infra
 
-- include: maas-infra-memcached.yml
+- import_playbook: maas-infra-memcached.yml
   tags:
     - maas-infra
 
-- include: maas-infra-rabbitmq.yml
+- import_playbook: maas-infra-rabbitmq.yml
   tags:
     - maas-infra
 
-- include: maas-infra-rsyslogd.yml
+- import_playbook: maas-infra-rsyslogd.yml
   tags:
     - maas-infra
 
-- include: maas-infra-pacemaker.yml
-  when:
-    - deploy_osp | bool
+- import_playbook: maas-infra-pacemaker.yml
   tags:
     - maas-pacemaker
 

--- a/playbooks/maas-infra-galera.yml
+++ b/playbooks/maas-infra-galera.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: galera_all
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -28,16 +28,26 @@
     - name: Set the current group
       set_fact:
         maas_current_group: galera_all
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+
   tags:
     - maas-infra-galera
 
 
 - name: Install checks for infra galera
   hosts: galera_all
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
     - name: Check for required galera variables
       fail:
         msg: >-
@@ -46,7 +56,7 @@
       when:
         - not galera_root_password is defined
 
-    - name: Include ubuntu install tasks
+    - name: Include install tasks
       include_tasks: "common-tasks/maas-infra-{{ ansible_distribution | lower }}-install.yml"
 
     - name: Install holland check

--- a/playbooks/maas-infra-galera.yml
+++ b/playbooks/maas-infra-galera.yml
@@ -16,19 +16,27 @@
 - name: Gather facts
   hosts: galera_all
   gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
   tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
     - name: Set the current group
       set_fact:
         maas_current_group: galera_all
   tags:
     - maas-infra-galera
 
+
 - name: Install checks for infra galera
   hosts: galera_all
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   pre_tasks:
     - name: Check for required galera variables
       fail:
@@ -39,7 +47,7 @@
         - not galera_root_password is defined
 
     - name: Include ubuntu install tasks
-      include: "common-tasks/maas-infra-{{ ansible_distribution | lower }}-install.yml"
+      include_tasks: "common-tasks/maas-infra-{{ ansible_distribution | lower }}-install.yml"
 
     - name: Install holland check
       template:
@@ -76,6 +84,8 @@
     - vars/main.yml
     - vars/maas.yml
     - "vars/maas-{{ ansible_distribution | lower }}.yml"
+
   environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-infra-galera

--- a/playbooks/maas-infra-memcached.yml
+++ b/playbooks/maas-infra-memcached.yml
@@ -16,11 +16,19 @@
 - name: Gather facts
   hosts: memcached_all
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: memcached_all
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
@@ -32,13 +40,7 @@
   hosts: memcached_all
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
-  pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
-    - name: Set the current group
-      set_fact:
-        maas_current_group: memcached_all
-
+  become: true
   tasks:
     - name: Copy over pip constraints
       copy:

--- a/playbooks/maas-infra-memcached.yml
+++ b/playbooks/maas-infra-memcached.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: memcached_all
-  gather_facts: false
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -39,9 +39,15 @@
 
 - name: Install checks for infra memcached
   hosts: memcached_all
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Install memcached check
       template:

--- a/playbooks/maas-infra-memcached.yml
+++ b/playbooks/maas-infra-memcached.yml
@@ -46,22 +46,6 @@
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
-  post_tasks:
-    - name: Install memcached pip packages to venv
-      pip:
-        name: "{{ maas_memcached_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-infra-memcached.yml
+++ b/playbooks/maas-infra-memcached.yml
@@ -32,37 +32,16 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
-
-
-- name: Gather facts
-  hosts: memcached_all
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
-  tags:
-    - maas-infra-memcached
 
 
 - name: Install checks for infra memcached
   hosts: memcached_all
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install memcached check
       template:
@@ -77,6 +56,8 @@
     - vars/main.yml
     - vars/maas.yml
     - "vars/maas-{{ ansible_distribution | lower }}.yml"
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-infra-memcached

--- a/playbooks/maas-infra-pacemaker.yml
+++ b/playbooks/maas-infra-pacemaker.yml
@@ -23,14 +23,16 @@
       when:
         - deploy_osp | bool
 
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Set the current group
       set_fact:
         maas_current_group: shared-infra_hosts
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -56,6 +58,8 @@
     - vars/main.yml
     - vars/maas.yml
     - "vars/maas-{{ ansible_distribution | lower }}.yml"
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-infra-pacemaker

--- a/playbooks/maas-infra-pacemaker.yml
+++ b/playbooks/maas-infra-pacemaker.yml
@@ -16,6 +16,7 @@
 - name: Gather facts
   hosts: shared-infra_hosts
   gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
@@ -38,7 +39,7 @@
   hosts: shared-infra_hosts
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install checks for infra pacemaker
       template:
@@ -48,10 +49,13 @@
         group: "root"
         mode: "0644"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - deploy_osp | bool
 
   vars_files:
     - vars/main.yml
     - vars/maas.yml
     - "vars/maas-{{ ansible_distribution | lower }}.yml"
+
   tags:
     - maas-infra-pacemaker

--- a/playbooks/maas-infra-pacemaker.yml
+++ b/playbooks/maas-infra-pacemaker.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: shared-infra_hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -39,9 +39,15 @@
 
 - name: Install checks for infra galera
   hosts: shared-infra_hosts
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Install checks for infra pacemaker
       template:

--- a/playbooks/maas-infra-rabbitmq.yml
+++ b/playbooks/maas-infra-rabbitmq.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: rabbitmq_all:Controller
-  gather_facts: false
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -39,9 +39,15 @@
 
 - name: Gather facts
   hosts: rabbitmq_all
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Install rabbitmq pip packages
       package:
@@ -68,6 +74,12 @@
   gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Ensure MaaS rabbitmq user as administrator with rabbitmqctl
       rabbitmq_user:
@@ -121,9 +133,15 @@
 
 - name: Install checks for infra rabbitmq
   hosts: rabbitmq_all
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Get list of vhosts
       uri:

--- a/playbooks/maas-infra-rabbitmq.yml
+++ b/playbooks/maas-infra-rabbitmq.yml
@@ -16,14 +16,23 @@
 - name: Gather facts
   hosts: rabbitmq_all:Controller
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: rabbitmq_all
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -32,13 +41,7 @@
   hosts: rabbitmq_all
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
-  pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
-    - name: Set the current group
-      set_fact:
-        maas_current_group: rabbitmq_all
-
+  become: true
   tasks:
     - name: Install rabbitmq pip packages
       package:
@@ -64,7 +67,7 @@
   hosts: rabbitmq_all
   gather_facts: true
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Ensure MaaS rabbitmq user as administrator with rabbitmqctl
       rabbitmq_user:
@@ -120,7 +123,7 @@
   hosts: rabbitmq_all
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Get list of vhosts
       uri:

--- a/playbooks/maas-infra-rsyslogd.yml
+++ b/playbooks/maas-infra-rsyslogd.yml
@@ -15,20 +15,33 @@
 
 - name: Gather facts
   hosts: rsyslog_all
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: false
+  become: true
   tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
     - name: Set the current group
       set_fact:
         maas_current_group: rsyslog_all
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+
   tags:
-    - maas-infra-rsyslog
+    - always
+
 
 - name: Install checks for infra rsyslog
   hosts: rsyslog_all
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install rsyslog check
       template:
@@ -43,5 +56,6 @@
     - vars/main.yml
     - vars/maas.yml
     - "vars/maas-{{ ansible_distribution | lower }}.yml"
+
   tags:
     - maas-infra-rsyslog

--- a/playbooks/maas-infra-rsyslogd.yml
+++ b/playbooks/maas-infra-rsyslogd.yml
@@ -57,5 +57,7 @@
     - vars/maas.yml
     - "vars/maas-{{ ansible_distribution | lower }}.yml"
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-infra-rsyslog

--- a/playbooks/maas-infra-rsyslogd.yml
+++ b/playbooks/maas-infra-rsyslogd.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: rsyslog_all
-  gather_facts: false
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -39,9 +39,15 @@
 
 - name: Install checks for infra rsyslog
   hosts: rsyslog_all
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Install rsyslog check
       template:

--- a/playbooks/maas-managed-k8.yml
+++ b/playbooks/maas-managed-k8.yml
@@ -19,7 +19,7 @@
   become: "{{ mk8s_ansible_become | default('no') }}"
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Set the current group
       set_fact:
@@ -52,7 +52,7 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
 
     - name: Install mk8s ui local checks
       template:
@@ -61,7 +61,7 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
 
     - name: Install mk8s ui lb checks
       template:
@@ -70,7 +70,7 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
         - not maas_private_monitoring_enabled
@@ -82,7 +82,7 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_private_monitoring_enabled
         - maas_private_monitoring_zone is defined
@@ -110,7 +110,7 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
 
     - name: Install mk8s etp local checks
       template:
@@ -119,12 +119,14 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
     # Ideally ETP should not be accessible from the outside so skip those checks
 
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-managed-k8
@@ -143,7 +145,7 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
 
     - name: Install mk8s etg local checks
       template:
@@ -152,12 +154,14 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
     # Ideally etg should not be accessible from the outside so skip those checks
 
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-managed-k8
@@ -176,7 +180,7 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
 
     - name: Install mk8s auth local checks
       template:
@@ -185,12 +189,14 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
     # Ideally auth should not be accessible from the outside so skip those checks
 
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-managed-k8

--- a/playbooks/maas-managed-k8.yml
+++ b/playbooks/maas-managed-k8.yml
@@ -17,7 +17,7 @@
   hosts: os-infra_hosts:Controller
   user: "{{ mk8s_ansible_user | default('root') }}"
   become: "{{ mk8s_ansible_become | default('no') }}"
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   pre_tasks:
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
@@ -43,7 +43,13 @@
   hosts:  "{{ mk8s_ui_hosts | default('mk8s_ui_all') }}"
   user: "{{ mk8s_ansible_user | default('root') }}"
   become: "{{ mk8s_ansible_become | default('no') }}"
-  gather_facts: false
+  gather_facts: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Install mk8s ui process check
       template:
@@ -101,7 +107,13 @@
   hosts:  "{{ mk8s_etp_hosts | default('mk8s_etp_all') }}"
   user: "{{ mk8s_ansible_user | default('root') }}"
   become: "{{ mk8s_ansible_become | default('no') }}"
-  gather_facts: false
+  gather_facts: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Install mk8s etp process check
       template:
@@ -136,7 +148,13 @@
   hosts: "{{ mk8s_etg_hosts | default('mk8s_etg_all') }}"
   user: "{{ mk8s_ansible_user | default('root') }}"
   become: "{{ mk8s_ansible_become | default('no') }}"
-  gather_facts: false
+  gather_facts: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Install mk8s etg process check
       template:
@@ -171,7 +189,13 @@
   hosts:  "{{ mk8s_auth_hosts | default('mk8s_auth_all') }}"
   user: "{{ mk8s_ansible_user | default('root') }}"
   become: "{{ mk8s_ansible_become | default('no') }}"
-  gather_facts: false
+  gather_facts: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Install mk8s auth process check
       template:

--- a/playbooks/maas-managed-k8.yml
+++ b/playbooks/maas-managed-k8.yml
@@ -33,9 +33,11 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - maas-managed-k8
     - always
+
 
 - name: Install checks for mk8s ui
   hosts:  "{{ mk8s_ui_hosts | default('mk8s_ui_all') }}"
@@ -84,12 +86,16 @@
       when:
         - maas_private_monitoring_enabled
         - maas_private_monitoring_zone is defined
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-managed-k8
+
 
 - name: Install checks for mk8s etp
   hosts:  "{{ mk8s_etp_hosts | default('mk8s_etp_all') }}"
@@ -115,11 +121,14 @@
         mode: "0644"
       delegate_to: "{{ physical_host }}"
     # Ideally ETP should not be accessible from the outside so skip those checks
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - maas-managed-k8
+
 
 - name: Install checks for mk8s etg
   hosts: "{{ mk8s_etg_hosts | default('mk8s_etg_all') }}"
@@ -145,11 +154,14 @@
         mode: "0644"
       delegate_to: "{{ physical_host }}"
     # Ideally etg should not be accessible from the outside so skip those checks
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - maas-managed-k8
+
 
 - name: Install checks for mk8s auth
   hosts:  "{{ mk8s_auth_hosts | default('mk8s_auth_all') }}"
@@ -175,8 +187,10 @@
         mode: "0644"
       delegate_to: "{{ physical_host }}"
     # Ideally auth should not be accessible from the outside so skip those checks
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - maas-managed-k8

--- a/playbooks/maas-openstack-all.yml
+++ b/playbooks/maas-openstack-all.yml
@@ -13,50 +13,50 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: maas-openstack-cinder.yml
+- import_playbook: maas-openstack-cinder.yml
   tags:
     - maas-openstack
 
-- include: maas-openstack-designate.yml
+- import_playbook: maas-openstack-designate.yml
   tags:
     - maas-openstack
 
-- include: maas-openstack-glance.yml
+- import_playbook: maas-openstack-glance.yml
   tags:
     - maas-openstack
 
-- include: maas-openstack-heat.yml
+- import_playbook: maas-openstack-heat.yml
   tags:
     - maas-openstack
 
-- include: maas-openstack-horizon.yml
+- import_playbook: maas-openstack-horizon.yml
   tags:
     - maas-openstack
 
-- include: maas-openstack-ironic.yml
+- import_playbook: maas-openstack-ironic.yml
   tags:
     - maas-openstack
 
-- include: maas-openstack-keystone.yml
+- import_playbook: maas-openstack-keystone.yml
   tags:
     - maas-openstack
 
-- include: maas-openstack-magnum.yml
+- import_playbook: maas-openstack-magnum.yml
   tags:
     - maas-openstack
 
-- include: maas-openstack-neutron.yml
+- import_playbook: maas-openstack-neutron.yml
   tags:
     - maas-openstack
 
-- include: maas-openstack-nova.yml
+- import_playbook: maas-openstack-nova.yml
   tags:
     - maas-openstack
 
-- include: maas-openstack-octavia.yml
+- import_playbook: maas-openstack-octavia.yml
   tags:
     - maas-openstack
 
-- include: maas-openstack-swift.yml
+- import_playbook: maas-openstack-swift.yml
   tags:
     - maas-openstack

--- a/playbooks/maas-openstack-cinder.yml
+++ b/playbooks/maas-openstack-cinder.yml
@@ -30,10 +30,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install cinder api checks
       template:
@@ -96,10 +92,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install cinder api checks
       template:
@@ -137,10 +129,6 @@
         maas_current_group: cinder_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
     - name: Stop deployment of cinder backup
       block:
@@ -191,10 +179,6 @@
         maas_current_group: cinder_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Install cinder volume checks

--- a/playbooks/maas-openstack-cinder.yml
+++ b/playbooks/maas-openstack-cinder.yml
@@ -50,22 +50,6 @@
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
-  post_tasks:
-    - name: Install cinder pip packages to venv
-      pip:
-        name: "{{ maas_openstack_cinder_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-openstack-cinder.yml
+++ b/playbooks/maas-openstack-cinder.yml
@@ -23,6 +23,12 @@
       when:
         - deploy_osp | bool
 
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
     - name: Set the current group
       set_fact:
         maas_current_group: cinder_all
@@ -33,35 +39,6 @@
 
   tags:
     - always
-
-
-- name: Gather facts
-  hosts: cinder_all
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  pre_tasks:
-    - include_task: "common-tasks/maas_excluded_regex.yml"
-
-    - include_task: "common-tasks/maas_get_openrc.yml"
-
-    - include_task: "common-tasks/maas_get_maasrc.yml"
-  tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-    - vars/maas-openstack.yml
-
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
-  tags:
-    - maas-openstack-cinder
 
 
 - name: Install checks for openstack cinder-api
@@ -108,6 +85,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-cinder
 
@@ -132,6 +111,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-cinder
 
@@ -155,6 +136,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-cinder
@@ -194,6 +177,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-cinder

--- a/playbooks/maas-openstack-cinder.yml
+++ b/playbooks/maas-openstack-cinder.yml
@@ -13,15 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Gather facts
-  hosts: cinder_all
-  gather_facts: false
+- name: Install checks for openstack cinder-api
+  hosts: cinder_api
+  gather_facts: true
+  user: "{{ ansible_user | default('root') }}"
   become: true
-  tasks:
+  pre_tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: cinder_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
@@ -29,23 +34,6 @@
 
     - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: cinder_all
-
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-
-  tags:
-    - always
-
-
-- name: Install checks for openstack cinder-api
-  hosts: cinder_api
-  gather_facts: false
-  user: "{{ ansible_user | default('root') }}"
-  become: true
   tasks:
     - name: Install cinder api checks
       template:
@@ -93,9 +81,25 @@
 
 - name: Install checks for openstack cinder-api
   hosts: cinder_scheduler
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: cinder_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install cinder api checks
       template:
@@ -119,9 +123,37 @@
 
 - name: Install checks for openstack cinder-backup
   hosts: cinder_backup
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: cinder_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
+    - name: Stop deployment of cinder backup
+      block:
+        - name: Notify
+          debug:
+            msg: >-
+              No suitable backed was available for cinder backup to run. This check will not be deployed.
+
+        - name: Exit
+          meta: end_play
+      when:
+        - (((groups['swift_all'] | default([])) | union(groups['rgws'] | default([]))) | length) < 1
+
   tasks:
     - name: Install cinder backup checks
       template:
@@ -145,9 +177,25 @@
 
 - name: Install checks for openstack cinder-volume
   hosts: cinder_volume
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: cinder_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install cinder volume checks
       template:

--- a/playbooks/maas-openstack-cinder.yml
+++ b/playbooks/maas-openstack-cinder.yml
@@ -16,6 +16,7 @@
 - name: Gather facts
   hosts: cinder_all
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
@@ -25,9 +26,11 @@
     - name: Set the current group
       set_fact:
         maas_current_group: cinder_all
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -36,13 +39,13 @@
   hosts: cinder_all
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - include_task: "common-tasks/maas_excluded_regex.yml"
 
-    - include: "common-tasks/maas_get_openrc.yml"
+    - include_task: "common-tasks/maas_get_openrc.yml"
 
-    - include: "common-tasks/maas_get_maasrc.yml"
+    - include_task: "common-tasks/maas_get_maasrc.yml"
   tasks:
     - name: Copy over pip constraints
       copy:
@@ -65,7 +68,7 @@
   hosts: cinder_api
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install cinder api checks
       template:
@@ -113,7 +116,7 @@
   hosts: cinder_scheduler
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install cinder api checks
       template:
@@ -128,6 +131,7 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   tags:
     - maas-openstack-cinder
 
@@ -136,7 +140,7 @@
   hosts: cinder_backup
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install cinder backup checks
       template:
@@ -160,7 +164,7 @@
   hosts: cinder_volume
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install cinder volume checks
       template:

--- a/playbooks/maas-openstack-designate.yml
+++ b/playbooks/maas-openstack-designate.yml
@@ -23,6 +23,8 @@
       when:
         - deploy_osp | bool
 
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Set the current group
@@ -35,34 +37,6 @@
 
   tags:
     - always
-
-
-- name: Gather facts
-  hosts: "{{ designate_hosts_all | default('designate_all') }}"
-  user: "{{ designate_ansible_user | default('root') }}"
-  become: true
-  gather_facts: "{{ gather_facts | default(true) }}"
-  pre_tasks:
-    - include: "common-tasks/maas_get_openrc.yml"
-      when:
-        - not deploy_osp | bool
-
-  tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host }}"
-
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-    - vars/maas-openstack.yml
-
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
-  tags:
-    - maas-openstack-designate
 
 
 - name: Install checks for openstack designate
@@ -78,7 +52,7 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
 
     - name: Install designate mdns checks
       template:
@@ -87,7 +61,7 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
 
     - name: Install designate lb checks
       template:
@@ -96,7 +70,7 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_remote_check | bool
         - not maas_private_monitoring_enabled
@@ -108,7 +82,7 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host }}"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
       when:
         - maas_private_monitoring_enabled
         - maas_private_monitoring_zone is defined
@@ -117,6 +91,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-designate

--- a/playbooks/maas-openstack-designate.yml
+++ b/playbooks/maas-openstack-designate.yml
@@ -30,10 +30,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install designate api checks
       template:

--- a/playbooks/maas-openstack-designate.yml
+++ b/playbooks/maas-openstack-designate.yml
@@ -27,6 +27,7 @@
   tags:
     - always
 
+
 - name: Gather facts
   hosts: "{{ designate_hosts_all | default('designate_all') }}"
   user: "{{ designate_ansible_user | default('root') }}"
@@ -49,29 +50,16 @@
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host }}"
 
-  post_tasks:
-    - name: Install designate pip packages to venv
-      pip:
-        name: "{{ maas_openstack_designate_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-      virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-designate
+
 
 - name: Install checks for openstack designate
   hosts: "{{ designate_hosts_all | default('designate_all') }}"
@@ -125,5 +113,6 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   tags:
     - maas-openstack-designate

--- a/playbooks/maas-openstack-designate.yml
+++ b/playbooks/maas-openstack-designate.yml
@@ -13,37 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Gather facts
+- name: Install checks for openstack designate
   hosts: designate_all:Controller
-  gather_facts: false
+  user: "{{ ansible_user | default('root') }}"
   become: true
-  tasks:
+  gather_facts: true
+  pre_tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
     - name: Set the current group
       set_fact:
         maas_current_group: designate_all
 
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-  tags:
-    - always
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
 
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
-- name: Install checks for openstack designate
-  hosts: "{{ designate_hosts_all | default('designate_all') }}"
-  user: "{{ designate_ansible_user | default('root') }}"
-  become: true
-  gather_facts: false
   tasks:
     - name: Install designate api checks
       template:

--- a/playbooks/maas-openstack-designate.yml
+++ b/playbooks/maas-openstack-designate.yml
@@ -16,14 +16,23 @@
 - name: Gather facts
   hosts: designate_all:Controller
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: designate_all
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -31,17 +40,12 @@
 - name: Gather facts
   hosts: "{{ designate_hosts_all | default('designate_all') }}"
   user: "{{ designate_ansible_user | default('root') }}"
-  become: "{{ designate_ansible_become | default('no') }}"
+  become: true
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
     - include: "common-tasks/maas_get_openrc.yml"
       when:
         - not deploy_osp | bool
-
-    - name: Set the current group
-      set_fact:
-        maas_current_group: designate_all
 
   tasks:
     - name: Copy over pip constraints
@@ -64,7 +68,7 @@
 - name: Install checks for openstack designate
   hosts: "{{ designate_hosts_all | default('designate_all') }}"
   user: "{{ designate_ansible_user | default('root') }}"
-  become: "{{ designate_ansible_become | default('no') }}"
+  become: true
   gather_facts: false
   tasks:
     - name: Install designate api checks

--- a/playbooks/maas-openstack-glance.yml
+++ b/playbooks/maas-openstack-glance.yml
@@ -49,22 +49,6 @@
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
-  post_tasks:
-    - name: Install glance pip packages to venv
-      pip:
-        name: "{{ maas_openstack_glance_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml
@@ -143,5 +127,6 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   tags:
     - maas-openstack-glance

--- a/playbooks/maas-openstack-glance.yml
+++ b/playbooks/maas-openstack-glance.yml
@@ -13,16 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-- name: Gather facts
-  hosts: glance_all
-  gather_facts: false
+- name: Install checks for openstack glance-api
+  hosts: glance_api
+  gather_facts: true
+  user: "{{ ansible_user | default('root') }}"
   become: true
-  tasks:
+  pre_tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: glance_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
@@ -30,23 +34,6 @@
 
     - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: glance_all
-
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-
-  tags:
-    - always
-
-
-- name: Install checks for openstack glance-api
-  hosts: glance_api
-  gather_facts: false
-  user: "{{ ansible_user | default('root') }}"
-  become: true
   tasks:
     - name: Install glance api checks
       template:
@@ -94,9 +81,25 @@
 
 - name: Install checks for openstack glance-registry
   hosts: glance_registry
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: glance_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install glance registry checks
       template:

--- a/playbooks/maas-openstack-glance.yml
+++ b/playbooks/maas-openstack-glance.yml
@@ -30,10 +30,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install glance api checks
       template:
@@ -95,10 +91,6 @@
         maas_current_group: glance_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Install glance registry checks

--- a/playbooks/maas-openstack-glance.yml
+++ b/playbooks/maas-openstack-glance.yml
@@ -17,14 +17,27 @@
 - name: Gather facts
   hosts: glance_all
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: glance_all
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -33,15 +46,7 @@
   hosts: glance_all
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
-  pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
-    - include: "common-tasks/maas_get_openrc.yml"
-    - include: "common-tasks/maas_get_maasrc.yml"
-    - name: Set the current group
-      set_fact:
-        maas_current_group: glance_all
-
+  become: true
   tasks:
     - name: Copy over pip constraints
       copy:
@@ -64,7 +69,7 @@
   hosts: glance_api
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install glance api checks
       template:
@@ -112,7 +117,7 @@
   hosts: glance_registry
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install glance registry checks
       template:

--- a/playbooks/maas-openstack-glance.yml
+++ b/playbooks/maas-openstack-glance.yml
@@ -42,29 +42,6 @@
     - always
 
 
-- name: Gather facts
-  hosts: glance_all
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-    - vars/maas-openstack.yml
-
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
-  tags:
-    - maas-openstack-glance
-
-
 - name: Install checks for openstack glance-api
   hosts: glance_api
   gather_facts: false
@@ -109,6 +86,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-glance
 
@@ -132,6 +111,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-glance

--- a/playbooks/maas-openstack-heat.yml
+++ b/playbooks/maas-openstack-heat.yml
@@ -30,9 +30,7 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
 
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Install heat api checks
@@ -96,9 +94,7 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
 
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Install heat api cfn checks
@@ -161,10 +157,6 @@
         maas_current_group: heat_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Install heat api cloudwatch checks

--- a/playbooks/maas-openstack-heat.yml
+++ b/playbooks/maas-openstack-heat.yml
@@ -51,22 +51,6 @@
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
-  post_tasks:
-    - name: Install heat pip packages to venv
-      pip:
-        name: "{{ maas_openstack_heat_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-openstack-heat.yml
+++ b/playbooks/maas-openstack-heat.yml
@@ -16,14 +16,25 @@
 - name: Gather facts
   hosts: heat_all
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: heat_all
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -32,18 +43,7 @@
   hosts: heat_all
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
-  pre_tasks:
-    - name: Include OSP vars
-      include_vars: vars/maas-osp.yml
-      when:
-        - deploy_osp | bool
-    - include: "common-tasks/maas_excluded_regex.yml"
-    - include: "common-tasks/maas_get_openrc.yml"
-    - name: Set the current group
-      set_fact:
-        maas_current_group: heat_all
-
+  become: true
   tasks:
     - name: Copy over pip constraints
       copy:
@@ -66,7 +66,7 @@
   hosts: heat_api
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install heat api checks
       template:
@@ -114,7 +114,7 @@
   hosts: heat_api_cfn
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install heat api cfn checks
       template:
@@ -162,7 +162,7 @@
   hosts: heat_api_cloudwatch
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install heat api cloudwatch checks
       template:

--- a/playbooks/maas-openstack-heat.yml
+++ b/playbooks/maas-openstack-heat.yml
@@ -13,37 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Gather facts
-  hosts: heat_all
-  gather_facts: false
+- name: Install checks for openstack heat-api
+  hosts: heat_api
+  gather_facts: true
+  user: "{{ ansible_user | default('root') }}"
   become: true
-  tasks:
+  pre_tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
 
-    - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
     - name: Set the current group
       set_fact:
         maas_current_group: heat_all
 
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-  tags:
-    - always
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
 
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
-- name: Install checks for openstack heat-api
-  hosts: heat_api
-  gather_facts: false
-  user: "{{ ansible_user | default('root') }}"
-  become: true
   tasks:
     - name: Install heat api checks
       template:
@@ -91,9 +81,25 @@
 
 - name: Install checks for openstack heat-api-cfn
   hosts: heat_api_cfn
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: heat_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install heat api cfn checks
       template:
@@ -141,9 +147,25 @@
 
 - name: Install checks for openstack heat-api-cloudwatch
   hosts: heat_api_cloudwatch
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: heat_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install heat api cloudwatch checks
       template:

--- a/playbooks/maas-openstack-heat.yml
+++ b/playbooks/maas-openstack-heat.yml
@@ -39,29 +39,6 @@
     - always
 
 
-- name: Gather facts
-  hosts: heat_all
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-    - vars/maas-openstack.yml
-
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
-  tags:
-    - maas-openstack-heat
-
-
 - name: Install checks for openstack heat-api
   hosts: heat_api
   gather_facts: false
@@ -105,6 +82,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-heat
@@ -154,6 +133,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-heat
 
@@ -201,6 +182,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-heat

--- a/playbooks/maas-openstack-horizon.yml
+++ b/playbooks/maas-openstack-horizon.yml
@@ -109,5 +109,7 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-horizon

--- a/playbooks/maas-openstack-horizon.yml
+++ b/playbooks/maas-openstack-horizon.yml
@@ -30,10 +30,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install horizon checks
       template:

--- a/playbooks/maas-openstack-horizon.yml
+++ b/playbooks/maas-openstack-horizon.yml
@@ -16,42 +16,34 @@
 - name: Gather facts
   hosts: horizon
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-  tags:
-    - always
 
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-- name: Gather facts
-  hosts: horizon
-  user: "{{ ansible_user | default('root') }}"
-  become: yes
-  gather_facts: "{{ gather_facts | default(true) }}"
-  tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
-
-    - include: "common-tasks/maas_get_openrc.yml"
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
 
     - name: Set the current group
       set_fact:
         maas_current_group: horizon
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
-    - maas-openstack-horizon
+    - always
+
 
 - name: Install checks for openstack horizon
   hosts: horizon
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install horizon checks
       template:
@@ -116,5 +108,6 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   tags:
     - maas-openstack-horizon

--- a/playbooks/maas-openstack-horizon.yml
+++ b/playbooks/maas-openstack-horizon.yml
@@ -13,37 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Gather facts
+- name: Install checks for openstack horizon
   hosts: horizon
-  gather_facts: false
+  gather_facts: true
+  user: "{{ ansible_user | default('root') }}"
   become: true
-  tasks:
+  pre_tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
 
-    - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
     - name: Set the current group
       set_fact:
         maas_current_group: horizon
 
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-  tags:
-    - always
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
 
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
-- name: Install checks for openstack horizon
-  hosts: horizon
-  gather_facts: false
-  user: "{{ ansible_user | default('root') }}"
-  become: true
   tasks:
     - name: Install horizon checks
       template:

--- a/playbooks/maas-openstack-ironic.yml
+++ b/playbooks/maas-openstack-ironic.yml
@@ -30,10 +30,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install ironic api checks
       template:
@@ -105,10 +101,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install ironic ironic-conductor checks
       template:
@@ -144,10 +136,6 @@
         maas_current_group: ironic_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Install ironic ironic-compute checks

--- a/playbooks/maas-openstack-ironic.yml
+++ b/playbooks/maas-openstack-ironic.yml
@@ -16,14 +16,25 @@
 - name: Gather facts
   hosts: ironic_all
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: ironic_all
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -32,14 +43,7 @@
   hosts: ironic_all:ironic_compute
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
-  pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
-    - include: "common-tasks/maas_get_openrc.yml"
-    - name: Set the current group
-      set_fact:
-        maas_current_group: ironic_all
-
+  become: true
   tasks:
     - name: Copy over pip constraints
       copy:
@@ -62,7 +66,7 @@
   hosts: ironic_api
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install ironic api checks
       template:
@@ -119,7 +123,7 @@
   hosts: ironic_conductor
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install ironic ironic-conductor checks
       template:
@@ -143,7 +147,7 @@
   hosts: ironic_compute
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install ironic ironic-compute checks
       template:

--- a/playbooks/maas-openstack-ironic.yml
+++ b/playbooks/maas-openstack-ironic.yml
@@ -47,22 +47,6 @@
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
-  post_tasks:
-    - name: Install ironic pip packages to venv
-      pip:
-        name: "{{ maas_openstack_ironic_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-openstack-ironic.yml
+++ b/playbooks/maas-openstack-ironic.yml
@@ -13,37 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Gather facts
-  hosts: ironic_all
-  gather_facts: false
+- name: Install checks for openstack ironic-api
+  hosts: ironic_api
+  gather_facts: true
+  user: "{{ ansible_user | default('root') }}"
   become: true
-  tasks:
+  pre_tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
 
-    - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
     - name: Set the current group
       set_fact:
         maas_current_group: ironic_all
 
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-  tags:
-    - always
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
 
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
-- name: Install checks for openstack ironic-api
-  hosts: ironic_api
-  gather_facts: false
-  user: "{{ ansible_user | default('root') }}"
-  become: true
   tasks:
     - name: Install ironic api checks
       template:
@@ -100,9 +90,25 @@
 
 - name: Install checks for openstack ironic-conductor
   hosts: ironic_conductor
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: ironic_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install ironic ironic-conductor checks
       template:
@@ -124,9 +130,25 @@
 
 - name: Install checks for openstack ironic-compute
   hosts: ironic_compute
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: ironic_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install ironic ironic-compute checks
       template:

--- a/playbooks/maas-openstack-ironic.yml
+++ b/playbooks/maas-openstack-ironic.yml
@@ -39,29 +39,6 @@
     - always
 
 
-- name: Gather facts
-  hosts: ironic_all:ironic_compute
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-    - vars/maas-openstack.yml
-
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
-  tags:
-    - maas-openstack-ironic
-
-
 - name: Install checks for openstack ironic-api
   hosts: ironic_api
   gather_facts: false
@@ -115,6 +92,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-ironic
 
@@ -162,6 +141,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-ironic

--- a/playbooks/maas-openstack-keystone.yml
+++ b/playbooks/maas-openstack-keystone.yml
@@ -16,14 +16,25 @@
 - name: Gather facts
   hosts: keystone_all
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: keystone_all
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -32,14 +43,7 @@
   hosts: keystone_all
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
-  pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
-    - include: "common-tasks/maas_get_openrc.yml"
-    - name: Set the current group
-      set_fact:
-        maas_current_group: keystone_all
-
+  become: true
   tasks:
     - name: Copy over pip constraints
       copy:
@@ -62,7 +66,7 @@
   hosts: keystone_all
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   pre_tasks:
     - name: Create keystone user for monitoring
       shell: |

--- a/playbooks/maas-openstack-keystone.yml
+++ b/playbooks/maas-openstack-keystone.yml
@@ -47,22 +47,6 @@
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
-  post_tasks:
-    - name: Install keystone pip packages to venv
-      pip:
-        name: "{{ maas_openstack_keystone_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-openstack-keystone.yml
+++ b/playbooks/maas-openstack-keystone.yml
@@ -30,10 +30,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
     - name: Create keystone user for monitoring
       shell: |
         . /root/openrc

--- a/playbooks/maas-openstack-keystone.yml
+++ b/playbooks/maas-openstack-keystone.yml
@@ -39,29 +39,6 @@
     - always
 
 
-- name: Gather facts
-  hosts: keystone_all
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-    - vars/maas-openstack.yml
-
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
-  tags:
-    - maas-openstack-keystone
-
-
 - name: Install checks for openstack keystone
   hosts: keystone_all
   gather_facts: false
@@ -133,6 +110,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-keystone

--- a/playbooks/maas-openstack-keystone.yml
+++ b/playbooks/maas-openstack-keystone.yml
@@ -13,38 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Gather facts
+- name: Install checks for openstack keystone
   hosts: keystone_all
-  gather_facts: false
+  gather_facts: true
+  user: "{{ ansible_user | default('root') }}"
   become: true
-  tasks:
+  pre_tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
 
-    - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
     - name: Set the current group
       set_fact:
         maas_current_group: keystone_all
 
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-  tags:
-    - always
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
 
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
-- name: Install checks for openstack keystone
-  hosts: keystone_all
-  gather_facts: false
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  pre_tasks:
     - name: Create keystone user for monitoring
       shell: |
         . /root/openrc

--- a/playbooks/maas-openstack-magnum.yml
+++ b/playbooks/maas-openstack-magnum.yml
@@ -40,27 +40,6 @@
     - always
 
 
-- name: Gather facts
-  hosts: magnum
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-    - vars/maas-openstack.yml
-
-  tags:
-    - maas-openstack-magnum
-
-
 - name: Install checks for openstack magnum-api
   hosts: magnum
   gather_facts: false
@@ -89,6 +68,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-magnum

--- a/playbooks/maas-openstack-magnum.yml
+++ b/playbooks/maas-openstack-magnum.yml
@@ -30,10 +30,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install magnum api checks
       template:

--- a/playbooks/maas-openstack-magnum.yml
+++ b/playbooks/maas-openstack-magnum.yml
@@ -13,38 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-- name: Gather facts
+- name: Install checks for openstack magnum-api
   hosts: magnum
-  gather_facts: false
+  gather_facts: true
+  user: "{{ ansible_user | default('root') }}"
   become: true
-  tasks:
+  pre_tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
 
-    - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
     - name: Set the current group
       set_fact:
         maas_current_group: magnum
 
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-  tags:
-    - always
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
 
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
-- name: Install checks for openstack magnum-api
-  hosts: magnum
-  gather_facts: false
-  user: "{{ ansible_user | default('root') }}"
-  become: true
   tasks:
     - name: Install magnum api checks
       template:

--- a/playbooks/maas-openstack-magnum.yml
+++ b/playbooks/maas-openstack-magnum.yml
@@ -17,14 +17,25 @@
 - name: Gather facts
   hosts: magnum
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: magnum
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -33,14 +44,7 @@
   hosts: magnum
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
-  pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
-    - include: "common-tasks/maas_get_openrc.yml"
-    - name: Set the current group
-      set_fact:
-        maas_current_group: magnum
-
+  become: true
   tasks:
     - name: Copy over pip constraints
       copy:
@@ -61,7 +65,7 @@
   hosts: magnum
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install magnum api checks
       template:

--- a/playbooks/maas-openstack-magnum.yml
+++ b/playbooks/maas-openstack-magnum.yml
@@ -48,22 +48,6 @@
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
-  post_tasks:
-    - name: Install magnum pip packages to venv
-      pip:
-        name: "{{ maas_openstack_magnum_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-openstack-neutron.yml
+++ b/playbooks/maas-openstack-neutron.yml
@@ -47,27 +47,13 @@
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
-  post_tasks:
-    - name: Install neutron pip packages to venv
-      pip:
-        name: "{{ maas_openstack_neutron_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-neutron
 

--- a/playbooks/maas-openstack-neutron.yml
+++ b/playbooks/maas-openstack-neutron.yml
@@ -13,37 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Gather facts
-  hosts: neutron_all
-  gather_facts: false
+- name: Install checks for openstack neutron
+  hosts: neutron_server
+  gather_facts: true
+  user: "{{ ansible_user | default('root') }}"
   become: true
-  tasks:
+  pre_tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
 
-    - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
     - name: Set the current group
       set_fact:
         maas_current_group: neutron_all
 
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-  tags:
-    - always
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
 
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
-- name: Install checks for openstack neutron
-  hosts: neutron_server
-  gather_facts: false
-  user: "{{ ansible_user | default('root') }}"
-  become: true
   tasks:
     - name: Install neutron server checks
       template:
@@ -91,9 +81,25 @@
 
 - name: Install checks for openstack neutron dhcp agent
   hosts: neutron_dhcp_agent
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: neutron_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install neutron dhcp agent checks
       template:
@@ -117,9 +123,25 @@
 
 - name: Install checks for openstack neutron l3 agent
   hosts: neutron_l3_agent
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: neutron_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install neutron l3 agent checks
       template:
@@ -143,9 +165,25 @@
 
 - name: Install checks for openstack neutron linux bridge agent
   hosts: neutron_linuxbridge_agent
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: neutron_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install neutron linux bridge agent checks
       template:
@@ -170,9 +208,25 @@
 
 - name: Install checks for openstack neutron OVS agent
   hosts: neutron_openvswitch_agent
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: neutron_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install neutron OVS agent checks
       template:
@@ -197,9 +251,25 @@
 
 - name: Install checks for openstack neutron metadata agent
   hosts: neutron_metadata_agent
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: neutron_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install neutron metadata agent checks
       template:
@@ -223,9 +293,25 @@
 
 - name: Install checks for openstack neutron metering agent
   hosts: neutron_metering_agent
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: neutron_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install neutron metadata agent checks
       template:

--- a/playbooks/maas-openstack-neutron.yml
+++ b/playbooks/maas-openstack-neutron.yml
@@ -16,14 +16,25 @@
 - name: Gather facts
   hosts: neutron_all
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: neutron_all
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -32,14 +43,7 @@
   hosts: neutron_all
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
-  pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
-    - include: "common-tasks/maas_get_openrc.yml"
-    - name: Set the current group
-      set_fact:
-        maas_current_group: neutron_all
-
+  become: true
   tasks:
     - name: Copy over pip constraints
       copy:
@@ -62,7 +66,7 @@
   hosts: neutron_server
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install neutron server checks
       template:
@@ -110,7 +114,7 @@
   hosts: neutron_dhcp_agent
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install neutron dhcp agent checks
       template:
@@ -134,7 +138,7 @@
   hosts: neutron_l3_agent
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install neutron l3 agent checks
       template:
@@ -158,7 +162,7 @@
   hosts: neutron_linuxbridge_agent
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install neutron linux bridge agent checks
       template:
@@ -183,7 +187,7 @@
   hosts: neutron_openvswitch_agent
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install neutron OVS agent checks
       template:
@@ -208,7 +212,7 @@
   hosts: neutron_metadata_agent
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install neutron metadata agent checks
       template:
@@ -232,7 +236,7 @@
   hosts: neutron_metering_agent
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install neutron metadata agent checks
       template:

--- a/playbooks/maas-openstack-neutron.yml
+++ b/playbooks/maas-openstack-neutron.yml
@@ -39,29 +39,6 @@
     - always
 
 
-- name: Gather facts
-  hosts: neutron_all
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-    - vars/maas-openstack.yml
-
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
-  tags:
-    - maas-openstack-neutron
-
-
 - name: Install checks for openstack neutron
   hosts: neutron_server
   gather_facts: false
@@ -106,6 +83,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-neutron
 
@@ -130,6 +109,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-neutron
 
@@ -153,6 +134,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-neutron
@@ -179,6 +162,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-neutron
 
@@ -204,6 +189,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-neutron
 
@@ -228,6 +215,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-neutron
 
@@ -251,6 +240,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-neutron

--- a/playbooks/maas-openstack-neutron.yml
+++ b/playbooks/maas-openstack-neutron.yml
@@ -30,10 +30,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install neutron server checks
       template:
@@ -96,10 +92,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install neutron dhcp agent checks
       template:
@@ -138,10 +130,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install neutron l3 agent checks
       template:
@@ -179,10 +167,6 @@
         maas_current_group: neutron_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Install neutron linux bridge agent checks
@@ -223,10 +207,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install neutron OVS agent checks
       template:
@@ -266,10 +246,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install neutron metadata agent checks
       template:
@@ -307,10 +283,6 @@
         maas_current_group: neutron_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Install neutron metadata agent checks

--- a/playbooks/maas-openstack-nova.yml
+++ b/playbooks/maas-openstack-nova.yml
@@ -47,22 +47,6 @@
         dest: "/tmp/pip-constraints.txt"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
-  post_tasks:
-    - name: Install nova pip packages to venv
-      pip:
-        name: "{{ maas_openstack_nova_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-      virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-openstack-nova.yml
+++ b/playbooks/maas-openstack-nova.yml
@@ -16,14 +16,25 @@
 - name: Gather facts
   hosts: nova_all
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: nova_all
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -32,14 +43,7 @@
   hosts: nova_all
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
-  pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
-    - include: "common-tasks/maas_get_openrc.yml"
-    - name: Set the current group
-      set_fact:
-        maas_current_group: nova_all
-
+  become: true
   tasks:
     - name: Copy over pip constraints
       copy:
@@ -62,7 +66,7 @@
   hosts: nova_api_metadata
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install nova nova-api-metadata checks
       template:
@@ -81,11 +85,12 @@
   tags:
     - maas-openstack-nova
 
+
 - name: Install checks for openstack nova-api
   hosts: nova_api_os_compute
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install nova api checks
       template:
@@ -133,14 +138,16 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   tags:
     - maas-openstack-nova
+
 
 - name: Install checks for openstack nova-api
   hosts: nova_scheduler
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install nova api checks
       template:
@@ -155,14 +162,16 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   tags:
     - maas-openstack-nova
+
 
 - name: Install checks for openstack nova-api-metadata
   hosts: nova_cert
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install nova nova-api-metadata checks
       template:
@@ -177,14 +186,16 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   tags:
     - maas-openstack-nova
+
 
 - name: Install checks for openstack nova-compute
   hosts: nova_compute
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install nova nova-compute checks
       template:
@@ -199,14 +210,16 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   tags:
     - maas-openstack-nova
+
 
 - name: Install checks for openstack nova-conductor
   hosts: nova_conductor
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install nova nova-conductor checks
       template:
@@ -221,14 +234,16 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   tags:
     - maas-openstack-nova
+
 
 - name: Install checks for openstack nova-console
   hosts: nova_console
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install nova nova-console-auth checks
       template:
@@ -252,5 +267,6 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   tags:
     - maas-openstack-nova

--- a/playbooks/maas-openstack-nova.yml
+++ b/playbooks/maas-openstack-nova.yml
@@ -13,37 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Gather facts
-  hosts: nova_all
-  gather_facts: false
+- name: Install checks for openstack nova-api-metadata
+  hosts: nova_api_metadata
+  gather_facts: true
+  user: "{{ ansible_user | default('root') }}"
   become: true
-  tasks:
+  pre_tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
 
-    - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
     - name: Set the current group
       set_fact:
         maas_current_group: nova_all
 
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-  tags:
-    - always
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
 
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
-- name: Install checks for openstack nova-api-metadata
-  hosts: nova_api_metadata
-  gather_facts: false
-  user: "{{ ansible_user | default('root') }}"
-  become: true
   tasks:
     - name: Install nova nova-api-metadata checks
       template:
@@ -67,9 +57,25 @@
 
 - name: Install checks for openstack nova-api
   hosts: nova_api_os_compute
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: nova_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install nova api checks
       template:
@@ -126,9 +132,25 @@
 
 - name: Install checks for openstack nova-api
   hosts: nova_scheduler
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: nova_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install nova api checks
       template:
@@ -152,9 +174,25 @@
 
 - name: Install checks for openstack nova-api-metadata
   hosts: nova_cert
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: nova_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install nova nova-api-metadata checks
       template:
@@ -178,9 +216,25 @@
 
 - name: Install checks for openstack nova-compute
   hosts: nova_compute
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: nova_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install nova nova-compute checks
       template:
@@ -204,9 +258,25 @@
 
 - name: Install checks for openstack nova-conductor
   hosts: nova_conductor
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: nova_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install nova nova-conductor checks
       template:
@@ -230,9 +300,25 @@
 
 - name: Install checks for openstack nova-console
   hosts: nova_console
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: nova_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install nova nova-console-auth checks
       template:

--- a/playbooks/maas-openstack-nova.yml
+++ b/playbooks/maas-openstack-nova.yml
@@ -30,10 +30,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install nova nova-api-metadata checks
       template:
@@ -71,10 +67,6 @@
         maas_current_group: nova_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Install nova api checks
@@ -147,10 +139,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install nova api checks
       template:
@@ -188,10 +176,6 @@
         maas_current_group: nova_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Install nova nova-api-metadata checks
@@ -231,10 +215,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install nova nova-compute checks
       template:
@@ -273,10 +253,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install nova nova-conductor checks
       template:
@@ -314,10 +290,6 @@
         maas_current_group: nova_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Install nova nova-console-auth checks

--- a/playbooks/maas-openstack-nova.yml
+++ b/playbooks/maas-openstack-nova.yml
@@ -39,29 +39,6 @@
     - always
 
 
-- name: Gather facts
-  hosts: nova_all
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-    - vars/maas-openstack.yml
-
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
-  tags:
-    - maas-openstack-nova
-
-
 - name: Install checks for openstack nova-api-metadata
   hosts: nova_api_metadata
   gather_facts: false
@@ -81,6 +58,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-nova
@@ -139,6 +118,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-nova
 
@@ -162,6 +143,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-nova
@@ -187,6 +170,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-nova
 
@@ -211,6 +196,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-nova
 
@@ -234,6 +221,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-nova
@@ -267,6 +256,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-nova

--- a/playbooks/maas-openstack-octavia.yml
+++ b/playbooks/maas-openstack-octavia.yml
@@ -23,7 +23,7 @@
       when:
         - deploy_osp | bool
 
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Set the current group
       set_fact:
@@ -97,6 +97,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-octavia
 
@@ -165,6 +167,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-octavia

--- a/playbooks/maas-openstack-octavia.yml
+++ b/playbooks/maas-openstack-octavia.yml
@@ -13,35 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Gather facts
-  hosts: octavia_all:Controller
-  gather_facts: false
+- name: Install checks for octavia
+  hosts: "{{ octavia_hosts_all | default('octavia_all') }}"
+  user: "{{ octavia_ansible_user | default('root') }}"
   become: true
-  tasks:
+  gather_facts: true
+  pre_tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
 
-    - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
     - name: Set the current group
       set_fact:
-        maas_current_group: "octavia_hosts_all"
+        maas_current_group: octavia_hosts_all
 
-  vars_files:
-   - vars/main.yml
-   - vars/maas.yml
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-  tags:
-   - always
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
 
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
-- name: Install checks for octavia
-  hosts: "{{ octavia_hosts_all | default('octavia_all') }}"
-  user: "{{ octavia_ansible_user | default('root') }}"
-  become: true
-  gather_facts: false
   tasks:
     - name: Install octavia process check
       template:
@@ -107,7 +99,23 @@
   hosts: "{{ octavia_hosts_api | default('octavia-api') }}"
   user: "{{ octavia_ansible_user | default('root') }}"
   become: true
-  gather_facts: false
+  gather_facts: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: octavia_hosts_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Add load-balancer member role (RPC-O)
       shell: ". {{ maas_openrc | default('/root/openrc') }} && openstack role add --project $OS_PROJECT_NAME --user $OS_USERNAME load-balancer_observer"

--- a/playbooks/maas-openstack-octavia.yml
+++ b/playbooks/maas-openstack-octavia.yml
@@ -39,28 +39,16 @@
       set_fact:
         maas_current_group: "octavia_hosts_all"
 
-  post_tasks:
-    - name: Install octavia pip packages to venv
-      pip:
-        name: "{{ maas_openstack_octavia_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
   vars_files:
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-octavia
+
 
 - name: Install checks for octavia
   hosts: "{{ octavia_hosts_all | default('octavia_all') }}"
@@ -121,8 +109,10 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   tags:
     - maas-openstack-octavia
+
 
 - name: Install checks for openstack octavia-api
   hosts: "{{ octavia_hosts_api | default('octavia-api') }}"
@@ -188,5 +178,6 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   tags:
     - maas-openstack-octavia

--- a/playbooks/maas-openstack-octavia.yml
+++ b/playbooks/maas-openstack-octavia.yml
@@ -30,10 +30,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install octavia process check
       template:
@@ -111,10 +107,6 @@
         maas_current_group: octavia_hosts_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Add load-balancer member role (RPC-O)

--- a/playbooks/maas-openstack-octavia.yml
+++ b/playbooks/maas-openstack-octavia.yml
@@ -16,44 +16,31 @@
 - name: Gather facts
   hosts: octavia_all:Controller
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
-  vars_files:
-   - vars/main.yml
-   - vars/maas.yml
-  tags:
-   - always
 
-
-- name: Gather facts
-  hosts: "{{ octavia_hosts_all | default('octavia_all') }}"
-  user: "{{ octavia_ansible_user | default('root') }}"
-  become: "{{ octavia_ansible_become | default('no') }}"
-  gather_facts: "{{ gather_facts | default(true) }}"
-  tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
+
     - name: Set the current group
       set_fact:
         maas_current_group: "octavia_hosts_all"
 
   vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-    - vars/maas-openstack.yml
-
-  environment: "{{ deployment_environment_variables | default({}) }}"
+   - vars/main.yml
+   - vars/maas.yml
 
   tags:
-    - maas-openstack-octavia
+   - always
 
 
 - name: Install checks for octavia
   hosts: "{{ octavia_hosts_all | default('octavia_all') }}"
   user: "{{ octavia_ansible_user | default('root') }}"
-  become: "{{ octavia_ansible_become | default('no') }}"
+  become: true
   gather_facts: false
   tasks:
     - name: Install octavia process check
@@ -117,7 +104,7 @@
 - name: Install checks for openstack octavia-api
   hosts: "{{ octavia_hosts_api | default('octavia-api') }}"
   user: "{{ octavia_ansible_user | default('root') }}"
-  become: "{{ octavia_ansible_become | default('no') }}"
+  become: true
   gather_facts: false
   tasks:
     - name: Add load-balancer member role (RPC-O)

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -16,6 +16,7 @@
 - name: Perform pre-flight and configuration checks
   hosts: "{{ maas_rally_target_group }}[0]"
   gather_facts: false
+  become: true
   pre_tasks:
     - name: Safety check - ensure maas_rally is enabled
       fail:
@@ -72,10 +73,13 @@
   vars_files:
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
 
 - name: Configure maas_rally virtual environments
   hosts: "{{ maas_rally_target_group }}"
   gather_facts: true
+  become: true
   pre_tasks:
     - name: Create rally constraint file
       template:
@@ -157,6 +161,7 @@
 - name: Prepare OpenStack and DB for performance monitoring
   hosts: "{{ maas_rally_target_group }}[0]"
   gather_facts: false
+  become: true
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
 
@@ -449,6 +454,7 @@
 - name: Configure performance checks
   hosts: "{{ maas_rally_target_group }}"
   gather_facts: false
+  become: true
   pre_tasks:
     - include: "common-tasks/maas_excluded_regex.yml"
 
@@ -572,15 +578,25 @@
     - vars/maas.yml
     - "vars/maas-{{ ansible_distribution | lower }}.yml"
     - vars/maas-openstack.yml
+
   environment: "{{ deployment_environment_variables | default({}) }}"
 
 
 - name: Deploy support helper script to utility containers
   hosts: utility_all
   gather_facts: false
+  become: true
   tasks:
     - name: Copy maas_rally support helper script
       copy:
         src: files/rax-maas/tools/rally_diag.sh
         dest: /root/rally_diag.sh
         mode: 0770
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+    - "vars/maas-{{ ansible_distribution | lower }}.yml"
+    - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -13,15 +13,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Perform pre-flight and configuration checks
-  hosts: "{{ maas_rally_target_group }}[0]"
+- name: Ensure rally basic requirements are met
+  hosts: "shared-infra_hosts"
   gather_facts: false
+  connection: local
+  tasks:
+    - name: Add hosts to dynamic inventory group
+      group_by:
+        key: dynamic_rally_hosts
+        parents: rally_all
+      when:
+        - (((groups['swift_all'] | default([])) | union(groups['rgws'] | default([]))) | length) > 0
+
+    - name: Set rally fact when needed
+      set_fact:
+        maas_rally_enabled: false
+      when:
+        - maas_rally_enabled | bool
+        - (((groups['swift_all'] | default([])) | union(groups['rgws'] | default([]))) | length) > 0
+  tags:
+    - always
+
+
+- name: Perform pre-flight and configuration checks
+  hosts: "dynamic_rally_hosts[0]"
+  gather_facts: true
   become: true
   pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: rally_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
     - name: Safety check - ensure maas_rally is enabled
-      fail:
+      debug:
         msg: "Rally performance tests are disabled. If you really want them please read the documentation and set maas_rally_enabled to true."
-      when: not maas_rally_enabled
+      when:
+        - not (maas_rally_enabled | bool)
+
+    - name: Exit
+      meta: end_play
+      when:
+        - not (maas_rally_enabled | bool)
 
     - name: Generate check template dictionary
       set_fact:
@@ -71,16 +114,39 @@
         - maas_rally_checks[item]['duration_threshold'] < 1 or maas_rally_checks[item]['duration_threshold'] > 100
 
   vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+    - "vars/maas-{{ ansible_distribution | lower }}.yml"
     - vars/maas-openstack.yml
 
   environment: "{{ deployment_environment_variables | default({}) }}"
 
 
 - name: Configure maas_rally virtual environments
-  hosts: "{{ maas_rally_target_group }}"
+  hosts: "dynamic_rally_hosts"
   gather_facts: true
   become: true
   pre_tasks:
+    - name: Exit
+      meta: end_play
+      when:
+        - not (maas_rally_enabled | bool)
+
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: rally_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
     - name: Create rally constraint file
       template:
         src: templates/rax-maas/rally-constraint.txt.j2
@@ -159,11 +225,29 @@
 
 
 - name: Prepare OpenStack and DB for performance monitoring
-  hosts: "{{ maas_rally_target_group }}[0]"
-  gather_facts: false
+  hosts: "dynamic_rally_hosts[0]"
+  gather_facts: true
   become: true
   pre_tasks:
+    - name: Exit
+      meta: end_play
+      when:
+        - not (maas_rally_enabled | bool)
+
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: rally_all
+
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
     - name: Create maas_rally database
       include_tasks: common-tasks/mysql-db-user.yml
@@ -451,10 +535,20 @@
 
 
 - name: Configure performance checks
-  hosts: "{{ maas_rally_target_group }}"
-  gather_facts: false
+  hosts: "dynamic_rally_hosts"
+  gather_facts: true
   become: true
   pre_tasks:
+    - name: Exit
+      meta: end_play
+      when:
+        - not (maas_rally_enabled | bool)
+
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Ensure maas plugin directory exists
@@ -583,8 +677,29 @@
 
 - name: Deploy support helper script to utility containers
   hosts: utility_all
-  gather_facts: false
+  gather_facts: true
   become: true
+  pre_tasks:
+    - name: Exit
+      meta: end_play
+      when:
+        - not (maas_rally_enabled | bool)
+
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: rally_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Copy maas_rally support helper script
       copy:

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -163,11 +163,10 @@
   gather_facts: false
   become: true
   pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Create maas_rally database
-      include: common-tasks/mysql-db-user.yml
-      static: no
+      include_tasks: common-tasks/mysql-db-user.yml
       vars:
         user_name: "{{ maas_rally_galera_user }}"
         password: "{{ maas_rally_galera_password }}"
@@ -456,7 +455,7 @@
   gather_facts: false
   become: true
   pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Ensure maas plugin directory exists
       file:

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -51,10 +51,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
     - name: Safety check - ensure maas_rally is enabled
       debug:
         msg: "Rally performance tests are disabled. If you really want them please read the documentation and set maas_rally_enabled to true."
@@ -142,10 +138,6 @@
         maas_current_group: rally_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
     - name: Create rally constraint file
       template:
@@ -244,10 +236,6 @@
         maas_current_group: rally_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
     - name: Create maas_rally database
       include_tasks: common-tasks/mysql-db-user.yml
@@ -695,10 +683,6 @@
         maas_current_group: rally_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Copy maas_rally support helper script

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -77,18 +77,17 @@
   hosts: "{{ maas_rally_target_group }}"
   gather_facts: true
   pre_tasks:
-    - name: Install maas and maas_rally pip packages to venv
-      pip:
-        name: "{{ maas_rally_pip_packages }}"
-        state: "{{ maas_rally_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_rally_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
+    - name: Create rally constraint file
+      template:
+        src: templates/rax-maas/rally-constraint.txt.j2
+        dest: /tmp/rally-constraint.txt
+
+    - include_tasks: common-tasks/maas-venv-create.yml
+      vars:
+        target_venv: "{{ maas_rally_venv }}"
+        pip_package_list: "{{ maas_pip_rally_packages }}"
+        pip_package_state: "{{ maas_pip_rally_package_state }}"
+        pip_package_constraint: "/tmp/rally-constraint.txt"
 
     - name: Create rally config directory
       file:
@@ -97,16 +96,6 @@
         owner: "root"
         group: "root"
         mode: "0750"
-
-    # Shade is required for the os_* ansible modules
-    - name: Ensure target has shade module installed
-      pip:
-        name: shade
-        state: present
-        virtualenv: /tmp/maas_rally_shade_venv
-        extra_args: >-
-          --isolated
-          {{ pip_install_options | default('') }}
 
     - name: Get keystone endpoint
       shell: |-
@@ -196,41 +185,43 @@
       with_items:
         - "{{ maas_rally_checks.keys() | list }}"
 
-    - name: Create maas_rally projects
-      os_project:
-        name: "{{ item.value.project }}"
-        state: present
-        cloud: default
-        endpoint_type: "admin"
-        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
-        domain_id: "Default"
-      with_dict: "{{ maas_rally_checks }}"
-      when:
-        - item.value.enabled
+    - name: Create MaaS virtualenv
       vars:
-        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
-      register: rally_projects
+        ansible_python_interpreter: "{{ maas_rally_venv }}/bin/python"
+      block:
+        - name: Create maas_rally projects
+          os_project:
+            name: "{{ item.value.project }}"
+            state: present
+            cloud: default
+            endpoint_type: "admin"
+            validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+            domain_id: "Default"
+          with_dict: "{{ maas_rally_checks }}"
+          when:
+            - item.value.enabled
+          register: rally_projects
 
-  #   NOTE(cfarquhar): The os_quota module is new in ansible 2.3. Use it instead
-  #                    of the shell module below when we reach ansible >= 2.3.
-  #  - name: Ensure quotas for rally projects
-  #    os_quota:
-  #      state: present
-  #      cloud: default
-  #      validate_certs: "{{ not keystone_service_adminuri_insecure }}"
-  #      name: "{{ item.value.project | default('rally_' + item.key) }}"
-  #      instances: "{{ item.value.quotas.instances }}"
-  #      cores: "{{ item.value.quotas.cores }}"
-  #      ram: "{{ item.value.quotas.ram }}"
-  #      fixed_ips: "{{ item.value.quotas.fixed-ips }}"
-  #      floatingip: "{{ item.value.quotas.floating-ips }}"
-  #      port: "{{ item.value.quotas.ports }}"
-  #      snapshots: "{{ item.value.quotas.snapshots }}"
-  #      volumes: "{{ item.value.quotas.volumes }}"
-  #      per_volume_gigabytes: "{{ item.value.quotas.gigabytes }}"
-  #    with_dict: "{{ maas_rally_checks }}"
-  #    when:
-  #     - item.value.quotas is defined
+      #   NOTE(cfarquhar): The os_quota module is new in ansible 2.3. Use it instead
+      #                    of the shell module below when we reach ansible >= 2.3.
+      #  - name: Ensure quotas for rally projects
+      #    os_quota:
+      #      state: present
+      #      cloud: default
+      #      validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+      #      name: "{{ item.value.project | default('rally_' + item.key) }}"
+      #      instances: "{{ item.value.quotas.instances }}"
+      #      cores: "{{ item.value.quotas.cores }}"
+      #      ram: "{{ item.value.quotas.ram }}"
+      #      fixed_ips: "{{ item.value.quotas.fixed-ips }}"
+      #      floatingip: "{{ item.value.quotas.floating-ips }}"
+      #      port: "{{ item.value.quotas.ports }}"
+      #      snapshots: "{{ item.value.quotas.snapshots }}"
+      #      volumes: "{{ item.value.quotas.volumes }}"
+      #      per_volume_gigabytes: "{{ item.value.quotas.gigabytes }}"
+      #    with_dict: "{{ maas_rally_checks }}"
+      #    when:
+      #     - item.value.quotas is defined
 
     - name: Set quotas for maas_rally projects
       shell: |-
@@ -250,100 +241,96 @@
       when:
         - item.value.enabled
 
-    - name: Grant admin role to admin user for maas_rally projects
-      os_user_role:
-        user: "{{ openrc_os_username }}"
-        project: "{{ item.value.project }}"
-        role: "admin"
-        state: present
-        cloud: default
-        endpoint_type: "admin"
-        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
-      with_dict: "{{ maas_rally_checks }}"
+    - name: Create MaaS virtualenv
       vars:
-        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
-      when:
-        - item.value.enabled
+        ansible_python_interpreter: "{{ maas_rally_venv }}/bin/python"
+      block:
+        - name: Grant admin role to admin user for maas_rally projects
+          os_user_role:
+            user: "{{ openrc_os_username }}"
+            project: "{{ item.value.project }}"
+            role: "admin"
+            state: present
+            cloud: default
+            endpoint_type: "admin"
+            validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+          with_dict: "{{ maas_rally_checks }}"
+          when:
+            - item.value.enabled
 
-    - name: Create maas_rally users in keystone
-      os_user:
-        name: "{{ item.value.user_name }}"
-        password: "{{ item.value.user_password }}"
-        default_project: "{{ item.value.project }}"
-        state: present
-        cloud: default
-        endpoint_type: "admin"
-        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
-        domain: "Default"
-      with_dict: "{{ maas_rally_checks }}"
-      vars:
-        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
-      when:
-        - item.value.enabled
+        - name: Create maas_rally users in keystone
+          os_user:
+            name: "{{ item.value.user_name }}"
+            password: "{{ item.value.user_password }}"
+            default_project: "{{ item.value.project }}"
+            state: present
+            cloud: default
+            endpoint_type: "admin"
+            validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+            domain: "Default"
+          with_dict: "{{ maas_rally_checks }}"
+          when:
+            - item.value.enabled
 
-    - name: Grant _member_ role for rally users
-      os_user_role:
-        user: "{{ item.value.user_name }}"
-        project: "{{ item.value.project }}"
-        role: "_member_"
-        state: present
-        cloud: default
-        endpoint_type: "admin"
-        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
-      with_dict: "{{ maas_rally_checks }}"
-      vars:
-        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
-      when:
-        - item.value.enabled
+        - name: Grant _member_ role for rally users
+          os_user_role:
+            user: "{{ item.value.user_name }}"
+            project: "{{ item.value.project }}"
+            role: "_member_"
+            state: present
+            cloud: default
+            endpoint_type: "admin"
+            validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+          with_dict: "{{ maas_rally_checks }}"
+          when:
+            - item.value.enabled
 
-    - name: Grant extra roles for rally users
-      os_user_role:
-        user: "{{ item.0.user_name }}"
-        project: "{{ item.0.project }}"
-        role: "{{ item.1 }}"
-        state: present
-        cloud: default
-        endpoint_type: "admin"
-        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
-      with_subelements:
-        - "{{ maas_rally_checks }}"
-        - extra_user_roles
-        - skip_missing: yes
-      vars:
-        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
-      when:
-        - item.0.enabled
+        - name: Grant extra roles for rally users
+          os_user_role:
+            user: "{{ item.0.user_name }}"
+            project: "{{ item.0.project }}"
+            role: "{{ item.1 }}"
+            state: present
+            cloud: default
+            endpoint_type: "admin"
+            validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+          with_subelements:
+            - "{{ maas_rally_checks }}"
+            - extra_user_roles
+            - skip_missing: yes
+          when:
+            - item.0.enabled
 
     - name: Download cirros image for rally_cirros
       get_url:
         url: http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img
         dest: /tmp/cirros-0.3.5-x86_64-disk.img"
 
-    - name: Create rally_cirros image in glance
-      os_image:
-        cloud: default
-        state: present
-        name: rally_cirros
-        filename: /tmp/cirros-0.3.5-x86_64-disk.img"
-        is_public: yes
-        endpoint_type: "admin"
-        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+    - name: Create MaaS virtualenv
       vars:
-        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
+        ansible_python_interpreter: "{{ maas_rally_venv }}/bin/python"
+      block:
+        - name: Create rally_cirros image in glance
+          os_image:
+            cloud: default
+            state: present
+            name: rally_cirros
+            filename: /tmp/cirros-0.3.5-x86_64-disk.img"
+            is_public: yes
+            endpoint_type: "admin"
+            validate_certs: "{{ not keystone_service_adminuri_insecure }}"
 
-    - name: Create rally nova flavor
-      os_nova_flavor:
-        cloud: default
-        state: present
-        name: rally
-        ram: 256
-        disk: 1
-        vcpus: 1
-        is_public: true
-        endpoint_type: "admin"
-        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
-      vars:
-        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
+        - name: Create rally nova flavor
+          os_nova_flavor:
+            cloud: default
+            state: present
+            name: rally
+            ram: 256
+            disk: 1
+            vcpus: 1
+            is_public: true
+            endpoint_type: "admin"
+            validate_certs: "{{ not keystone_service_adminuri_insecure }}"
 
     # NOTE(cfarquhar): Unfortunately rally's validation step doesn't account for
     #         predefined contexts (i.e. project and user) and non-public
@@ -367,40 +354,40 @@
     #    when:
     #     - item.value.enabled
 
-    - name: Create rally networks
-      os_network:
-        cloud: default
-        state: present
-        name: "{{ item.value.net_name | default('rally_net_' + item.key) }}"
-        shared: no
-        project: "{{ item.value.project }}"
-        endpoint_type: "admin"
-        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
-        wait: yes
-      with_dict: "{{ maas_rally_checks }}"
+    - name: Create MaaS virtualenv
       vars:
-        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
-      when:
-        - item.value.enabled
-        - "{{ 'compute' in item.value.primary_resources }}"
+        ansible_python_interpreter: "{{ maas_rally_venv }}/bin/python"
+      block:
+        - name: Create rally networks
+          os_network:
+            cloud: default
+            state: present
+            name: "{{ item.value.net_name | default('rally_net_' + item.key) }}"
+            shared: no
+            project: "{{ item.value.project }}"
+            endpoint_type: "admin"
+            validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+            wait: yes
+          with_dict: "{{ maas_rally_checks }}"
+          when:
+            - item.value.enabled
+            - "{{ 'compute' in item.value.primary_resources }}"
 
-    - name: Create rally subnets
-      os_subnet:
-        cloud: default
-        state: present
-        name: "{{ item.value.subnet_name | default('rally_subnet_' + item.key) }}"
-        network_name: "{{ item.value.net_name | default('rally_net_' + item.key) }}"
-        cidr: "{{ item.value.subnet_cidr | default('192.168.0.0/24') }}"
-        project: "{{ item.value.project }}"
-        endpoint_type: "admin"
-        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
-        wait: yes
-      with_dict: "{{ maas_rally_checks }}"
-      vars:
-        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
-      when:
-        - item.value.enabled
-        - "{{ 'compute' in item.value.primary_resources }}"
+        - name: Create rally subnets
+          os_subnet:
+            cloud: default
+            state: present
+            name: "{{ item.value.subnet_name | default('rally_subnet_' + item.key) }}"
+            network_name: "{{ item.value.net_name | default('rally_net_' + item.key) }}"
+            cidr: "{{ item.value.subnet_cidr | default('192.168.0.0/24') }}"
+            project: "{{ item.value.project }}"
+            endpoint_type: "admin"
+            validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+            wait: yes
+          with_dict: "{{ maas_rally_checks }}"
+          when:
+            - item.value.enabled
+            - "{{ 'compute' in item.value.primary_resources }}"
 
     - name: Check for existing maas_rally database initialization
       command: "{{ maas_rally_venv_bin }}/rally-manage db revision"
@@ -517,14 +504,16 @@
       set_fact:
         maas_rally_checks: "{{ check_template|combine(maas_rally_checks, recursive=True) }}"
 
-    - name: Retrieve network UUIDs
-      os_networks_facts:
-        cloud: default
-        wait: yes
-        endpoint_type: "admin"
-        validate_certs: "{{ not keystone_service_adminuri_insecure }}"
+    - name: Create MaaS virtualenv
       vars:
-        - ansible_python_interpreter: /tmp/maas_rally_shade_venv/bin/python
+        ansible_python_interpreter: "{{ maas_rally_venv }}/bin/python"
+      block:
+        - name: Retrieve network UUIDs
+          os_networks_facts:
+            cloud: default
+            wait: yes
+            endpoint_type: "admin"
+            validate_certs: "{{ not keystone_service_adminuri_insecure }}"
 
     - name: Store network UUIDs in dictionary
       set_fact:

--- a/playbooks/maas-openstack-swift.yml
+++ b/playbooks/maas-openstack-swift.yml
@@ -59,26 +59,11 @@
     # when:
     #  - "'hosts' in groups"
 
-  post_tasks:
-    - name: Install swift pip packages to venv
-      pip:
-        name: "{{ maas_openstack_swift_pip_packages }}"
-        state: "{{ maas_pip_package_state }}"
-        extra_args: >-
-          --isolated
-          --constraint /tmp/pip-constraints.txt
-          {{ pip_install_options | default('') }}
-        virtualenv: "{{ maas_venv }}"
-      register: install_pip_packages
-      until: install_pip_packages is success
-      retries: 5
-      delay: 2
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
   environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:

--- a/playbooks/maas-openstack-swift.yml
+++ b/playbooks/maas-openstack-swift.yml
@@ -16,14 +16,25 @@
 - name: Gather facts
   hosts: swift_all
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: swift_all
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -32,16 +43,7 @@
   hosts: swift_all
   gather_facts: "{{ gather_facts | default(true) }}"
   user: "{{ ansible_user | default('root') }}"
-  become: yes
-  pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
-
-    - include: "common-tasks/maas_get_openrc.yml"
-
-    - name: Set the current group
-      set_fact:
-        maas_current_group: swift_all
-
+  become: true
   tasks:
     - name: Copy over pip constraints
       copy:
@@ -73,6 +75,7 @@
 - name: Gather swift host groups extra facts
   hosts: swift_all
   gather_facts: false
+  become: true
   tasks:
     - name: Set Storage address fact for host
       set_fact:
@@ -131,7 +134,7 @@
   hosts: swift_acc
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install swift account server checks
       template:
@@ -164,7 +167,7 @@
   hosts: swift_cont
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install swift container process checks
       template:
@@ -195,7 +198,7 @@
   hosts: swift_obj
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Install swift object server checks
       template:
@@ -228,7 +231,7 @@
   hosts: swift_proxy
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Get openstack release
       command: "grep DISTRIB_RELEASE /etc/openstack-release"
@@ -323,7 +326,7 @@
   hosts: swift_proxy
   gather_facts: false
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Create keystone user for swift filecheck
       shell: |

--- a/playbooks/maas-openstack-swift.yml
+++ b/playbooks/maas-openstack-swift.yml
@@ -29,10 +29,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Set Storage address fact for host
       set_fact:
@@ -106,10 +102,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install swift account server checks
       template:
@@ -157,10 +149,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
-
   tasks:
     - name: Install swift container process checks
       template:
@@ -206,10 +194,6 @@
         maas_current_group: swift_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Install swift object server checks
@@ -257,10 +241,6 @@
         maas_current_group: swift_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Get openstack release
@@ -370,10 +350,6 @@
         maas_current_group: swift_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
-    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
   tasks:
     - name: Create keystone user for swift filecheck

--- a/playbooks/maas-openstack-swift.yml
+++ b/playbooks/maas-openstack-swift.yml
@@ -39,39 +39,6 @@
     - always
 
 
-- name: Gather facts
-  hosts: swift_all
-  gather_facts: "{{ gather_facts | default(true) }}"
-  user: "{{ ansible_user | default('root') }}"
-  become: true
-  tasks:
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-
-    # - name: Retrieve openrc file
-    # fetch:
-    #  src: /root/openrc
-    #  dest: /root/openrc
-    #  flat: true
-    # delegate_to: "{{ item }}"
-    # with_items: "{{ groups['hosts'] }}"
-    # when:
-    #  - "'hosts' in groups"
-
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-    - vars/maas-openstack.yml
-
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
-  tags:
-    - maas-openstack-swift
-
-
 - name: Gather swift host groups extra facts
   hosts: swift_all
   gather_facts: false
@@ -127,6 +94,8 @@
     - vars/maas.yml
     - vars/maas-openstack.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-swift
 
@@ -158,6 +127,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-swift
@@ -191,6 +162,9 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-openstack-swift
 
@@ -222,6 +196,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-swift
@@ -317,6 +293,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-swift
@@ -492,6 +470,8 @@
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
 
   tags:
     - maas-openstack-swift

--- a/playbooks/maas-openstack-swift.yml
+++ b/playbooks/maas-openstack-swift.yml
@@ -13,36 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Gather facts
+- name: Gather swift host groups extra facts
   hosts: swift_all
-  gather_facts: false
+  gather_facts: true
   become: true
-  tasks:
+  pre_tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
 
-    - include_tasks: "common-tasks/maas_excluded_regex.yml"
-
-    - include_tasks: "common-tasks/maas_get_openrc.yml"
-
     - name: Set the current group
       set_fact:
         maas_current_group: swift_all
 
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-  tags:
-    - always
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
 
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
 
-- name: Gather swift host groups extra facts
-  hosts: swift_all
-  gather_facts: false
-  become: true
   tasks:
     - name: Set Storage address fact for host
       set_fact:
@@ -101,9 +91,25 @@
 
 - name: Install checks for openstack swift account
   hosts: swift_acc
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: swift_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install swift account server checks
       template:
@@ -136,9 +142,25 @@
 
 - name: Install checks for openstack swift container
   hosts: swift_cont
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: swift_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install swift container process checks
       template:
@@ -170,9 +192,25 @@
 
 - name: Install checks for openstack swift object group
   hosts: swift_obj
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: swift_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Install swift object server checks
       template:
@@ -205,9 +243,25 @@
 
 - name: Install swift-recon checks for openstack swift proxy
   hosts: swift_proxy
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: swift_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Get openstack release
       command: "grep DISTRIB_RELEASE /etc/openstack-release"
@@ -302,9 +356,25 @@
 
 - name: Install accesscheck for openstack swift proxy
   hosts: swift_proxy
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: swift_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
   tasks:
     - name: Create keystone user for swift filecheck
       shell: |

--- a/playbooks/maas-poller-all.yml
+++ b/playbooks/maas-poller-all.yml
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: maas-poller-install.yml
+- import_playbook: maas-poller-install.yml
   tags:
     - maas-poller
 
-- include: maas-poller-setup.yml
+- import_playbook: maas-poller-setup.yml
   tags:
     - maas-poller

--- a/playbooks/maas-poller-install.yml
+++ b/playbooks/maas-poller-install.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: shared-infra_hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -37,9 +37,14 @@
 
 - name: Install MaaS Poller
   hosts: shared-infra_hosts
-  gather_facts: false
+  gather_facts: true
   become: true
   pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
     - name: Gather variables for each operating system
       include_vars: "{{ item }}"
       with_first_found:

--- a/playbooks/maas-poller-install.yml
+++ b/playbooks/maas-poller-install.yml
@@ -16,6 +16,7 @@
 - name: Gather facts
   hosts: shared-infra_hosts
   gather_facts: "{{ gather_facts | default(true) }}"
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
@@ -25,15 +26,19 @@
     - name: Set the current group
       set_fact:
         maas_current_group: shared-infra_hosts
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
+
 
 - name: Install MaaS Poller
   hosts: shared-infra_hosts
   gather_facts: false
+  become: true
   pre_tasks:
     - name: Gather variables for each operating system
       include_vars: "{{ item }}"

--- a/playbooks/maas-poller-install.yml
+++ b/playbooks/maas-poller-install.yml
@@ -54,7 +54,7 @@
 
   tasks:
     - name: Include Ubuntu distro install tasks
-      include: "common-tasks/maas-poller-{{ ansible_distribution | lower }}-install.yml"
+      include_tasks: "common-tasks/maas-poller-{{ ansible_distribution | lower }}-install.yml"
       when:
         - maas_private_monitoring_enabled | bool
         - maas_private_monitoring_zone is defined
@@ -65,5 +65,6 @@
     - "vars/maas-{{ ansible_distribution | lower }}.yml"
 
   environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-poller-install

--- a/playbooks/maas-poller-setup.yml
+++ b/playbooks/maas-poller-setup.yml
@@ -16,15 +16,31 @@
 - name: Gather facts
   hosts: shared-infra_hosts
   gather_facts: "{{ gather_facts | default(true) }}"
-  pre_tasks:
-    - include: "common-tasks/maas_excluded_regex.yml"
+  become: true
+  tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: shared-infra_hosts
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+
   tags:
-    - maas-poller-setup
+    - always
+
 
 - name: Setup MaaS Poller
   hosts: shared-infra_hosts
   gather_facts: false
-  become: yes
+  become: true
   tasks:
     - name: Generate MaaS poller config
       when:

--- a/playbooks/maas-poller-setup.yml
+++ b/playbooks/maas-poller-setup.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: shared-infra_hosts
-  gather_facts: "{{ gather_facts | default(true) }}"
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -39,41 +39,47 @@
 
 - name: Setup MaaS Poller
   hosts: shared-infra_hosts
-  gather_facts: false
+  gather_facts: true
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Generate MaaS poller config
-      when:
-        - maas_private_monitoring_enabled | bool
-        - maas_private_monitoring_zone is defined
       template:
         src: "templates/rax-maas/rackspace-monitoring-poller.cfg"
         dest: /etc/rackspace-monitoring-poller.cfg
         mode: 0600
         owner: root
         group: root
-
-    - name: Enable MaaS poller via config
       when:
         - maas_private_monitoring_enabled | bool
         - maas_private_monitoring_zone is defined
+
+    - name: Enable MaaS poller via config
       copy:
         src: files/rackspace-monitoring-poller-enabled
         dest: /etc/default/rackspace-monitoring-poller
         mode: 0600
         owner: root
         group: root
-
-    - name: Install check for poller's file descriptor usage
       when:
         - maas_private_monitoring_enabled | bool
         - maas_private_monitoring_zone is defined
+
+    - name: Install check for poller's file descriptor usage
       template:
         src: "templates/rax-maas/maas_poller_fd_count.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/maas_poller_fd_count--{{ inventory_hostname }}.yaml"
         mode: 0644
         owner: root
         group: root
+      when:
+        - maas_private_monitoring_enabled | bool
+        - maas_private_monitoring_zone is defined
 
     - name: Start maas poller
       include_tasks: common-tasks/maas_poller_start.yml

--- a/playbooks/maas-poller-setup.yml
+++ b/playbooks/maas-poller-setup.yml
@@ -81,5 +81,8 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-poller-setup

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -18,6 +18,12 @@
   connection: local
   gather_facts: true
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Check password is defined
       fail:
@@ -28,7 +34,7 @@
         - maas_pre_flight_check_enabled | default(false) | bool
         - groups['osds'] | default([]) | length > 0
         - groups['mons'] | default([]) | length > 0
-        - ansible_version.full | version_compare('2.1.0.0', '>=')
+        - ansible_version.full is version_compare('2.1.0.0', '>=')
         - hostvars[inventory_hostname][item.key] is undefined
       with_dict: "{{ maas_pw_check }}"
 
@@ -46,8 +52,14 @@
 - name: Check metadata variables are defined
   hosts: localhost
   connection: local
-  gather_facts: false
+  gather_facts: true
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Get rendered test metadata template string
       set_fact:
@@ -80,6 +92,12 @@
   gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Get rendered test metadata template string
       set_fact:
@@ -106,11 +124,11 @@
         os_image_api_version: '2'
         os_volume_api_version: '3'
       when:
-        - ansible_version.full | version_compare('2.0.0', '>=')
+        - ansible_version.full is version_compare('2.0.0', '>=')
         - (
             (maas_osa_version is defined) and
             (maas_osa_version is match('[0-9]+.[0-9]+.[0-9]+')) and
-            (maas_osa_version | version_compare('17.0.0', '>='))
+            (maas_osa_version is version_compare('17.0.0', '>='))
           ) or
           (deploy_osp | bool)
 

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -16,7 +16,8 @@
 - name: Check all passwords are defined
   hosts: localhost
   connection: local
-  gather_facts: "true"
+  gather_facts: true
+  become: true
   tasks:
     - name: Check password is defined
       fail:
@@ -30,11 +31,14 @@
         - ansible_version.full | version_compare('2.1.0.0', '>=')
         - hostvars[inventory_hostname][item.key] is undefined
       with_dict: "{{ maas_pw_check }}"
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   vars:
     maas_pw_check: "{{ lookup('file', playbook_dir + '/../tests/user_rpcm_secrets.yml') | from_yaml }}"
+
   tags:
     - maas-pre-flight
 
@@ -43,6 +47,7 @@
   hosts: localhost
   connection: local
   gather_facts: false
+  become: true
   tasks:
     - name: Get rendered test metadata template string
       set_fact:
@@ -57,9 +62,11 @@
       when:
         - maas_pre_flight_metadata_check_enabled | default(true) | bool
         - rendered_maas_metadata_test_tmpl is search('unknown')
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - maas-pre-flight
 
@@ -72,7 +79,7 @@
   hosts: utility_all
   gather_facts: true
   user: "{{ ansible_user | default('root') }}"
-  become: yes
+  become: true
   tasks:
     - name: Get rendered test metadata template string
       set_fact:

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -145,3 +145,26 @@
     - vars/maas.yml
 
   environment: "{{ deployment_environment_variables | default({}) }}"
+
+
+- name: Distribute openstack rc files
+  hosts: all
+  gather_facts: true
+  user: "{{ ansible_user | default('root') }}"
+  become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+  tasks:
+    - include_tasks: "common-tasks/maas_get_openrc.yml"
+
+    - include_tasks: "common-tasks/maas_get_maasrc.yml"
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -125,3 +125,5 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"

--- a/playbooks/maas-raxmon-assign-agent-to-entity.yml
+++ b/playbooks/maas-raxmon-assign-agent-to-entity.yml
@@ -33,3 +33,5 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"

--- a/playbooks/maas-raxmon-assign-agent-to-entity.yml
+++ b/playbooks/maas-raxmon-assign-agent-to-entity.yml
@@ -17,6 +17,7 @@
   hosts: localhost
   connection: local
   user: "{{ ansible_user | default('root') }}"
+  become: true
   tasks:
     - name: Run RAXMON
       vars:

--- a/playbooks/maas-raxmon-assign-agent-to-entity.yml
+++ b/playbooks/maas-raxmon-assign-agent-to-entity.yml
@@ -18,6 +18,12 @@
   connection: local
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Run RAXMON
       vars:

--- a/playbooks/maas-raxmon-delete-resources.yml
+++ b/playbooks/maas-raxmon-delete-resources.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: hosts
-  gather_facts: false
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -33,9 +33,15 @@
 
 - name: Clean up MaaS resources for gating tests
   hosts: hosts
-  gather_facts: false
+  gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Run RAXMON
       vars:

--- a/playbooks/maas-raxmon-delete-resources.yml
+++ b/playbooks/maas-raxmon-delete-resources.yml
@@ -66,3 +66,5 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"

--- a/playbooks/maas-raxmon-delete-resources.yml
+++ b/playbooks/maas-raxmon-delete-resources.yml
@@ -13,13 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Gather facts
+  hosts: hosts
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+
+  tags:
+    - always
+
+
 - name: Clean up MaaS resources for gating tests
   hosts: hosts
+  gather_facts: false
   user: "{{ ansible_user | default('root') }}"
+  become: true
   tasks:
-    - name: Include maas venv create
-      include_tasks: common-tasks/maas-venv-create.yml
-
     - name: Run RAXMON
       vars:
         ansible_python_interpreter: "{{ maas_venv }}/bin/python"

--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -17,6 +17,7 @@
   hosts: hosts
   gather_facts: true
   serial: "{{ maas_restart_serial | default(1) }}"
+  become: true
   tasks:
     - name: Restart rackspace-monitoring-poller (systemd)
       service:

--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -60,5 +60,7 @@
     - vars/main.yml
     - vars/maas.yml
 
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
   tags:
     - maas-restart

--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -18,6 +18,12 @@
   gather_facts: true
   serial: "{{ maas_restart_serial | default(1) }}"
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Restart rackspace-monitoring-poller (systemd)
       service:

--- a/playbooks/maas-verify.yml
+++ b/playbooks/maas-verify.yml
@@ -76,11 +76,6 @@
         - rpc-maas-tool.py
         - alarmparser.py
 
-    - name: Copy over pip constraints
-      copy:
-        src: "files/pip-constraints.txt"
-        dest: "/tmp/pip-constraints.txt"
-
     - name: Include maas venv create
       include_tasks: common-tasks/maas-venv-create.yml
 

--- a/playbooks/maas-verify.yml
+++ b/playbooks/maas-verify.yml
@@ -16,14 +16,17 @@
 - name: Gather facts
   hosts: swift_all
   gather_facts: false
+  become: true
   tasks:
     - name: Include OSP vars
       include_vars: vars/maas-osp.yml
       when:
         - deploy_osp | bool
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+
   tags:
     - always
 
@@ -32,6 +35,7 @@
   hosts: hosts
   user: root
   gather_facts: false
+  become: true
   tasks:
     - name: Ensure log directories
       file:

--- a/playbooks/maas-verify.yml
+++ b/playbooks/maas-verify.yml
@@ -15,7 +15,7 @@
 
 - name: Gather facts
   hosts: swift_all
-  gather_facts: false
+  gather_facts: true
   become: true
   tasks:
     - name: Include OSP vars
@@ -33,9 +33,15 @@
 
 - name: Verify MaaS
   hosts: hosts
-  user: root
-  gather_facts: false
+  user: "{{ ansible_user | default('root') }}"
+  gather_facts: true
   become: true
+  pre_tasks:
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - deploy_osp | bool
+
   tasks:
     - name: Ensure log directories
       file:

--- a/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
@@ -2,7 +2,7 @@
 {% set label = "ceph_osd_stats" %}
 {% set check_name = label+'--'+inventory_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
-{% if (physical_host is defined and physical_host != ansible_host) or (deploy_osp) %}
+{% if (physical_host is defined and physical_host != ansible_host) or (deploy_osp | bool) %}
 {% if (deploy_osp | bool) %}
 {% set _ = ceph_args.extend(["--deploy_osp"]) %}
 {% endif %}

--- a/playbooks/templates/rax-maas/rally-constraint.txt.j2
+++ b/playbooks/templates/rax-maas/rally-constraint.txt.j2
@@ -1,0 +1,3 @@
+git+https://github.com/openstack/monitorstack@master#egg=monitorstack
+git+{{ maas_rally_git_repo }}@{{ maas_rally_git_version }}#egg=rally
+keystoneauth1>=3.0.0

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -171,21 +171,15 @@ designate_process_names:
 maas_rally_enabled: false
 
 #
-#  The ansible host group where the maas_rally performance monitoring plugin
-#  will be installed.
-#
-maas_rally_target_group: shared-infra_hosts
-
-#
 #  The node from which checks will run.  The maas_rally plugin will be installed
-#  on all hosts in `maas_rally_target_group`, but performance checks (each of
+#  on all hosts in "shared-infra_hosts" machines, but performance checks (each of
 #  which consumes resources) should only execute from a single node to avoid
 #  uncoordinated resource consumption.  The best practice is to override this
 #  with a single hostname (e.g. infra01) in user vars.  Then, if the primary
 #  node fails maas_rally_primary_node can be updated to resume monitoring from
 #  another node.
 #
-maas_rally_primary_node: "{{ groups[maas_rally_target_group][0] }}"
+maas_rally_primary_node: "{{ groups['shared-infra_hosts'][0] }}"
 
 #
 #  The maas_rally_check_overrides dictionary is the primary configuration

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -31,49 +31,6 @@ maas_horizon_scheme: https
 # maas_designate_scheme: https
 
 #
-# pip installable packages for given services used within maas
-#
-maas_openstack_cinder_pip_packages:
-  - python-cinderclient
-  - python-keystoneclient
-
-maas_openstack_designate_pip_packages:
-  - python-designateclient
-  - python-keystoneclient
-  - dnspython
-
-maas_openstack_glance_pip_packages:
-  - python-glanceclient
-  - python-keystoneclient
-
-maas_openstack_heat_pip_packages:
-  - python-heatclient
-  - python-keystoneclient
-
-maas_openstack_ironic_pip_packages:
-  - python-ironicclient
-  - python-keystoneclient
-
-maas_openstack_keystone_pip_packages:
-  - python-openstackclient
-
-maas_openstack_magnum_pip_packages:
-  - python-keystoneclient
-  - python-magnumclient
-
-maas_openstack_neutron_pip_packages:
-  - python-keystoneclient
-  - python-neutronclient
-
-maas_openstack_nova_pip_packages:
-  - python-keystoneclient
-  - python-novaclient
-
-maas_openstack_swift_pip_packages:
-  - python-openstackclient
-  - python-swiftclient
-
-#
 # The Cinder backup monitor can be turned on or off based on provided config.
 #  By default this will be enabeled should hosts be setup and configured for
 #  the service. Set this to "false" to disable it regardless of the detected
@@ -176,9 +133,6 @@ maas_nova_console_ports:
   spice: 6082
 
 maas_nova_console_port: "{{ maas_nova_console_ports[maas_nova_console_type] }}"
-
-maas_openstack_octavia_pip_packages:
-  - python-keystoneclient
 
 octavia_process_names:
   - uwsgi
@@ -425,18 +379,7 @@ maas_rally_git_version: "stable/0.9"
 #
 # Set the pip package state, defaults to present
 #
-maas_rally_pip_package_state: present
-
-#
-# pip packages required for plugin functionality
-#
-maas_rally_pip_packages:
-  - influxdb
-  - "keystoneauth1>=3.0.0"
-  - "git+https://github.com/openstack/monitorstack@master#egg=monitorstack"
-  - numpy
-  - pymysql
-  - "git+{{ maas_rally_git_repo }}@{{ maas_rally_git_version }}#egg=rally"
+maas_pip_rally_package_state: present
 
 #
 #  Default values for performance checks.  They are intentionally conservative

--- a/playbooks/vars/maas-osp.yml
+++ b/playbooks/vars/maas-osp.yml
@@ -79,6 +79,7 @@ designate_ansible_become: True
 designate_ansible_user: 'heat-admin'
 designate_hosts_all: 'Controller'
 
+ansible_user: heat-admin
 ansible_ssh_private_key_file: /home/stack/.ssh/id_rsa
 ansible_become: yes
 

--- a/playbooks/vars/maas-osp.yml
+++ b/playbooks/vars/maas-osp.yml
@@ -28,9 +28,6 @@ maas_openrc: '/root/openrc-maas'
 
 osp_internal_netmask: "{{ internal_vip_address | ipsubnet(24) }}"
 
-maas_openstack_octavia_pip_packages:
-  - python-keystoneclient
-
 octavia_hosts_all: 'Controller'
 octavia_hosts_api: 'Controller'
 octavia_process_names:
@@ -81,11 +78,6 @@ mk8s_ansible_become: yes
 designate_ansible_become: True
 designate_ansible_user: 'heat-admin'
 designate_hosts_all: 'Controller'
-
-maas_openstack_designate_pip_packages:
-  - python-designateclient
-  - python-keystoneclient
-  - dnspython
 
 ansible_ssh_private_key_file: /home/stack/.ssh/id_rsa
 ansible_become: yes

--- a/playbooks/vars/maas-ubuntu.yml
+++ b/playbooks/vars/maas-ubuntu.yml
@@ -61,12 +61,6 @@ maas_poller_distro_packages:
   - rackspace-monitoring-poller
 
 #
-# pip installable packages for given services used within maas
-#
-maas_container_pip_packages:
-  - lxc-python2
-
-#
 # Distro packages needed to be installed for rabbitmq monitoring
 #
 maas_rabbitmq_distro_packages:

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -334,16 +334,11 @@ maas_rabbitmq_messages_without_consumers_threshold: 20000
 #
 maas_percent_used_critical_threshold: 85
 
-#
-# Packages used for the maas memcached check
-#
-maas_memcached_pip_packages:
-  - python-memcached
 
 #
 # pip installable packages for verifying maas deployment
 #
-maas_verify_pip_packages:
+maas_pip_verify_packages:
   - futures
   - pyyaml
   - waxeye
@@ -355,17 +350,20 @@ maas_verify_pip_packages:
 maas_pip_packages:
   - apache-libcloud
   - cryptography
+  - dnspython
   - ipaddr
   - lxml
   - monitorstack
+  - netifaces
   - psutil
+  - python-memcached
   - rackspace-monitoring-cli
   - requests
 
 #
 # pip installable packages for given services used within maas
 #
-maas_container_pip_packages:
+maas_pip_container_packages:
   - lxc-python2
 
 #
@@ -479,9 +477,6 @@ maas_network_checks_list:
     tx_pct_warn: 60
     tx_pct_crit: 80
 
-maas_network_check_pip_packages:
-  - "netifaces"
-
 #
 # maas_k8s_ui_scheme: https
 #
@@ -498,7 +493,28 @@ maas_managed_k8s_etg_process_name: etg
 maas_managed_k8s_auth_process_name: auth
 
 #
-# Set pip packages that will be installed in the maas venv
+# pip installable packages for given services used within maas
 #
-maas_pip_container_packages:
-  - lxc-python2
+maas_pip_openstack_packages:
+  - python-cinderclient
+  - python-designateclient
+  - python-glanceclient
+  - python-heatclient
+  - python-ironicclient
+  - python-keystoneclient
+  - python-magnumclient
+  - python-neutronclient
+  - python-novaclient
+  - python-openstackclient
+  - python-swiftclient
+  - openstacksdk
+
+#
+# pip packages required for plugin functionality
+#
+maas_pip_rally_packages:
+  - influxdb
+  - keystoneauth1
+  - numpy
+  - pymysql
+  - openstacksdk

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -514,6 +514,8 @@ maas_pip_openstack_packages:
 maas_pip_rally_packages:
   - influxdb
   - keystoneauth1
+  - monitorstack
   - numpy
-  - pymysql
   - openstacksdk
+  - pymysql
+  - rally

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -379,7 +379,6 @@ maas_keys:
 maas_agent_distro_packages:
   - python-virtualenv
 
-
 #
 # MaaS poller options
 #

--- a/tests/test-setup.yml
+++ b/tests/test-setup.yml
@@ -16,7 +16,7 @@
 - name: Find and delete existing rpcm vars files
   hosts: localhost
   connection: local
-  user: root
+  user: "{{ ansible_user | default('root') }}"
   tasks:
     - name: Find existing /etc/openstack_deploy/user_rpcm_*.yml files
       find:
@@ -33,7 +33,7 @@
 - name: Copy var files in place
   hosts: localhost
   connection: local
-  user: root
+  user: "{{ ansible_user | default('root') }}"
   gather_facts: true
   tasks:
     - name: Copy RPC-O rpc-maas vars into place

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Install rpc-maas
-- include: "../playbooks/site.yml"
+- import_playbook: "../playbooks/site.yml"
 
 # Ensure all plugins are functional
-- include: "../playbooks/maas-verify.yml"
+- import_playbook: "../playbooks/maas-verify.yml"

--- a/tests/test_with_maas_rally.yml
+++ b/tests/test_with_maas_rally.yml
@@ -19,13 +19,13 @@
 # Liberty and Mitaka deployments, add the include tasks to test.yml.
 
 # Install rpc-maas
-- include: "../playbooks/site.yml"
+- import_playbook: "../playbooks/site.yml"
 
 # Install maas_rally performance monitoring
-- include: "../playbooks/maas-openstack-rally.yml"
+- import_playbook: "../playbooks/maas-openstack-rally.yml"
 
 # Restart the rackspace-monitoring-agent after the rally deployment
-- include: "../playbooks/maas-restart.yml"
+- import_playbook: "../playbooks/maas-restart.yml"
 
 # Ensure all plugins are functional
-- include: "../playbooks/maas-verify.yml"
+- import_playbook: "../playbooks/maas-verify.yml"


### PR DESCRIPTION
This change removes the assumption that pip is ever installed on a host
machine. Instead we'll now simply execute out of a venv and change the
playbook execution path to the venv as needed.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>