### PR TITLE
Add RPCO Liberty and Mitaka test scenarios

### DIFF
--- a/tests/user_rpco-liberty_vars.yml
+++ b/tests/user_rpco-liberty_vars.yml
@@ -1,0 +1,44 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+maas_excluded_alarms: []
+
+# swift-recon does not have '--time' option in Liberty
+maas_excluded_checks:
+  - 'filebeat_process_check'
+
+maas_pre_flight_check_enabled: true
+
+# Nova console type is required
+maas_nova_console_type: spice
+
+# Repo compatibility for liberty
+repo_server_port: 8181
+openstack_repo_url: "http://{{ internal_lb_vip_address }}:{{ repo_server_port }}"
+openstack_upstream_domain: "rpc-repo.rackspace.com"
+repo_pip_default_index: "http://{{ openstack_upstream_domain }}/pools"
+
+# Allow maas-verify to properly validate all issues
+maas_verify_registration: true
+maas_verify_status: true
+
+# Disable remote.http checks because AIO endpoints will always be private
+# addresses. Private network monitoring will need to be added.
+maas_remote_check: false
+
+# Set metadata explicitly to OSA
+maas_env_product: osa
+maas_product_dir: /opt/openstack-ansible
+maas_product_osa_dir: /opt/openstack-ansible

--- a/tests/user_rpco-mitaka_vars.yml
+++ b/tests/user_rpco-mitaka_vars.yml
@@ -1,0 +1,35 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+maas_excluded_alarms: []
+maas_excluded_checks: []
+
+maas_pre_flight_check_enabled: true
+
+# Nova console type is required
+maas_nova_console_type: spice
+
+# Allow maas-verify to properly validate all issues
+maas_verify_registration: true
+maas_verify_status: true
+
+# Disable remote.http checks because AIO endpoints will always be private
+# addresses. Private network monitoring will need to be added.
+maas_remote_check: false
+
+# Set metadata explicitly to OSA
+maas_env_product: osa
+maas_product_dir: /opt/openstack-ansible
+maas_product_osa_dir: /opt/openstack-ansible


### PR DESCRIPTION
Adds the ability to utilize aio-create.sh to create RPCO Liberty or
Mitaka AIO. This is primarily useful to build test servers for
ensuring dynamic variable generation is functioning successfully.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>