### PR TITLE
Create additional check name for container_conntrack_count

### DIFF
--- a/playbooks/maas-container-conntrack.yml
+++ b/playbooks/maas-container-conntrack.yml
@@ -56,7 +56,7 @@
     - name: Install conntrack count checks
       template:
         src: "templates/rax-maas/conntrack_count.yaml.j2"
-        dest: "/etc/rackspace-monitoring-agent.conf.d/conntrack_count--{{ inventory_hostname }}.yaml"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/container_conntrack_count--{{ inventory_hostname }}.yaml"
         owner: "root"
         group: "root"
         mode: "0644"

--- a/playbooks/templates/rax-maas/conntrack_count.yaml.j2
+++ b/playbooks/templates/rax-maas/conntrack_count.yaml.j2
@@ -1,5 +1,9 @@
 {% from "templates/common/macros.jinja" import get_metadata with context %}
-{% set label = "conntrack_count" %}
+{% if inventory_hostname in groups['neutron_agents_container'] | default([]) %}
+{%   set label = "container_conntrack_count" %}
+{% else %}
+{%   set label = "conntrack_count" %}
+{% endif %}
 {% set check_name = label+'--'+inventory_hostname %}
 type        : agent.plugin
 label       : "{{ check_name }}"


### PR DESCRIPTION
This change fixes the conntrack_status check run in the
maas-container-conntrack.yml playbook to prevent overwriting the
physical conntrack_count check. This will create two separate checks with
different names off the same template.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>