### PR TITLE
NATT-51 Add vendor powersupply monitoring

### DIFF
--- a/playbooks/files/rax-maas/plugins/hp_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/hp_monitoring.py
@@ -50,6 +50,11 @@ def get_chassis_status(command, item):
                          'Status', 'Ok')
 
 
+def get_powersupply_status(command, item):
+    return check_command((command, '-s', 'show %s' % item),
+                         'Condition', 'Ok')
+
+
 def get_drive_status(command):
     return check_command((command, 'ctrl', 'all', 'show', 'config'),
                          'logicaldrive', ('OK)', 'OK, Encrypted)'))
@@ -87,6 +92,8 @@ def main():
     status['hardware_processors_status'] = \
         get_chassis_status('hpasmcli', 'server')
     status['hardware_memory_status'] = get_chassis_status('hpasmcli', 'dimm')
+    status['hardware_powersupply_status'] = \
+        get_powersupply_status('hpasmcli', 'powersupply')
     status['hardware_disk_status'] = get_drive_status(ssacli_bin)
     status['hardware_controller_status'] = get_controller_status(ssacli_bin)
     status['hardware_controller_cache_status'] = \

--- a/playbooks/files/rax-maas/plugins/openmanage.py
+++ b/playbooks/files/rax-maas/plugins/openmanage.py
@@ -29,7 +29,7 @@ CHASSIS = re.compile(OM_PATTERN % {'field': '^Health', 'group_pattern': '\w+'},
                      re.MULTILINE)
 STORAGE = re.compile(OM_PATTERN % {'field': '^Status', 'group_pattern': '\w+'},
                      re.MULTILINE)
-regex = {'storage': STORAGE, 'chassis': CHASSIS}
+regex = {'storage': STORAGE, 'chassis': CHASSIS, 'pwrsupplies': STORAGE}
 
 
 def hardware_report(report_type, report_request):
@@ -106,8 +106,12 @@ def main(args):
         status_err(str(e), m_name='maas_hwvendor')
 
     status_ok(m_name='maas_hwvendor')
-    metric_bool('hardware_%s_status' % report_request,
-                all_okay(report, regex[report_type]))
+    if report_request == 'pwrsupplies':
+        metric_bool('hardware_%s_status' % report_request,
+                    all_okay(report, regex[report_request]))
+    else:
+        metric_bool('hardware_%s_status' % report_request,
+                    all_okay(report, regex[report_type]))
 
 
 if __name__ == '__main__':

--- a/playbooks/templates/rax-maas/hp-check.yaml.j2
+++ b/playbooks/templates/rax-maas/hp-check.yaml.j2
@@ -67,3 +67,12 @@ alarms      :
             if (metric["hardware_processors_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "Physical Processor Error");
             }
+    hp-powersupply_status :
+        label                   : hp-powersupply--{{ inventory_hostname | quote }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (('hp-powersupply--'+inventory_hostname | quote) is match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["hardware_powersupply_status"] != 1) {
+                return new AlarmStatus(CRITICAL, "Physical Powersupply Error");
+            }

--- a/playbooks/templates/rax-maas/openmanage-powersupply.yaml.j2
+++ b/playbooks/templates/rax-maas/openmanage-powersupply.yaml.j2
@@ -1,0 +1,24 @@
+{% from "templates/common/macros.jinja" import get_metadata with context %}
+{% set label = "openmanage-pwrsupplies" %}
+{% set check_name = label+'--'+inventory_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name is match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}/openmanage.py", "chassis", "pwrsupplies"]
+    timeout : {{ (maas_check_timeout_override[label] | default(maas_check_timeout) * 1000) }}
+{{ get_metadata(label).strip() }}
+{# Add extra metadata options with two leading white spaces #}
+alarms      :
+    openmanage-pwrsupplies_status :
+        label                   : openmanage-pwrsupplies--{{ inventory_hostname | quote }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (('openmanage-pwrsupplies--'+inventory_hostname) is match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["hardware_pwrsupplies_status"] != 1) {
+                return new AlarmStatus(CRITICAL, "Physical power supply error");
+            }


### PR DESCRIPTION
This change leverages HP and Dell hardware management CLI tooling to
include monitoring the power supply status.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>