### PR TITLE
Use OSA version to detect holland virtualenv

### DIFF
--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -176,7 +176,7 @@
         - name: Determine if holland is deployed in a venv
           find:
             paths: /openstack/venvs
-            patterns: "holland-{{ ansible_local['maas']['general']['maas_product_rpco_version'] }}"
+            patterns: "holland-{{ ansible_local['maas']['general']['maas_product_osa_version'] }}"
             file_type: directory
           register: holland_venv_detection
           delegate_to: "{{ groups['galera_all'][0] }}"

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -287,7 +287,7 @@ maas_holland_venv_enabled: "{{ ansible_local['maas']['general']['maas_holland_ve
 #
 # maas_holland_venv_bin: Set the path to the holland venv
 #
-maas_holland_venv_bin: "/openstack/venvs/holland-{{ ansible_local['maas']['general']['maas_product_rpco_version'] | default(rpc_release) }}/bin"
+maas_holland_venv_bin: "/openstack/venvs/holland-{{ ansible_local['maas']['general']['maas_product_osa_version'] | default(rpc_release) }}/bin"
 
 #
 # MaaS mysql check options


### PR DESCRIPTION
In the event that OSA and RPCO versions are not identical, this change
uses the OSA version to detect whether or not holland is deployed into a
virtualenv.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>