### PR TITLE
Recreate /etc/mtab after container boots

### DIFF
--- a/playbooks/maas-container-storage.yml
+++ b/playbooks/maas-container-storage.yml
@@ -70,7 +70,6 @@
   gather_facts: true
   user: "{{ ansible_user | default('root') }}"
   become: true
-  pre_tasks:
   tasks:
     - name: Remove the old mtab object
       file:
@@ -83,6 +82,27 @@
         remote_src: true
         mode: 0644
 
+    - name: add mtab service
+      block:
+        - name: Create mtab oneshot service
+          template:
+            src: templates/rax-maas/mtab_systemd_oneshot.j2
+            dest: /etc/systemd/system/mtab-oneshot.service
+            owner: root
+            group: root
+            mode: 0664
+
+        - name: Enable mtab oneshot service
+          systemd:
+            name: mtab-oneshot.service
+            daemon_reload: true
+            enabled: true
+      when:
+        - hostvars[inventory_hostname]['ansible_distribution'] | lower == 'ubuntu'
+        - hostvars[inventory_hostname]['ansible_distribution_major_version'] is version_compare('16', '>=')
+
+  tags:
+    - maas-container-storage
 
 - name: Install checks for infra storage local checks
   hosts: known_container_hosts

--- a/playbooks/templates/rax-maas/mtab_systemd_oneshot.j2
+++ b/playbooks/templates/rax-maas/mtab_systemd_oneshot.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=MaaS service to unlink /etc/mtab
+After=syslog.target network.target
+
+[Service]
+Type=oneshot
+ExecStart=-/usr/bin/unlink /etc/mtab
+ExecStart=/bin/cp /proc/self/mounts /etc/mtab
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This changes adds a oneshot (run once) systemd unit file to unlink and
re-create /etc/mtab as a regular file. This change allows the container
storage check to properly execute within confines of a chroot in 16.04
and onward.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>