### PR TITLE
Fix pre-flight cinder backup logic

### DIFF
--- a/playbooks/maas-openstack-cinder.yml
+++ b/playbooks/maas-openstack-cinder.yml
@@ -156,6 +156,8 @@
         group: "root"
         mode: "0644"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
+      when:
+        - ansible_local['maas']['general']['maas_monitor_cinder_backup'] | bool
 
   vars_files:
     - vars/main.yml

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -345,9 +345,7 @@
         path: "/etc/ansible/facts.d/maas.fact"
         section: "general"
         option: "maas_monitor_cinder_backup"
-        value: true
-      when:
-        - ((groups['swift_all'] | default([])) | length) > 0
+        value: "{{ maas_monitor_cinder_backup }}"
 
     - name: Merge maas_excluded_checks
       set_fact:
@@ -433,6 +431,7 @@
   vars_files:
     - vars/main.yml
     - vars/maas.yml
+    - vars/maas-openstack.yml
   tags:
     - maas-pre-flight
 

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -36,7 +36,7 @@ maas_horizon_scheme: https
 #  the service. Set this to "false" to disable it regardless of the detected
 #  config.
 #
-maas_monitor_cinder_backup: "{{ ansible_local['maas']['general']['maas_monitor_cinder_backup'] | default(false) }}"
+maas_monitor_cinder_backup: "{{ cinder_service_backup_program_enabled | default(ansible_local['maas']['general']['maas_monitor_cinder_backup'] | default(false)) }}"
 maas_cinder_volumes_vg_warning_threshold: 80.0
 maas_cinder_volumes_vg_critical_threshold: 90.0
 


### PR DESCRIPTION
This change resolves some assumptions of always deploying cinder backup
when swift is detected in and environment with cinder.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>