### PR TITLE
Add multipath check

### DIFF
--- a/playbooks/maas-infra-multipathd.yml
+++ b/playbooks/maas-infra-multipathd.yml
@@ -1,0 +1,73 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Install checks for multipathd
+  hosts: "cinder_volume:nova_compute"
+  gather_facts: true
+  user: "{{ ansible_user | default('root') }}"
+  become: true
+  pre_tasks:
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+
+    - name: Include OSP vars
+      include_vars: vars/maas-osp.yml
+      when:
+        - ansible_local['maas']['general']['deploy_osp'] | bool
+
+    - name: Set the current group
+      set_fact:
+        maas_current_group: multipathd_all
+
+    - include_tasks: "common-tasks/maas_excluded_regex.yml"
+
+  tasks:
+    - name: Check if multipathd is running
+      shell: service multipathd status
+      ignore_errors: yes
+      changed_when: false
+      register: service_multipathd_status
+      tags:
+        - skip_ansible_lint
+
+    - name: Check if multipathd has connections
+      command: multipath -l
+      ignore_errors: yes
+      changed_when: false
+      register: service_multipathd_connections
+
+    - name: Install multipathd process check
+      template:
+        src: "templates/rax-maas/multipathd_process_check.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/multipathd_process_check--{{ inventory_hostname }}.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
+      when:
+        - service_multipathd_status is success
+        - (service_multipathd_connections.stdout_lines | length) > 0
+      delegate_to: "{{ physical_host | default(ansible_host) }}"
+
+  vars_files:
+    - vars/main.yml
+    - vars/maas.yml
+    - vars/maas-openstack.yml
+
+  environment: "{{ deployment_environment_variables | default({}) }}"
+
+  tags:
+    - maas-infra-multipathd

--- a/playbooks/maas-openstack-all.yml
+++ b/playbooks/maas-openstack-all.yml
@@ -60,3 +60,7 @@
 - import_playbook: maas-openstack-swift.yml
   tags:
     - maas-openstack
+
+- import_playbook: maas-infra-multipathd.yml
+  tags:
+    - maas-openstack

--- a/playbooks/templates/common/macros.jinja
+++ b/playbooks/templates/common/macros.jinja
@@ -5,7 +5,7 @@ api
 kubernetes
 {% elif check_label.startswith('rsyslogd_process_check') %}
 logging
-{% elif check_label in ['container_storage_check', 'holland_local_check', 'maas_poller_fd_count', 'memcached_status'] or check_label.startswith('galera') or check_label.startswith('rabbitmq') %}
+{% elif check_label in ['multipath_process_check', 'container_storage_check', 'holland_local_check', 'maas_poller_fd_count', 'memcached_status'] or check_label.startswith('galera') or check_label.startswith('rabbitmq') %}
 infrastructure
 {% elif check_label in ['conntrack_count', 'cpu_check', 'disk_utilisation', 'memory_check', 'private_ping_check', 'private_ssh_check', 'host_bonding_iface_status_check'] or check_label.startswith('filesystem') or check_label.startswith('network_throughput') %}
 host

--- a/playbooks/templates/rax-maas/multipathd_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/multipathd_process_check.yaml.j2
@@ -1,0 +1,24 @@
+{% from "templates/common/macros.jinja" import get_metadata with context %}
+{% set label = "multipathd_process_check" %}
+{% set check_name = label+'--'+inventory_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name is match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}/process_check_host.py", "multipathd"]
+    timeout : {{ (maas_check_timeout_override[label] | default(maas_check_timeout) * 1000) }}
+{{ get_metadata(label).strip() }}
+{# Add extra metadata options with two leading white spaces #}
+alarms      :
+    multipathd_process_status:
+        label                   : "multipathd_process_status--{{ inventory_hostname }}"
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ ('multipathd_process_status--'+inventory_hostname is match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["multipathd_process_status"] != 1 ) {
+                return new AlarmStatus(CRITICAL, "multipathd process not running on {{ inventory_hostname }}");
+            }


### PR DESCRIPTION
This change adds a multipath check which will now look for the multipath
process and if the process its found, and there are active connections,
a process check will be deployed. This check will alert if the process
dies or ever becomes unresponsive.

Signed-off-by: cloudnull <kevin@cloudnull.com>