### PR TITLE
Add block to correct mtab

### DIFF
--- a/playbooks/files/rax-maas/plugins/container_storage_check.py
+++ b/playbooks/files/rax-maas/plugins/container_storage_check.py
@@ -57,9 +57,12 @@ def container_check(thresh):
 
         with Chroot('/proc/%s/root' % int(c.init_pid)):
             for partition in psutil.disk_partitions():
-                percent_used = disk_usage(part=partition)
-                if percent_used >= thresh:
-                    return False
+                try:
+                    percent_used = disk_usage(part=partition)
+                    if percent_used >= thresh:
+                        return False
+                except OSError:
+                    pass
     else:
         return True
 

--- a/playbooks/maas-container-storage.yml
+++ b/playbooks/maas-container-storage.yml
@@ -65,7 +65,26 @@
     - always
 
 
-- name: Install checks for infra memcached
+- name: Fix mtab within containers
+  hosts: all_containers
+  gather_facts: true
+  user: "{{ ansible_user | default('root') }}"
+  become: true
+  pre_tasks:
+  tasks:
+    - name: Remove the old mtab object
+      file:
+        path: /etc/mtab
+
+    - name: Create new mtab file
+      copy:
+        src: /proc/self/mounts
+        dest: /etc/mtab
+        remote_src: true
+        mode: 0644
+
+
+- name: Install checks for infra storage local checks
   hosts: known_container_hosts
   gather_facts: true
   user: "{{ ansible_user | default('root') }}"
@@ -84,8 +103,6 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      when:
-        - ansible_distribution_version == '14.04'
       delegate_to: "{{ physical_host | default(ansible_host) }}"
 
   vars_files:


### PR DESCRIPTION
This change will ensure that the container is able to do a storage
lookup and determine the filesystem type.

The constraint for container filesystem checks has been removed.

Signed-off-by: cloudnull <kevin@cloudnull.com>