### PR TITLE
Bump embedded Ansible version to 2.7.11

### DIFF
--- a/playbooks/common-tasks/maas-infra-ubuntu-install.yml
+++ b/playbooks/common-tasks/maas-infra-ubuntu-install.yml
@@ -24,9 +24,8 @@
 
 - name: Ensure galera packages are installed
   apt:
-    pkg: "{{ item }}"
+    name: "{{ maas_galera_distro_packages }}"
     state: "{{ maas_package_state }}"
     update_cache: yes
     cache_valid_time: 600
   delegate_to: "{{ physical_host | default(ansible_host) }}"
-  with_items: "{{ maas_galera_distro_packages }}"

--- a/playbooks/common-tasks/maas-venv-create.yml
+++ b/playbooks/common-tasks/maas-venv-create.yml
@@ -26,15 +26,33 @@
   retries: 5
   delay: 2
 
+- name: Check for pip.conf
+  stat:
+    path: /root/.pip/pip.conf
+  register: pip_conf
+
+# NOTE(npawelek): The use of index-url deployed with OSA prevents
+# building an isolated virtualenv due to missing packages. Temporarily
+# comment this value to create the MaaS virualenv with PyPI, then
+# uncomment it upon completion.
+- name: Temporarily comment pip.conf index-url
+  replace:
+    path: /root/.pip/pip.conf
+    regexp: '^index-url'
+    replace: '#index-url'
+  when:
+    - pip_conf.stat.exists is defined
+    - pip_conf.stat.exists | bool
+
 - name: Create MaaS venv (--no-site-packages)
-  command: "virtualenv --no-site-packages --no-setuptools {{ target_venv | default(maas_venv) }}"
+  command: "virtualenv --no-site-packages {{ target_venv | default(maas_venv) }}"
   args:
     creates: "{{ target_venv | default(maas_venv) }}/bin/python"
   when:
     - not ansible_local['maas']['general']['deploy_osp'] | bool
 
 - name: Create MaaS venv (--system-site-packages)
-  command: "virtualenv --system-site-packages --no-setuptools {{ target_venv | default(maas_venv) }}"
+  command: "virtualenv --system-site-packages {{ target_venv | default(maas_venv) }}"
   args:
     creates: "{{ target_venv | default(maas_venv) }}/bin/python"
   when:
@@ -60,7 +78,6 @@
           command: >-
             {{ ansible_python_interpreter }} /tmp/get-pip.py
             --isolated
-            --no-setuptools
             --no-wheel
             {{ pip_install_options | default('') }}
       when:
@@ -107,3 +124,12 @@
       until: install_pip_packages is success
       retries: 5
       delay: 2
+
+- name: Revert pip.conf index-url
+  replace:
+    path: /root/.pip/pip.conf
+    regexp: '^#index-url'
+    replace: 'index-url'
+  when:
+    - pip_conf.stat.exists is defined
+    - pip_conf.stat.exists | bool

--- a/tests/test-ansible-functional.sh
+++ b/tests/test-ansible-functional.sh
@@ -137,11 +137,11 @@ function set_ansible_parameters {
 function setup_embedded_ansible {
   # Installation of embedded ansible for rpc-maas
   if [[ ! -d "/opt/magnanimous-turbo-chainsaw" ]]; then
-    export ANSIBLE_VERSION=2.6.12
+    export ANSIBLE_VERSION=2.7.11
     curl https://raw.githubusercontent.com/rcbops/magnanimous-turbo-chainsaw/master/scripts/setup.sh | bash
   fi
   pushd /opt/magnanimous-turbo-chainsaw/scripts
-    PS1="${PS1:-'\[\033[01;31m\]\h\[\033[01;34m\] \W \$\[\033[00m\] '}" ANSIBLE_VERSION=2.6.12 source /opt/magnanimous-turbo-chainsaw/scripts/setup-workspace.sh
+    PS1="${PS1:-'\[\033[01;31m\]\h\[\033[01;34m\] \W \$\[\033[00m\] '}" ANSIBLE_VERSION=2.7.11 source /opt/magnanimous-turbo-chainsaw/scripts/setup-workspace.sh
   popd
   export ANSIBLE_EMBED_BINARY="${ANSIBLE_EMBED_HOME}/bin/ansible-playbook -e \$USER_ALL_VARS"
   export ANSIBLE_BINARY="${ANSIBLE_BINARY:-$ANSIBLE_EMBED_BINARY}"


### PR DESCRIPTION
The most notable change upgrading Ansible from 2.6.12 to 2.7.11 is that
Ansible 2.7+ requires setuptools in order to build an isolated
virtualenv with --no-system-site-packages (default). Our typical OSA
deployments alternatively replace the --index-url with that of the repo
container for all pip related tasks. As setuptools is now required, but
not part of the repo, it will fail. These changes will temporarily
remove the index-url from the pip.conf to successfully build the
virtualenv.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>