### PR TITLE
Enable release-specific disabled checks for RPCR OSP

### DIFF
--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -237,6 +237,12 @@
             path: /etc/rhosp-release
           register: osp_release_file
 
+        - name: Register /etc/rhosp-release codename
+          shell: awk -F"[()]" '{print $2}' /etc/rhosp-release
+          register: maas_product_osp_codename
+          when:
+            - osp_release_file.stat.exists | bool
+
         - name: Register /etc/rhosp-release version
           shell: cat /etc/rhosp-release | tr -dc '0-9.'
           register: maas_product_osp_version
@@ -251,6 +257,15 @@
             value: "{{ maas_product_osp_version.stdout }}"
           when:
             - maas_product_osp_version.changed | bool
+
+        - name: Set OSP release codename fact
+          ini_file:
+            path: "/etc/ansible/facts.d/maas.fact"
+            section: "general"
+            option: "maas_product_osp_codename"
+            value: "{{ maas_product_osp_codename.stdout | lower }}"
+          when:
+            - maas_product_osp_codename.changed | bool
 
         - name: Refresh local facts
           setup:
@@ -351,12 +366,21 @@
       set_fact:
         tmp_checks_merge: "{{ maas_excluded_checks }}"
 
-    - name: Merge maas_release_excluded_checks
+    - name: Merge maas_osa_release_excluded_checks
       set_fact:
-        tmp_checks_merge: "{{ tmp_checks_merge | union(maas_release_excluded_checks[ansible_local['maas']['general']['maas_product_osa_codename']]) }}"
+        tmp_checks_merge: "{{ tmp_checks_merge | union(maas_osa_release_excluded_checks[ansible_local['maas']['general']['maas_product_osa_codename']]) }}"
       when:
+        - not (deploy_osp | default(False) | bool)
         - ansible_local['maas']['general']['maas_product_osa_codename'] is defined
-        - maas_release_excluded_checks[ansible_local['maas']['general']['maas_product_osa_codename']] is defined
+        - maas_osa_release_excluded_checks[ansible_local['maas']['general']['maas_product_osa_codename']] is defined
+
+    - name: Merge maas_osp_release_excluded_checks
+      set_fact:
+        tmp_checks_merge: "{{ tmp_checks_merge | union(maas_osp_release_excluded_checks[ansible_local['maas']['general']['maas_product_osp_codename']]) }}"
+      when:
+        - deploy_osp | default(False) | bool
+        - ansible_local['maas']['general']['maas_product_osp_codename'] is defined
+        - maas_osp_release_excluded_checks[ansible_local['maas']['general']['maas_product_osp_codename']] is defined
 
     - name: Set maas_merged_excluded_checks fact
       ini_file:

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -554,9 +554,9 @@ maas_compat:
     horizon_service_port: '80'
 
 #
-# Release specific check exclusions
+# Release specific check exclusions for OSA
 #
-maas_release_excluded_checks:
+maas_osa_release_excluded_checks:
   1andone:
     - swift_time_sync_check
   kilo:
@@ -565,3 +565,11 @@ maas_release_excluded_checks:
     - glance_registry_local_check
   rocky:
     - glance_registry_local_check
+
+#
+# Release specific check exclusions for OSP
+#
+maas_osp_release_excluded_checks:
+  queens:
+    - filesystem_/var/lib/docker/overlay2
+    - filesystem_/var/lib/docker/containers


### PR DESCRIPTION
This change automatically disables known release-specific checks during
an OSP deployment.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>