### PR TITLE
Refactor ceph osd alarms

### DIFF
--- a/playbooks/library/ceph_osd_host_facts
+++ b/playbooks/library/ceph_osd_host_facts
@@ -35,12 +35,33 @@ EXAMPLES = """
 """
 
 
+def discover_stale_osds(current_ids, deployed_ids):
+    """
+    Compares currently deployed OSD IDs to active OSD IDs.
+
+    Args:
+        current_ids (list): List generated from gather_facts method.
+        deployed_ids (list): List defined from search of existing MaaS check
+            templates. This is registered when the Ansible module is executed.
+
+    Returns:
+         stale_ids (list): List of OSD IDs that are not current. These are
+            intended to be returned by the module and removed in a follow-up
+            task.
+
+    """
+    # NOTE (npawelek): current_ids must be last
+    stale_ids = list(set(deployed_ids) - set(current_ids))
+    return stale_ids
+
+
 class OSDHostFacts(object):
     def __init__(self, module):
         self.state_change = False
         self.module = module
 
-    def gather_facts(self, hostname, container_name, deploy_osp=False):
+    def gather_facts(self, hostname, container_name, deployed_osd_list,
+                     deploy_osp=False):
         """Get information about OSDs."""
         ceph_command_string = "ceph"
         if deploy_osp:
@@ -65,9 +86,14 @@ class OSDHostFacts(object):
                 if _osd['name'] == hostname:
                     osd_ids = _osd['children']
             facts = osd_ids
+            stale_osd_list = discover_stale_osds(facts, deployed_osd_list)
             self.module.exit_json(
                 changed=self.state_change,
-                ansible_facts={'ceph_osd_list': facts})
+                ansible_facts={
+                    'ceph_osd_list': facts,
+                    'stale_osd_list': stale_osd_list
+                }
+            )
 
 
 def main():
@@ -83,6 +109,10 @@ def main():
                 required=False,
                 default=False,
                 type='bool'
+            ),
+            deployed_osd_list=dict(
+                required=True,
+                type='list'
             )
         ),
         supports_check_mode=False
@@ -91,7 +121,9 @@ def main():
     osd_host_facts.gather_facts(
         hostname=module.params.get('hostname'),
         container_name=module.params.get('container_name'),
-        deploy_osp=module.params.get('deploy_osp', False))
+        deploy_osp=module.params.get('deploy_osp', False),
+        deployed_osd_list=module.params.get('deployed_osd_list')
+    )
 
 
 if __name__ == '__main__':

--- a/playbooks/maas-ceph-osd.yml
+++ b/playbooks/maas-ceph-osd.yml
@@ -36,7 +36,7 @@
 - import_playbook: maas-ceph-raxmon.yml
 
 
-- name: Install checks for ceph mons
+- name: Install checks for ceph osds
   hosts: osds
   gather_facts: true
   user: "{{ ansible_user | default('root') }}"
@@ -68,23 +68,53 @@
         - ansible_local['maas']['general']['deploy_osp'] | bool
 
   tasks:
+    - name: Identify all deployed OSD check templates
+      find:
+        paths: /etc/rackspace-monitoring-agent.conf.d
+        patterns: "ceph_osd_[0-9]*"
+      register: osd_templates
+
+    - name: Define list of deployed OSD IDs
+      set_fact:
+        deployed_osds_list: "{{ deployed_osds_list | default([]) }} + [{{ item.path.split('_')[2] | int }}]"
+      with_items:
+        - "{{ osd_templates.files }}"
+
     - name: Discover Ceph facts
       ceph_osd_host_facts:
         hostname: "{{ ansible_hostname }}"
         container_name: "{{ container_name | default(inventory_hostname) }}"
         deploy_osp: "{{ ansible_local['maas']['general']['deploy_osp'] | bool }}"
+        deployed_osd_list: "{{ deployed_osds_list | default([]) }}"
       tags:
         - always
 
   post_tasks:
+    - name: Remove legacy osd_stats_check template
+      file:
+        path: "/etc/rackspace-monitoring-agent.conf.d/ceph_osd_stats.yaml--{{ inventory_hostname }}.yaml"
+        state: absent
+
+    - name: Remove osd_stats_check with stale OSD IDs
+      file:
+        path: "/etc/rackspace-monitoring-agent.conf.d/ceph_osd_{{ item | string }}_stats.yaml--{{ inventory_hostname }}.yaml"
+        state: absent
+      with_items:
+        - "{{ stale_osd_list }}"
+      when:
+        - stale_osd_list is defined
+        - stale_osd_list | length > 0
+
     - name: Install local osd checks
       template:
         src: "templates/rax-maas/ceph_osd_stats.yaml.j2"
-        dest: "/etc/rackspace-monitoring-agent.conf.d/ceph_osd_stats.yaml--{{ inventory_hostname }}.yaml"
+        dest: "/etc/rackspace-monitoring-agent.conf.d/ceph_osd_{{ item }}_stats.yaml--{{ inventory_hostname }}.yaml"
         owner: "root"
         group: "root"
         mode: "0644"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
+      with_items:
+        - "{{ ceph_osd_list }}"
 
   vars_files:
     - vars/main.yml

--- a/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
+++ b/playbooks/templates/rax-maas/ceph_osd_stats.yaml.j2
@@ -1,5 +1,6 @@
 {% from "templates/common/macros.jinja" import get_metadata with context %}
-{% set label = "ceph_osd_stats" %}
+{% set item_string = item | string %}
+{% set label = "ceph_osd_" + item_string + "_stats" %}
 {% set check_name = label+'--'+inventory_hostname %}
 {% set ceph_args = [maas_plugin_dir + "/ceph_monitoring.py", "--name", "client.raxmon", "--keyring", "/etc/ceph/ceph.client.raxmon.keyring"] %}
 {% if maas_rpc_legacy_ceph | bool %}
@@ -8,11 +9,10 @@
 {% if (ansible_local['maas']['general']['deploy_osp'] | bool) %}
 {% set _ = ceph_args.extend(["--deploy_osp"]) %}
 {% endif %}
-{% set _ = ceph_args.extend(["osd", "--osd_ids"]) %}
-{% set _ = ceph_args.append(ceph_osd_list | default([]) | join(' ')) %}
+{% set _ = ceph_args.extend(["osd", "--osd_id"]) %}
+{% set _ = ceph_args.append(item_string | default('')) %}
 {% set _ceph_args = ceph_args | to_yaml(width=1000) %}
 {% set ceph_args = _ceph_args %}
-
 type        : agent.plugin
 label       : "{{ check_name }}"
 period      : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
@@ -25,14 +25,12 @@ details     :
 {{ get_metadata(label).strip() }}
 {# Add extra metadata options with two leading white spaces #}
 alarms      :
-{% for osd_id in ceph_osd_list %}
-    ceph_warn_osd.{{ osd_id }} :
-        label                   : ceph_warn_osd.{{ osd_id }}--{{ inventory_hostname }}
+    ceph_warn_osd.{{ item_string }}:
+        label                   : ceph_warn_osd.{{ item_string }}--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('ceph_warn_osd.'+osd_id | string+'--'+inventory_hostname) | regex_search(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('ceph_warn_osd.' + item_string + '--' + inventory_hostname) | regex_search(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (metric["osd.{{ osd_id }}_up"] == 0) {
+            if (metric["osd.{{ item_string }}_up"] == 0) {
                 return new AlarmStatus(CRITICAL, "Ceph osd error.");
             }
-{% endfor %}


### PR DESCRIPTION
This change refactors the ceph_osd_stats checks to have a 1:1
relationship of checks to alarms. The refactor utilizes the local socket
versus using expensive ceph API calls. Playbooks will also
attempt to remove the legacy osd_stats_check templates including those
with stale OSD IDs.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>