### PR TITLE
Add OpenStack Stein including test scenario

### DIFF
--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -569,6 +569,9 @@ maas_osa_release_excluded_checks:
     - glance_registry_local_check
   rocky:
     - glance_registry_local_check
+  stein:
+    - glance_registry_local_check
+    - nova_consoleauth_check
 
 #
 # Release specific check exclusions for OSP

--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -370,6 +370,10 @@ else
       elif [[ "${RE_JOB_SCENARIO}" == "rocky" ]]; then
         git checkout "stable/rocky"  # Branch checkout of Rocky (Current Stable)
         export ANSIBLE_INVENTORY="/opt/openstack-ansible/inventory"
+
+      elif [[ "${RE_JOB_SCENARIO}" == "stein" ]]; then
+        git checkout "stable/stein"  # Branch checkout of Stein (Current Stable)
+        export ANSIBLE_INVENTORY="/opt/openstack-ansible/inventory"
       fi
 
       # Install ovs agent if applicable
@@ -387,7 +391,7 @@ else
       # NOTE(npawelek): Rocky requires a different version to be set, all other
       # releases work with the existing pin
       case ${RE_JOB_SCENARIO} in
-        rocky)
+        rocky|stein)
           true
           ;;
         *)

--- a/tests/test-ansible-functional.sh
+++ b/tests/test-ansible-functional.sh
@@ -60,11 +60,9 @@ elif [[ ${RE_JOB_SCENARIO} == ceph ]]; then
   export ANSIBLE_INVENTORY="/opt/rpc-ceph/tests/inventory,/opt/magnanimous-turbo-chainsaw/overlay-inventory.yml"
   export ANSIBLE_OVERRIDES="/opt/rpc-ceph/tests/test-vars.yml"
 else
-  # Ansible Inventory will be set to OSA
+  # Ansible inventory will be retained from definition in aio-create.sh
+  # or be set to legacy OSA default.
   export ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY:-/opt/openstack-ansible/playbooks/inventory}"
-  if [[ "${RE_JOB_SCENARIO}" == "queens" ]]; then
-   export ANSIBLE_INVENTORY="/opt/openstack-ansible/inventory"
-  fi
 fi
 
 echo "WORKING_DIR: ${WORKING_DIR}"
@@ -94,7 +92,7 @@ esac
 # ansible that is not available in liberty and mitaka. There is no reason
 # to run it in a ceph context either.
 case ${RE_JOB_SCENARIO} in
-  kilo|*liberty|*mitaka|ceph|osp13|rocky)
+  kilo|*liberty|*mitaka|ceph|osp13|rocky|stein)
     export TEST_PLAYBOOK="${TEST_PLAYBOOK:-$WORKING_DIR/tests/test.yml}"
     ;;
   *)

--- a/tests/user_stein_vars.yml
+++ b/tests/user_stein_vars.yml
@@ -1,0 +1,46 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE(cfarquhar): The scenarios that create instances are disabled for now
+# since public cloud AIOs are unreliable in terms of performance.
+maas_rally_enabled: true
+maas_rally_check_overrides:
+  cinder:
+    enabled: false
+  glance:
+    enabled: true
+  keystone:
+    enabled: true
+  neutron_ports:
+    enabled: true
+  neutron_secgroups:
+    enabled: true
+  nova:
+    enabled: false
+  nova_cinder:
+    enabled: false
+  swift:
+    enabled: true
+    extra_user_roles:
+      - "swiftoperator"
+
+# Test pre-flight checks
+maas_pre_flight_check_enabled: true
+
+# Set test identifier
+maas_env_identifier: "{{ lookup('file', '/tmp/maas_env_identifier', errors='ignore') | default('') }}"
+
+# Set raxdc identifier
+maas_raxdc: false


### PR DESCRIPTION
This change adds the ability to deploy the openstack/openstack-ansible
stable/stein branch within rpc-maas tests.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>