### PR TITLE
NATT-83: Add network statistic error rate check

### DIFF
--- a/playbooks/files/rax-maas/plugins/network_stats_check.py
+++ b/playbooks/files/rax-maas/plugins/network_stats_check.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+# Copyright 2019, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+
+from maas_common import metric
+from maas_common import print_output
+from maas_common import status_err
+from maas_common import status_ok
+
+
+def physical_interface_errors():
+    vnet_devices = os.listdir('/sys/devices/virtual/net')
+    vnet_devices.append('bonding_masters')
+    totals = dict()
+    totals['rx_errors'] = 0
+    totals['tx_errors'] = 0
+    for d in os.listdir('/sys/class/net'):
+        if d not in vnet_devices:
+            for e in 'rx_errors', 'tx_errors':
+                filepath = '/sys/class/net/%s/statistics/%s' % (d, e)
+                with open(filepath) as f:
+                    totals[e] += int(f.read())
+    return totals
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Network error statistics '
+                                     'check')
+    parser.add_argument('--telegraf-output',
+                        action='store_true',
+                        default=False,
+                        help='Set the output format to telegraf')
+    args = parser.parse_args()
+    with print_output(print_telegraf=args.telegraf_output):
+        try:
+            totals = physical_interface_errors()
+        except Exception as e:
+            status_err(e, m_name='maas_network_stats')
+        else:
+            status_ok(m_name='maas_network_stats')
+            for k, v in totals.items():
+                metric('physical_interface_%s' % k, 'int64', v)

--- a/playbooks/maas-host-network.yml
+++ b/playbooks/maas-host-network.yml
@@ -42,7 +42,7 @@
     - always
 
 
-- name: Install checks for hosts network
+- name: Install checks for host networking
   hosts: hosts
   gather_facts: true
   become: true
@@ -71,28 +71,7 @@
       with_together:
         - "{{ maas_network_checks_list }}"
 
-  vars_files:
-    - vars/main.yml
-    - vars/maas.yml
-
-  environment: "{{ deployment_environment_variables | default({}) }}"
-
-  tags:
-    - maas-hosts-network
-
-
-- name: Install checks for bonding interfaces
-  hosts: hosts
-  gather_facts: true
-  become: true
-  pre_tasks:
-    - name: Include OSP vars
-      include_vars: vars/maas-osp.yml
-      when:
-        - ansible_local['maas']['general']['deploy_osp'] | bool
-
-  tasks:
-    - name: Install checks for bonding interfaces
+    - name: Install bonding interface status check
       template:
         src: "templates/rax-maas/host_bonding_iface_check.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/host_bonding_iface_check.yaml"
@@ -100,6 +79,14 @@
         group: "root"
         mode: "0644"
       when: maas_bonding_interfaces is defined and (maas_bonding_interfaces | length) > 0
+
+    - name: Install network statistics check
+      template:
+        src: "templates/rax-maas/network_stats_check.yaml.j2"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/network_stats_check.yaml"
+        owner: "root"
+        group: "root"
+        mode: "0644"
 
   vars_files:
     - vars/main.yml

--- a/playbooks/templates/common/macros.jinja
+++ b/playbooks/templates/common/macros.jinja
@@ -7,7 +7,7 @@ kubernetes
 logging
 {% elif check_label in ['multipath_process_check', 'tgtd_process_check', 'container_storage_check', 'holland_local_check', 'maas_poller_fd_count', 'memcached_status'] or check_label.startswith('galera') or check_label.startswith('rabbitmq') %}
 infrastructure
-{% elif check_label in ['conntrack_count', 'cpu_check', 'disk_utilisation', 'memory_check', 'private_ping_check', 'private_ssh_check', 'host_bonding_iface_status_check'] or check_label.startswith('filesystem') or check_label.startswith('network_throughput') %}
+{% elif check_label in ['conntrack_count', 'cpu_check', 'disk_utilisation', 'memory_check', 'private_ping_check', 'private_ssh_check', 'host_bonding_iface_status_check', 'network_stats_check'] or check_label.startswith('filesystem') or check_label.startswith('network_throughput') %}
 host
 {% elif check_label in ['hp-check', 'openmanage-memory', 'openmanage-processors', 'openmanage-vdisk'] %}
 host {# we can change to hardware here if we want #}

--- a/playbooks/templates/rax-maas/network_stats_check.yaml.j2
+++ b/playbooks/templates/rax-maas/network_stats_check.yaml.j2
@@ -1,0 +1,35 @@
+{% from "templates/common/macros.jinja" import get_metadata with context %}
+{% set label = "network_stats_check" %}
+{% set check_name = label+'--'+inventory_hostname %}
+type        : agent.plugin
+label       : "{{ check_name }}"
+period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
+timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
+disabled    : "{{ (check_name is match(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+details     :
+    file    : run_plugin_in_venv.sh
+    args    : ["{{ maas_plugin_dir }}/network_stats_check.py"]
+    timeout : {{ (maas_check_timeout_override[label] | default(maas_check_timeout) * 1000) }}
+{{ get_metadata(label).strip() }}
+{# Add extra metadata options with two leading white spaces #}
+alarms:
+    physical_interface_rx_errors:
+        label                   : physical_interface_rx_errors--{{ inventory_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (('physical_interface_rx_errors--'+inventory_hostname )is match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (rate(metric['physical_interface_rx_errors']) > {{ maas_network_rx_error_threshold }}) {
+              return new AlarmStatus(CRITICAL, "There have been more than {{ maas_network_rx_error_threshold }} network RX errors in the last {{ maas_check_period_override[label] | default(maas_check_period) }}s.");
+            }
+            return new AlarmStatus(OK, "#{physical_interface_rx_errors} network RX errors have been detected in the last {{ maas_check_period_override[label] | default(maas_check_period) }}.");
+    physical_interface_tx_errors:
+        label                   : physical_interface_tx_errors--{{ inventory_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (('physical_interface_tx_errors--'+inventory_hostname )is match(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (rate(metric['physical_interface_tx_errors']) > {{ maas_network_tx_error_threshold }}) {
+              return new AlarmStatus(CRITICAL, "There have been more than {{ maas_network_tx_error_threshold }} network TX errors in the last {{ maas_check_period_override[label] | default(maas_check_period) }}s.");
+            }
+            return new AlarmStatus(OK, "#{physical_interface_tx_errors} network TX errors have been detected in the last {{ maas_check_period_override[label] | default(maas_check_period) }}s.");

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -463,6 +463,12 @@ maas_network_checks_list:
     tx_pct_crit: 80
 
 #
+# MaaS network statistics check error rates
+#
+maas_network_rx_error_threshold: 64
+maas_network_tx_error_threshold: 64
+
+#
 # maas_k8s_ui_scheme: https
 #
 maas_managed_k8_kube_config_dir: /root/.k8


### PR DESCRIPTION
This check gathers physical network interface receive and transmit errors, sums
all error values, and evaluates based on a rate-over-time function in MaaS. By
default it looks for a total greater than 64 over a 60s period of time.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>