### PR TITLE
fix neutron ns check

### DIFF
--- a/playbooks/files/rax-maas/plugins/conntrack_count.py
+++ b/playbooks/files/rax-maas/plugins/conntrack_count.py
@@ -18,8 +18,6 @@ import argparse
 import ctypes
 import errno
 import os
-import subprocess
-import tempfile
 
 try:
     import lxc
@@ -154,8 +152,9 @@ def main():
         else:
             if not lxc_module_active:
                 raise maas_common.MaaSException(
-                    'Container monitoring requested but failed. Check lxc-python'
-                    'pip module not installed within the plugin execution path.'
+                    'Container monitoring requested but failed. Check'
+                    'lxc-python pip module not installed within the plugin'
+                    'execution path.'
                 )
             metrics = get_metrics_lxc_container(args.container)
 

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -350,6 +350,7 @@ maas_pip_packages:
   - monitorstack
   - psutil
   - git+https://github.com/lunaryorn/pyudev.git
+  - pyroute2
   - python-memcached
   - rackspace-monitoring-cli
   - requests


### PR DESCRIPTION
the neutron ns check has been updated to use the pyroute2 lib instead of
trying to parse shell output. Context managers are now being used to
enter a namespace when present instead of relying on the lxc-attach
command. All extra cruft has been removed from the check.

Signed-off-by: cloudnull <kevin@cloudnull.com>