### PR TITLE
Remove unused maas_current_group variable

### DIFF
--- a/playbooks/maas-agent-install.yml
+++ b/playbooks/maas-agent-install.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: hosts
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-agent-setup.yml
+++ b/playbooks/maas-agent-setup.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: hosts
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-ceph-mon.yml
+++ b/playbooks/maas-ceph-mon.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: mons
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-ceph-osd.yml
+++ b/playbooks/maas-ceph-osd.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: osds
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-ceph-rgw.yml
+++ b/playbooks/maas-ceph-rgw.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: rgws
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-container-conntrack.yml
+++ b/playbooks/maas-container-conntrack.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: neutron_agent
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-container-storage.yml
+++ b/playbooks/maas-container-storage.yml
@@ -48,10 +48,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: hosts
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-host-cdm.yml
+++ b/playbooks/maas-host-cdm.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: hosts
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-host-kernel.yml
+++ b/playbooks/maas-host-kernel.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: hosts
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-host-network.yml
+++ b/playbooks/maas-host-network.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: hosts
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-host-private-checks.yml
+++ b/playbooks/maas-host-private-checks.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: hosts
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-host-vendor.yml
+++ b/playbooks/maas-host-vendor.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: hosts
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-infra-galera.yml
+++ b/playbooks/maas-infra-galera.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: galera_all
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-infra-memcached.yml
+++ b/playbooks/maas-infra-memcached.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: memcached_all
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-infra-multipathd.yml
+++ b/playbooks/maas-infra-multipathd.yml
@@ -24,10 +24,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: multipathd_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:

--- a/playbooks/maas-infra-pacemaker.yml
+++ b/playbooks/maas-infra-pacemaker.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: shared-infra_hosts
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-infra-rabbitmq.yml
+++ b/playbooks/maas-infra-rabbitmq.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: rabbitmq_all
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-infra-rsyslogd.yml
+++ b/playbooks/maas-infra-rsyslogd.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: rsyslog_all
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-infra-tgtd.yml
+++ b/playbooks/maas-infra-tgtd.yml
@@ -24,10 +24,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: tgtd_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:

--- a/playbooks/maas-openstack-cinder.yml
+++ b/playbooks/maas-openstack-cinder.yml
@@ -24,10 +24,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: cinder_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -81,10 +77,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: cinder_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -114,10 +106,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: cinder_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Stop deployment of cinder backup
@@ -161,10 +149,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: cinder_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:

--- a/playbooks/maas-openstack-designate.yml
+++ b/playbooks/maas-openstack-designate.yml
@@ -24,10 +24,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: designate_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:

--- a/playbooks/maas-openstack-glance.yml
+++ b/playbooks/maas-openstack-glance.yml
@@ -24,10 +24,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: glance_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -81,10 +77,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: glance_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -96,13 +88,10 @@
         group: "root"
         mode: "0644"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml
     - vars/maas-openstack.yml
-
   environment: "{{ deployment_environment_variables | default({}) }}"
-
   tags:
     - maas-openstack-glance

--- a/playbooks/maas-openstack-heat.yml
+++ b/playbooks/maas-openstack-heat.yml
@@ -24,10 +24,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: heat_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -81,10 +77,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: heat_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -138,10 +130,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: heat_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:

--- a/playbooks/maas-openstack-horizon.yml
+++ b/playbooks/maas-openstack-horizon.yml
@@ -24,10 +24,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: horizon
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:

--- a/playbooks/maas-openstack-ironic.yml
+++ b/playbooks/maas-openstack-ironic.yml
@@ -24,10 +24,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: ironic_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -90,10 +86,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: ironic_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -121,10 +113,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: ironic_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:

--- a/playbooks/maas-openstack-keystone.yml
+++ b/playbooks/maas-openstack-keystone.yml
@@ -24,10 +24,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: keystone_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:

--- a/playbooks/maas-openstack-neutron.yml
+++ b/playbooks/maas-openstack-neutron.yml
@@ -24,10 +24,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: neutron_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -81,10 +77,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: neutron_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -114,10 +106,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: neutron_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -147,10 +135,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: neutron_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -166,7 +150,6 @@
         - ansible_local['maas']['general']['neutron_plugin_type'] is undefined
         - (neutron_plugin_type is undefined) or
           (neutron_plugin_type is search("lxb"))
-
 
   vars_files:
     - vars/main.yml
@@ -185,10 +168,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: neutron_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -225,10 +204,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: neutron_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -268,10 +243,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: neutron_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:

--- a/playbooks/maas-openstack-nova.yml
+++ b/playbooks/maas-openstack-nova.yml
@@ -24,10 +24,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: nova_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -57,10 +53,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: nova_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -123,10 +115,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: nova_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -156,10 +144,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: nova_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -189,10 +173,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: nova_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -231,10 +211,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: nova_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -264,10 +240,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: nova_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:

--- a/playbooks/maas-openstack-octavia.yml
+++ b/playbooks/maas-openstack-octavia.yml
@@ -24,10 +24,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: octavia_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -95,10 +91,6 @@
   become: true
   gather_facts: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: octavia_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:

--- a/playbooks/maas-openstack-rally.yml
+++ b/playbooks/maas-openstack-rally.yml
@@ -45,10 +45,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: rally_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Safety check - ensure maas_rally is enabled
@@ -128,10 +124,6 @@
       when:
         - not (maas_rally_enabled | bool)
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: rally_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
     - name: Create rally constraint file
@@ -190,10 +182,6 @@
       meta: end_play
       when:
         - not (maas_rally_enabled | bool)
-
-    - name: Set the current group
-      set_fact:
-        maas_current_group: rally_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
@@ -627,10 +615,6 @@
       meta: end_play
       when:
         - not (maas_rally_enabled | bool)
-
-    - name: Set the current group
-      set_fact:
-        maas_current_group: rally_all
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 

--- a/playbooks/maas-openstack-swift.yml
+++ b/playbooks/maas-openstack-swift.yml
@@ -23,10 +23,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: swift_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -91,10 +87,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: swift_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -133,10 +125,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: swift_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -174,10 +162,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: swift_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -216,10 +200,6 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: swift_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -315,10 +295,6 @@
   vars:
     ansible_python_interpreter: "{{ target_venv | default(maas_venv) }}/bin/python"
   pre_tasks:
-    - name: Set the current group
-      set_fact:
-        maas_current_group: swift_all
-
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:

--- a/playbooks/maas-poller-install.yml
+++ b/playbooks/maas-poller-install.yml
@@ -23,10 +23,6 @@
         filter: ansible_local
         gather_subset: "!all"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: shared-infra_hosts
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml

--- a/playbooks/maas-poller-setup.yml
+++ b/playbooks/maas-poller-setup.yml
@@ -25,10 +25,6 @@
 
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
-    - name: Set the current group
-      set_fact:
-        maas_current_group: shared-infra_hosts
-
   vars_files:
     - vars/main.yml
     - vars/maas.yml


### PR DESCRIPTION
This change helps to reduce time to execute playbooks on large
environments. It is not currently used in any capacity so it's removed.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>