### PR TITLE
Update for functional non osp-mnaio environment

### DIFF
--- a/playbooks/common-tasks/maas-host-vendor-dell.yml
+++ b/playbooks/common-tasks/maas-host-vendor-dell.yml
@@ -42,3 +42,13 @@
     mode: "0644"
   tags:
     - maas-hosts-vendor-dell
+
+- name: Install openmanage powersupply checks
+  template:
+    src: "templates/rax-maas/openmanage-powersupply.yaml.j2"
+    dest: "/etc/rackspace-monitoring-agent.conf.d/openmanage-powersupply--{{ inventory_hostname }}.yaml"
+    owner: "root"
+    group: "root"
+    mode: "0644"
+  tags:
+    - maas-hosts-vendor-dell

--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -199,14 +199,10 @@ def get_args():
     parser.add_argument('--name',
                         required=True,
                         help='Ceph client name')
-    # add deploy_osp arg
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument(
-        '--' + 'deploy_osp', nargs='?', default=False, const=True,
-        type=bool)
-    group.add_argument('--no' + 'deploy_osp', dest='deploy_osp',
-                       action='store_false')
-
+    parser.add_argument('--deploy_osp',
+                        action='store_true',
+                        default=False,
+                        help='Option for extending into OSP environments')
     parser.add_argument('--keyring',
                         required=True,
                         help='Ceph client keyring')

--- a/playbooks/files/rax-maas/plugins/openmanage.py
+++ b/playbooks/files/rax-maas/plugins/openmanage.py
@@ -23,7 +23,8 @@ from maas_common import print_output
 from maas_common import status_err
 from maas_common import status_ok
 
-SUPPORTED_VERSIONS = set(["7.1.0", "7.4.0", "8.3.0", "8.4.0", "9.1.0"])
+SUPPORTED_VERSIONS = set(["7.1.0", "7.4.0", "8.3.0", "8.4.0", "9.1.0",
+                          "9.2.0"])
 OM_PATTERN = '(?:%(field)s)\s+:\s+(%(group_pattern)s)'
 CHASSIS = re.compile(OM_PATTERN % {'field': '^Health', 'group_pattern': '\w+'},
                      re.MULTILINE)

--- a/playbooks/templates/rax-maas/ceph_cluster_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_cluster_stats.yaml.j2
@@ -2,11 +2,11 @@
 {% set label = "ceph_cluster_stats" %}
 {% set check_name = label+'--'+inventory_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
-{% if (maas_rpc_legacy_ceph | bool) or (ansible_local['maas']['general']['deploy_osp'] | bool) %}
+{% if maas_rpc_legacy_ceph | bool %}
+{% set _ = ceph_args.extend(["--container-name", container_name]) %}
+{% endif %}
 {% if (ansible_local['maas']['general']['deploy_osp'] | bool) %}
 {% set _ = ceph_args.extend(["--deploy_osp"]) %}
-{% endif %}
-{% set _ = ceph_args.extend(["--container-name", container_name]) %}
 {% endif %}
 {% set _ = ceph_args.extend(["cluster"]) %}
 {% set _ceph_args = ceph_args | to_yaml(width=1000) %}

--- a/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_mon_stats.yaml.j2
@@ -2,11 +2,11 @@
 {% set label = "ceph_mon_stats" %}
 {% set check_name = label+'--'+inventory_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
-{% if (maas_rpc_legacy_ceph | bool) or (ansible_local['maas']['general']['deploy_osp'] | bool) %}
+{% if maas_rpc_legacy_ceph | bool %}
+{% set _ = ceph_args.extend(["--container-name", container_name]) %}
+{% endif %}
 {% if (ansible_local['maas']['general']['deploy_osp'] | bool) %}
 {% set _ = ceph_args.extend(["--deploy_osp"]) %}
-{% endif %}
-{% set _ = ceph_args.extend(["--container-name", container_name]) %}
 {% endif %}
 {% set _ = ceph_args.extend(["mon", "--host", ansible_hostname]) %}
 {% set _ceph_args = ceph_args | to_yaml(width=1000) %}

--- a/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
@@ -2,11 +2,11 @@
 {% set label = "ceph_osd_stats" %}
 {% set check_name = label+'--'+inventory_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
-{% if (maas_rpc_legacy_ceph | bool) or (ansible_local['maas']['general']['deploy_osp'] | bool) %}
+{% if maas_rpc_legacy_ceph | bool %}
+{% set _ = ceph_args.extend(["--container-name", container_name]) %}
+{% endif %}
 {% if (ansible_local['maas']['general']['deploy_osp'] | bool) %}
 {% set _ = ceph_args.extend(["--deploy_osp"]) %}
-{% endif %}
-{% set _ = ceph_args.extend(["--container-name", container_name]) %}
 {% endif %}
 {% set _ = ceph_args.extend(["osd", "--osd_ids"]) %}
 {% set _ = ceph_args.append(ceph_osd_list | default([]) | join(' ')) %}

--- a/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_rgw_stats.yaml.j2
@@ -2,7 +2,9 @@
 {% set label = "ceph_rgw_stats" %}
 {% set check_name = label+'--'+inventory_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
-{% if radosgw_address is defined and radosgw_address != 'address' %}
+{% if (ansible_local['maas']['general']['deploy_osp'] | bool) %}
+{%   set _rgw_listen_addr = hostvars[inventory_hostname]['storage_ip'] %}
+{% elif radosgw_address is defined and radosgw_address != 'address' %}
 {%   set _rgw_listen_addr = radosgw_address %}
 {% elif radosgw_address_block is defined and radosgw_address_block != 'subnet' %}
 {%   set _rgw_listen_addr = hostvars[inventory_hostname]['ansible_all_ipv4_addresses'] | ipaddr(radosgw_address_block) | first %}


### PR DESCRIPTION
These changes allow for a physical OSP13 reference architecture
deployment with ceph. There were some assumptions and changes beyond
what was available to test within an osp mnaio.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>