### PR TITLE
Update maas_proxy_url logic

### DIFF
--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -299,10 +299,8 @@
         - ansible_local.maas.general.maas_raxdc is defined
 
     # NOTE(npawelek): The agents and pollers use an HTTP CONNECT method when
-    # establishing connectivity to the monitoring infrastructure. Unfortunately,
-    # testing this methodology will not work due to a bug in the ansible uri
-    # module. As a workaround, we use HTTP GET and add 404 as a valid response
-    # code. A 404 still represents we were able to make a successful connection
+    # establishing connectivity to the monitoring infrastructure. This will
+    # typically result in a 404 response.
     - name: maas_proxy_url block
       block:
         - name: Test direct http connectivity to agent endpoint
@@ -311,7 +309,10 @@
             validate_certs: "{{ maas_agent_endpoint.validate_certs }}"
             timeout: 5
             status_code: "{{ maas_agent_endpoint.status_code }}"
-          environment: {}
+          environment:
+            no_proxy: "{{ deployment_environment_variables.no_proxy }}"
+          when:
+            - deployment_environment_variables.no_proxy is defined
 
       rescue:
         - name: Test proxy http connectivity to agent endpoint
@@ -320,7 +321,9 @@
             validate_certs: "{{ maas_agent_endpoint.validate_certs }}"
             timeout: 5
             status_code: "{{ maas_agent_endpoint.status_code }}"
-          environment: "{{ deployment_environment_variables | default({}) }}"
+          environment:
+            http_proxy: "{{ deployment_environment_variables.http_proxy }}"
+            https_proxy: "{{ deployment_environment_variables.https_proxy | default(deployment_environment_variables.http_proxy) }}"
 
         - name: Set maas_proxy_url fact
           ini_file:


### PR DESCRIPTION
This change alters the proxy detection logic following alterations in
how MTC detects and builds proxy variables utilized by Ansible.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>