### PR TITLE
Update latest codebase for Kilo

### DIFF
--- a/playbooks/files/rax-maas/plugins/ironic_compute_nova_service_check.py
+++ b/playbooks/files/rax-maas/plugins/ironic_compute_nova_service_check.py
@@ -55,9 +55,9 @@ def check(auth_ref, args):
 
     # gather nova service states
     if args.host:
-        services = nova.services.list(host=args.host)
+        services = nova.services(host=args.host)
     else:
-        services = nova.services.list()
+        services = nova.services()
 
     if len(services) == 0:
         status_err("No host(s) found in the service list", m_name='maas_nova')

--- a/playbooks/files/rax-maas/plugins/maas_common.py
+++ b/playbooks/files/rax-maas/plugins/maas_common.py
@@ -219,7 +219,6 @@ else:
         return glance
 
 try:
-    from novaclient import client as nova_client
     from novaclient.client import exceptions as nova_exc
 except ImportError:
     def get_nova_client(*args, **kwargs):
@@ -244,15 +243,10 @@ else:
                                                       get_endpoint_type(
                                                           auth_details))
 
-        nova = nova_client.Client(
-            get_os_component_major_api_version('nova')[0],
-            auth_token=auth_token,
-            auth_url=auth_details['OS_AUTH_URL'],
-            bypass_url=bypass_url,
-            insecure=auth_details['OS_API_INSECURE'])
+        nova = OSC_CLIENT.compute
 
         try:
-            flavors = nova.flavors.list()
+            flavors = nova.flavors()
             # Exceptions are only thrown when we try and do something
             [flavor.id for flavor in flavors]
 

--- a/playbooks/files/rax-maas/plugins/nova_api_local_check.py
+++ b/playbooks/files/rax-maas/plugins/nova_api_local_check.py
@@ -67,11 +67,11 @@ def check(auth_ref, args):
         metric_bool('client_success', True, m_name='maas_nova')
         # time something arbitrary
         start = time.time()
-        nova.services.list()
+        nova.services()
         end = time.time()
         milliseconds = (end - start) * 1000
 
-        servers = nova.servers.list(search_opts={'all_tenants': 1})
+        servers = nova.servers(all_tenants=1)
         # gather some metrics
         status_count = collections.Counter([s.status for s in servers])
 

--- a/playbooks/files/rax-maas/plugins/nova_service_check.py
+++ b/playbooks/files/rax-maas/plugins/nova_service_check.py
@@ -60,9 +60,9 @@ def check(auth_ref, args):
 
     # gather nova service states
     if args.host:
-        services = nova.services.list(host=args.host)
+        services = [i for i in nova.services() if i.host == args.host]
     else:
-        services = nova.services.list()
+        services = nova.services()
 
     if len(services) == 0:
         status_err("No host(s) found in the service list", m_name='maas_nova')
@@ -76,9 +76,12 @@ def check(auth_ref, args):
             if service.state.lower() == 'down':
                 service_is_up = "No"
         elif service.status.lower() == 'disabled':
-            if service.disabled_reason:
-                if 'auto' in service.disabled_reason.lower():
-                    service_is_up = "No"
+            try:
+                if service.disabled_reason:
+                    if 'auto' in service.disabled_reason.lower():
+                        service_is_up = "No"
+            except AttributeError:
+                pass
 
         if args.host:
             name = '%s_status' % service.binary

--- a/playbooks/files/rax-maas/plugins/swift-recon.py
+++ b/playbooks/files/rax-maas/plugins/swift-recon.py
@@ -518,8 +518,7 @@ def get_stats_from(args):
                                  deploy_osp=deploy_osp)
     elif args.recon == 'replication':
         if args.ring not in {"account", "container", "object"}:
-            status_err('no ring provided to check',
-                                   m_name='maas_swift')
+            status_err('no ring provided to check', m_name='maas_swift')
         stats = swift_replication(args.ring,
                                   swift_recon_path=args.swift_recon_path,
                                   deploy_osp=deploy_osp)

--- a/playbooks/files/rax-maas/plugins/swift-recon.py
+++ b/playbooks/files/rax-maas/plugins/swift-recon.py
@@ -29,7 +29,9 @@ import shlex
 import subprocess
 
 import maas_common
-from maas_common import status_err, status_err_no_exit
+from maas_common import status_err
+from maas_common import status_ok
+from maas_common import status_err_no_exit
 
 
 class ParseError(maas_common.MaaSException):
@@ -56,19 +58,16 @@ def get_container_name(deploy_osp, for_ring):
     if not deploy_osp:
         # identify the container we will use for monitoring
         get_container = shlex.split(
-            'lxc-ls -1 --running ".*(swift_proxy|swift)"')
+            'lxc-ls -1 --running ".*(swift_proxy|swift)"'
+        )
 
         try:
             containers_list = subprocess.check_output(get_container)
             container = containers_list.splitlines()[0]
         except (IndexError, subprocess.CalledProcessError):
-            status_err('no running swift %s  or proxy containers found' %
-                       for_ring, m_name='maas_swift')
-
+            return False
     else:
-        get_containers = (
-            "/usr/local/bin/docker ps -f status=running"
-        )
+        get_containers = ("/usr/local/bin/docker ps -f status=running")
         containers_list = subprocess.check_output(get_containers.split())
 
         c = getcontainer('swift_proxy', containers_list)
@@ -110,17 +109,28 @@ def recon_output(for_ring, options=None, swift_recon_path=None,
     command = [os.path.join(swift_recon_path or "", 'swift-recon'), for_ring]
     command.extend(options or [])
     command_options = ' '.join(command)
-    if deploy_osp:
-        container_exec_command = 'docker exec %s' % container
-        full_command = '{container_exec_command} {command_options}'
+
+    if not container:
+        _full_command = '{command_options}'.format(
+            command_options=command_options
+        )
+    elif deploy_osp:
+        _full_command = '{container_exec_command} {command_options}'.format(
+            container_exec_command='docker exec {}'.format(
+                container
+            ),
+            command_options=command_options
+        )
     else:
-        container_exec_command = 'lxc-attach -n %s -- bash -c' % container
-        command_options = '"%s"' % command_options
-        full_command = '{container_exec_command} {command_options}'
-    full_command = shlex.split(
-        '{container_exec_command} {command_options}' .format(
-            container_exec_command=container_exec_command,
-            command_options=command_options))
+        _full_command = '{container_exec_command} {command_options}'.format(
+            container_exec_command='lxc-attach -n {} -- bash -c'.format(
+                container
+            ),
+            command_options='"{}"'.format(command_options)
+        )
+
+    full_command = shlex.split(_full_command)
+
     try:
         out = subprocess.check_output(full_command)
     except subprocess.CalledProcessError as error:
@@ -273,7 +283,7 @@ def swift_async(swift_recon_path=None, deploy_osp=False):
             break
     else:
         # If we didn't find a non-empty dict, error out
-        maas_common.status_err(
+        status_err(
             'No data could be collected about pending async operations',
             m_name='maas_swift'
         )
@@ -354,7 +364,7 @@ def swift_md5(swift_recon_path=None, deploy_osp=False):
         # If there was an error checking the md5sum, error out immediately
         if line.startswith('!!'):
             error_dict = error_re.search(line).groupdict()
-            maas_common.status_err(
+            status_err(
                 'md5 mismatch for {0} on host {1}'.format(
                     checking_dict.get('check'),
                     error_dict['address']
@@ -508,7 +518,7 @@ def get_stats_from(args):
                                  deploy_osp=deploy_osp)
     elif args.recon == 'replication':
         if args.ring not in {"account", "container", "object"}:
-            maas_common.status_err('no ring provided to check',
+            status_err('no ring provided to check',
                                    m_name='maas_swift')
         stats = swift_replication(args.ring,
                                   swift_recon_path=args.swift_recon_path,
@@ -528,10 +538,10 @@ def main():
     try:
         stats = get_stats_from(args)
     except (ParseError, CommandNotRecognized) as e:
-        maas_common.status_err(str(e), m_name='maas_swift')
+        status_err(str(e), m_name='maas_swift')
 
     if stats:
-        maas_common.status_ok(m_name='maas_swift')
+        status_ok(m_name='maas_swift')
         print_nested_stats(stats)
 
 

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -138,7 +138,9 @@
           when:
             - groups['swift_all'] | default([]) | length > 0
             - ansible_local['maas']['general']['maas_product_osa_codename'] is defined
-            - ansible_local['maas']['general']['maas_product_osa_codename'] == 'kilo'
+            - ansible_local['maas']['general']['maas_product_osa_codename'] == 'kilo' or
+              ansible_local['maas']['general']['maas_product_osa_codename'] == '1andone'
+
       when:
         - not (deploy_osp | default(False) | bool)
         - osa_release_file.stat.exists | bool

--- a/playbooks/templates/rax-maas/run_plugin_in_rally_venv.sh.j2
+++ b/playbooks/templates/rax-maas/run_plugin_in_rally_venv.sh.j2
@@ -8,6 +8,10 @@ if [[ -f {{ maas_maasrc | default('~/maasrc') }} ]]; then
   source {{ maas_maasrc | default('~/maasrc') }}
 fi
 
+if [[ -f {{ maas_environment | default('/etc/environment') }} ]]; then
+  source {{ maas_environment | default('/etc/environment') }}
+fi
+
 # NOTE(cloudnull): Hard coded because this was never addressed upstream
 export OS_API_INSECURE={{ maas_os_api_insecure | default('True') }}
 

--- a/playbooks/templates/rax-maas/run_plugin_in_venv.sh.j2
+++ b/playbooks/templates/rax-maas/run_plugin_in_venv.sh.j2
@@ -8,6 +8,10 @@ if [[ -f {{ maas_maasrc | default('~/maasrc') }} ]]; then
   source {{ maas_maasrc | default('~/maasrc') }}
 fi
 
+if [[ -f {{ maas_environment | default('/etc/environment') }} ]]; then
+  source {{ maas_environment | default('/etc/environment') }}
+fi
+
 # NOTE(cloudnull): Hard coded because this was never addressed upstream
 export OS_API_INSECURE={{ maas_os_api_insecure | default('True') }}
 

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -521,6 +521,7 @@ maas_agent_endpoint:
   status_code:
     - 200
     - 404
+    - 503
 
 #
 # Check to ensure no 'unknown' values are rendered into metadata
@@ -563,6 +564,8 @@ maas_compat:
 # Release specific check exclusions
 #
 maas_release_excluded_checks:
+  1andone:
+    - swift_time_sync_check
   kilo:
     - swift_time_sync_check
   queens:


### PR DESCRIPTION
This change converts nova client to use the openstacksdk in Kilo
environments. Fixes some nuances around the kilo codename '1andone'
which prevented some dynamic generation aspects from functioning
properly. Includes sourcing /etc/environment in the venv wrapper,
and updates swift-recon.py to allow baremetal proxy deployment.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>