### PR TITLE
NATT-90: Update virtualenv creation logic

### DIFF
--- a/playbooks/common-tasks/maas-agent-ubuntu-install.yml
+++ b/playbooks/common-tasks/maas-agent-ubuntu-install.yml
@@ -44,9 +44,19 @@
   retries: 5
   delay: 2
 
-- name: Ensure container packages are installed
+- name: Ensure packages are installed
   package:
-    name: "{{ maas_distro_packages | union(maas_extra_distro_packages) }}"
+    name: "{{ maas_distro_packages }}"
     state: "{{ maas_package_state }}"
     update_cache: yes
     cache_valid_time: 600
+
+- name: Ensure container packages are installed
+  package:
+    name: "{{ maas_extra_distro_packages }}"
+    state: "{{ maas_package_state }}"
+    update_cache: yes
+    cache_valid_time: 600
+  when:
+    - not (ansible_local['maas']['general']['deploy_osp'] | bool)
+    - ansible_local['maas']['general']['maas_container_host'] | bool

--- a/playbooks/common-tasks/maas-venv-create.yml
+++ b/playbooks/common-tasks/maas-venv-create.yml
@@ -27,7 +27,7 @@
   delay: 2
 
 - name: Create MaaS venv
-  command: "virtualenv --no-site-packages {{ target_venv | default(maas_venv) }}"
+  command: "virtualenv --no-site-packages --no-setuptools {{ target_venv | default(maas_venv) }}"
   args:
     creates: "{{ target_venv | default(maas_venv) }}/bin/python"
 
@@ -40,7 +40,7 @@
         name:
           - pip
           - setuptools
-        extra_args: "-U"
+        extra_args: "-U --isolated"
         virtualenv: "{{ target_venv | default(maas_venv) }}"
 
     - name: Ensure MaaS pip packages are installed
@@ -58,6 +58,7 @@
       delay: 2
       when:
         - not (ansible_local['maas']['general']['deploy_osp'] | bool)
+        - ansible_local['maas']['general']['maas_container_host'] | bool
 
     - name: Ensure MaaS pip packages are installed
       pip:
@@ -73,4 +74,5 @@
       retries: 5
       delay: 2
       when:
-        - ansible_local['maas']['general']['deploy_osp'] | bool
+        - ansible_local['maas']['general']['deploy_osp'] | bool or
+          not (ansible_local['maas']['general']['maas_container_host'] | bool)

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -511,6 +511,35 @@
     - maas-pre-flight
 
 
+- name: Check for containers on host
+  hosts: hosts
+  gather_facts: false
+  user: "{{ ansible_user | default('root') }}"
+  become: true
+  tasks:
+    - name: local container host block
+      block:
+        - name: Generate list of container hosts
+          set_fact:
+            _known_container_hosts: |-
+              {% set _var = [] -%}
+              {% for item in groups['all_containers'] | default([]) %}
+              {%   if hostvars[item]['physical_host'] | default(false) != item %}
+              {%     set _ = _var.append(hostvars[item]['physical_host']) %}
+              {%   endif %}
+              {% endfor %}
+              {{ _var | unique }}
+
+        - name: Set container host fact
+          ini_file:
+            path: "/etc/ansible/facts.d/maas.fact"
+            section: "general"
+            option: "maas_container_host"
+            value: "{{ inventory_hostname in _known_container_hosts }}"
+      when:
+        - not (ansible_local['maas']['general']['deploy_osp'] | bool)
+
+
 #
 # maasrc generation
 # (This following section could be removed when upstream decides to include

--- a/playbooks/vars/maas-ubuntu.yml
+++ b/playbooks/vars/maas-ubuntu.yml
@@ -31,7 +31,8 @@ maas_distro_packages:
 #
 # Enable additional package override
 #
-maas_extra_distro_packages: []
+maas_extra_distro_packages:
+  - lxc-dev
 
 #
 # List of packages maas requires on galera hosts

--- a/tests/test-ansible-functional.sh
+++ b/tests/test-ansible-functional.sh
@@ -234,12 +234,12 @@ function get_pip {
             ;;
     esac
 
-    virtualenv --no-site-packages /opt/test-maas
-    /opt/test-maas/bin/pip install pip setuptools --upgrade
-    /opt/test-maas/bin/pip install requests --upgrade
+    virtualenv --no-site-packages --no-setuptools /opt/test-maas
+    /opt/test-maas/bin/pip install pip setuptools --upgrade --isolated
+    /opt/test-maas/bin/pip install requests --upgrade --isolated
   else
-    /opt/test-maas/bin/pip install pip setuptools --upgrade
-    /opt/test-maas/bin/pip install requests --upgrade
+    /opt/test-maas/bin/pip install pip setuptools --upgrade --isolated
+    /opt/test-maas/bin/pip install requests --upgrade --isolated
   fi
 }
 


### PR DESCRIPTION
This change adds a local fact during pre-flight that will detect whether
a host has containers in the inventory. Depending on this fact the
associated packages will be installed properly.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>