### PR TITLE
NATT-63 Ensure security groups are actively enforcing

### DIFF
--- a/playbooks/files/rax-maas/plugins/iptables_check.py
+++ b/playbooks/files/rax-maas/plugins/iptables_check.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+# Copyright 2019, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+
+from maas_common import metric
+from maas_common import metric_bool
+from maas_common import print_output
+from maas_common import status_ok
+from maas_common import status
+
+
+def main():
+    iptables_exist = False
+    bridge_params = ["bridge-nf-call-arptables", "bridge-nf-call-ip6tables",
+                     "bridge-nf-call-iptables"]
+    bridge_sysctl = False
+    bridge_param_metrics = {}
+
+    # Check if there are instances on this host. If not, we don't care and
+    # just pass the check
+    try:
+        instances = subprocess.check_output(["virsh", "list"]).split('\n')
+    except Exception as e:
+        status("error", str(e), force_print=False)
+    instancesRunning = False
+    for instance in instances:
+        if "running" in instance:
+            instancesRunning = True
+
+    # No instances running, force a successful check run
+    if instancesRunning is False:
+        iptables_exist = True
+        bridge_sysctl = True
+        for param in bridge_params:
+            bridge_param_metrics[param] = "1"
+
+    # There are instances on this host. Verify appropriate sysctl settings and
+    # iptables rules
+    else:
+        try:
+            bridge_sysctl = True
+            for param in bridge_params:
+                bridge_param_metrics[param] = str(subprocess.check_output(
+                    ['cat', '/proc/sys/net/bridge/' + param])).rstrip('\n')
+                if bridge_param_metrics[param] != "1":
+                    bridge_sysctl = False
+        except Exception as e:
+            status('error', str(e), force_print=False)
+
+    # Check that iptables rules are in place
+    iptables_rules = ''
+    try:
+        iptables_rules = str(subprocess.check_output(
+            ['iptables-save'])).split('\n')
+    except Exception as e:
+        status('error', str(e), force_print=False)
+
+    iptables_exist = False
+    for rule in iptables_rules:
+        if "DROP" in rule:
+            iptables_exist = True
+
+    if bridge_sysctl is True and iptables_exist is True:
+        metric_bool('iptables_status', True, m_name='iptables_active')
+        status_ok(m_name='iptables_active')
+    else:
+        metric_bool('iptables_status', False, m_name='iptables_active')
+
+    metric('bridge-nf-call-arptables', 'int64',
+           bridge_param_metrics.get('bridge-nf-call-arptables', 0))
+    metric('bridge-nf-call-iptables', 'int64',
+           bridge_param_metrics.get('bridge-nf-call-iptables', 0))
+    metric('bridge-nf-call-ip6tables', 'int64',
+           bridge_param_metrics.get('bridge-nf-call-ip6tables', 0))
+
+
+if __name__ == '__main__':
+    with print_output(print_telegraf=False):
+        main()

--- a/playbooks/maas-openstack-nova.yml
+++ b/playbooks/maas-openstack-nova.yml
@@ -230,6 +230,15 @@
         mode: "0644"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
+    - name: Install iptables security group check
+      template:
+        src: "templates/rax-maas/nova_security_group_check.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/nova_security_group_check--{{ inventory_hostname }}.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/templates/rax-maas/nova_security_group_check.yaml.j2
+++ b/playbooks/templates/rax-maas/nova_security_group_check.yaml.j2
@@ -1,0 +1,25 @@
+{% from "templates/common/macros.jinja" import get_metadata with context %}
+{% set label = "nova_security_group_check" %}
+{% set check_name = label+'--'+inventory_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(300) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(299) }}"
+disabled    : "{{ (check_name is match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}/iptables_check.py"]
+    timeout : {{ (maas_check_timeout_override[label] | default(299) * 1000) }}
+{{ get_metadata(label).strip() }}
+{# Add extra metadata options with two leading white spaces #}
+alarms      :
+    nova_security_group_status :
+        label                   : nova_security_group_status--{{ inventory_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : false
+        criteria                : |
+            :set consecutiveCount=3
+            if (metric["iptables_status"] != 1) {
+                return new AlarmStatus(CRITICAL, "Security Groups are not enforcing");
+            }
+            return new AlarmStatus(OK, "Security Groups are enforcing");


### PR DESCRIPTION
When the following sysctl parameters are set to 0, instances are not
actively protected by iptables.

/proc/sys/net/bridge/bridge-nf-call-arptables
/proc/sys/net/bridge/bridge-nf-call-ip6tables
/proc/sys/net/bridge/bridge-nf-call-iptables

This change provides functionality to ensure these are set properly
across all compute nodes with instances running.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>