### PR TITLE
Fix Kilo endpoint detection and venv pip options

### DIFF
--- a/playbooks/common-tasks/maas-venv-create.yml
+++ b/playbooks/common-tasks/maas-venv-create.yml
@@ -62,7 +62,9 @@
         name:
           - pip
           - setuptools
-        extra_args: "-U --isolated"
+        extra_args: >-
+          -U --isolated
+          {{ pip_install_options | default('') }}
         virtualenv: "{{ target_venv | default(maas_venv) }}"
 
     - name: Build pip package list

--- a/playbooks/maas-agent-setup.yml
+++ b/playbooks/maas-agent-setup.yml
@@ -78,7 +78,7 @@
         - name: Get keystone endpoint
           shell: |-
             . {{ rc_file_location }}
-            openstack endpoint list --interface internal --service keystone --format value
+            openstack endpoint list --interface {{ openrc_clouds_yml_interface | default('internal') }} --service keystone --format csv
           register: keystone_endpoint
           changed_when: False
           run_once: true
@@ -93,8 +93,8 @@
 
         - name: Set clouds.yaml facts
           set_fact:
-            keystone_service_internalurl: "{{ (keystone_endpoint.stdout_lines[-1]).strip().split()[-1] }}"
-            keystone_service_region: "{{ (keystone_endpoint.stdout_lines[-1]).split()[1] }}"
+            keystone_service_internalurl: "{{ (keystone_endpoint.stdout_lines[-1]).split(',')[-1].strip('\"') }}"
+            keystone_service_region: "{{ (keystone_endpoint.stdout_lines[-1]).split(',')[1].strip('\"') }}"
             openrc_os_password: "{{ (admin_password.stdout).strip().split('=')[-1] }}"
           no_log: True
 


### PR DESCRIPTION
The '--format value' option did not exist in Kilo. This change uses csv
format to identify the keystone endpoint, which also exists in later
versions. Also provides an interface override in-case the internal
interface is v2.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>