### PR TITLE
Update nova service check to alert on additional nova states

### DIFF
--- a/playbooks/files/rax-maas/plugins/nova_service_check.py
+++ b/playbooks/files/rax-maas/plugins/nova_service_check.py
@@ -72,8 +72,12 @@ def check(auth_ref, args):
     for service in services:
         service_is_up = "Yes"
 
-        if service.status == 'enabled' and service.state == 'down':
+        if service.status.lower() == 'enabled' and service.state.lower() == 'down':
             service_is_up = "No"
+        elif service.status.lower() == 'disabled':
+            if service.disabled_reason:
+                if 'auto' in service.disabled_reason.lower():
+                    service_is_up = "No"
 
         if args.host:
             name = '%s_status' % service.binary

--- a/playbooks/files/rax-maas/plugins/nova_service_check.py
+++ b/playbooks/files/rax-maas/plugins/nova_service_check.py
@@ -72,8 +72,9 @@ def check(auth_ref, args):
     for service in services:
         service_is_up = "Yes"
 
-        if service.status.lower() == 'enabled' and service.state.lower() == 'down':
-            service_is_up = "No"
+        if service.status.lower() == 'enabled':
+            if service.state.lower() == 'down':
+                service_is_up = "No"
         elif service.status.lower() == 'disabled':
             if service.disabled_reason:
                 if 'auto' in service.disabled_reason.lower():


### PR DESCRIPTION
nova services can be in different states while also being "enabled". If
the service is set down and is done so via internal nova automation we
will now create an alert.

Signed-off-by: cloudnull <kevin@cloudnull.com>