### PR TITLE
Simplify maas_proxy_url logic

### DIFF
--- a/playbooks/maas-poller-setup.yml
+++ b/playbooks/maas-poller-setup.yml
@@ -40,7 +40,7 @@
   tasks:
     - name: Generate MaaS poller config
       template:
-        src: "templates/rax-maas/rackspace-monitoring-poller.cfg"
+        src: "templates/rax-maas/rackspace-monitoring-poller.cfg.j2"
         dest: /etc/rackspace-monitoring-poller.cfg
         mode: 0600
         owner: root

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -305,34 +305,13 @@
       when:
         - ansible_local.maas.general.maas_raxdc is defined
 
-    # NOTE(npawelek): The agents and pollers use an HTTP CONNECT method when
-    # establishing connectivity to the monitoring infrastructure. This will
-    # typically result in a 404 response.
     - name: maas_proxy_url block
       block:
         - name: Test direct http connectivity to agent endpoint
-          uri:
-            url: "{{ maas_agent_endpoint.url }}"
-            validate_certs: "{{ maas_agent_endpoint.validate_certs }}"
-            timeout: 5
-            status_code: "{{ maas_agent_endpoint.status_code }}"
-          environment:
-            no_proxy: "{{ deployment_environment_variables.no_proxy }}"
-          when:
-            - deployment_environment_variables.no_proxy is defined
+          shell: "echo Q | openssl s_client -connect {{ maas_agent_endpoint }}"
 
       rescue:
-        - name: Test proxy http connectivity to agent endpoint
-          uri:
-            url: "{{ maas_agent_endpoint.url }}"
-            validate_certs: "{{ maas_agent_endpoint.validate_certs }}"
-            timeout: 5
-            status_code: "{{ maas_agent_endpoint.status_code }}"
-          environment:
-            http_proxy: "{{ deployment_environment_variables.http_proxy }}"
-            https_proxy: "{{ deployment_environment_variables.https_proxy | default(deployment_environment_variables.http_proxy) }}"
-
-        - name: Set maas_proxy_url fact
+        - name: (fallback) Set maas_proxy_url fact
           ini_file:
             path: "/etc/ansible/facts.d/maas.fact"
             section: "general"

--- a/playbooks/maas-restart.yml
+++ b/playbooks/maas-restart.yml
@@ -25,25 +25,10 @@
         gather_subset: "!all"
 
   tasks:
-    - name: Restart rackspace-monitoring-poller (systemd)
-      service:
-        name: rackspace-monitoring-poller.service
-        state: restarted
-        sleep: 10
-      register: _maas_poller_restart
-      until: _maas_poller_restart is success
-      retries: 3
-      delay: 2
-      when:
-        - maas_private_monitoring_enabled | bool
-        - (physical_host | default(inventory_hostname)) in groups['shared-infra_hosts']
-        - ansible_distribution_version == "16.04" or (ansible_distribution | lower == "redhat")
-
-    - name: Restart rackspace-monitoring-poller (upstart)
+    - name: Restart rackspace-monitoring-poller
       service:
         name: rackspace-monitoring-poller
         state: restarted
-        sleep: 10
       register: _maas_poller_restart
       until: _maas_poller_restart is success
       retries: 3
@@ -51,7 +36,6 @@
       when:
         - maas_private_monitoring_enabled | bool
         - (physical_host | default(inventory_hostname)) in groups['shared-infra_hosts']
-        - ansible_distribution_version == "14.04"
 
     - name: Restart rackspace-monitoring-agent
       service:

--- a/playbooks/templates/rax-maas/rackspace-monitoring-poller.cfg
+++ b/playbooks/templates/rax-maas/rackspace-monitoring-poller.cfg
@@ -1,6 +1,0 @@
-monitoring_token {{ maas_agent_token }}
-monitoring_id {{ maas_entity_name }}
-monitoring_private_zones {{ maas_private_monitoring_zone }}
-{% if ansible_local['maas']['general']['maas_proxy_url'] is defined or maas_proxy_url is defined %}
-monitoring_proxy_url {{ (ansible_local['maas']['general']['maas_proxy_url'] | default(maas_proxy_url)) | bool }}
-{% endif %}

--- a/playbooks/templates/rax-maas/rackspace-monitoring-poller.cfg.j2
+++ b/playbooks/templates/rax-maas/rackspace-monitoring-poller.cfg.j2
@@ -1,6 +1,6 @@
-monitoring_id {{ maas_entity_name }}
 monitoring_token {{ maas_agent_token }}
-monitoring_upgrade {{ maas_agent_upgrade }}
+monitoring_id {{ maas_entity_name }}
+monitoring_private_zones {{ maas_private_monitoring_zone }}
 {% if ansible_local.maas.general.maas_proxy_url is defined or maas_proxy_url is defined %}
 monitoring_proxy_url {{ ansible_local.maas.general.maas_proxy_url | default(maas_proxy_url) }}
 {% endif %}

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -495,15 +495,9 @@ maas_pip_rally_packages:
   - rally
 
 #
-# agent endpoint A record
+# agent endpoint TLS location
 #
-maas_agent_endpoint:
-  url: "https://agent-endpoint-ord.monitoring.api.rackspacecloud.com"
-  validate_certs: false
-  status_code:
-    - 200
-    - 404
-    - 503
+maas_agent_endpoint: "agent-endpoint-ord.monitoring.api.rackspacecloud.com:443"
 
 #
 # Check to ensure no 'unknown' values are rendered into metadata


### PR DESCRIPTION
This changes removes usage of HTTP as the endpoints don't communicate
using HTTP. Instead, when a proxy is defined, we opt to use openssl
directly to determine whether the connection is possible without a
proxy. If this fails it will fallback to defining the maas_proxy_url
variable.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>