### PR TITLE
Remove keystone user create for maas

### DIFF
--- a/playbooks/maas-openstack-keystone.yml
+++ b/playbooks/maas-openstack-keystone.yml
@@ -35,33 +35,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Create keystone user for monitoring
-      shell: |
-        . /root/openrc
-        if ! {{ maas_venv_bin }}/openstack user show "{{ maas_keystone_user }}"; then
-        MAAS_ID=$({{ maas_venv_bin }}/openstack user create \
-                            --domain default \
-                            --password "{{ maas_keystone_password }}" \
-                            "{{ maas_keystone_user }}" | grep -w id | awk '{print $4}')
-        sleep 1
-        {{ maas_venv_bin }}/openstack role add \
-                        --project admin \
-                        --user "${MAAS_ID}" \
-                        admin
-        exit 3
-        fi
-      args:
-        executable: "/bin/bash"
-      changed_when:
-        - mon_user.rc == 3
-      failed_when:
-        - mon_user.rc not in [0, 3]
-      register: mon_user
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-      no_log: True
-      when:
-        - inventory_hostname in groups['keystone_all'][0]
-
   tasks:
     - name: Install keystone api checks
       template:

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -248,12 +248,6 @@ maas_ssl_check: false
 maas_remote_check: true
 
 #
-# maas_keystone_user: The keystone user to use/create to allow monitoring plugins to query
-#                     OpenStack APIs.
-#
-maas_keystone_user: maas
-
-#
 # maas_agent_upgrade: Allow for automatic MaaS agent upgrades
 #
 #

--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -145,7 +145,6 @@ function bootstrap_rpco {
   # Define rpco maas users
   cat > /etc/openstack_deploy/user_extras_secrets.yml << EOF
 ---
-maas_keystone_password:
 maas_rabbitmq_password:
 maas_swift_accesscheck_password:
 rpc_support_holland_password:

--- a/tests/user_rpcm_secrets.yml
+++ b/tests/user_rpcm_secrets.yml
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 maas_rabbitmq_password: secrete
-maas_keystone_password: secrete
 maas_swift_accesscheck_password: secrete
 maas_rally_users_password: secrete
 maas_rally_galera_password: secrete


### PR DESCRIPTION
Removing as this does not appear to be used any longer.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>