### PR TITLE
Remove legacy disk utilisation and filebeat checks

### DIFF
--- a/playbooks/maas-host-cdm.yml
+++ b/playbooks/maas-host-cdm.yml
@@ -52,6 +52,18 @@
       when:
         - ansible_local['maas']['general']['deploy_osp'] | bool
 
+    - name: Remove legacy filebeat checks
+      file:
+        path: "/etc/rackspace-monitoring-agent.conf.d/disk_utilisation--{{ inventory_hostname }}.yaml"
+        state: absent
+
+    - name: Remove legacy disk utilisation checks
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_fileglob:
+        - "/etc/rackspace-monitoring-agent.conf.d/filebeat*"
+
   tasks:
     - name: Discover disk device facts
       gather_disk_device_facts:
@@ -72,7 +84,7 @@
       with_items:
         - "{{ maas_filesystem_overrides | default(maas_filesystem_monitors) }}"
 
-    - name: Install disk utilisation Checks
+    - name: Install disk utilisation checks
       template:
         src: "templates/rax-maas/disk_utilisation.yaml.j2"
         dest: "/etc/rackspace-monitoring-agent.conf.d/disk_utilisation_{{ item.key }}--{{ inventory_hostname }}.yaml"


### PR DESCRIPTION
This change removes two legacy checks, filebeat and disk utilisation,
from older deployments when upgrading playbooks.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>