### PR TITLE
Update ceph auth for jewel

### DIFF
--- a/playbooks/common-tasks/maas-agent-ubuntu-install.yml
+++ b/playbooks/common-tasks/maas-agent-ubuntu-install.yml
@@ -19,6 +19,7 @@
     keyserver: "{{ maas_keys.keyserver | default(omit) }}"
     url: "{{ maas_keys.url | default(omit) }}"
     state: "{{ maas_keys.state }}"
+    validate_certs: "{{ maas_apt_validate_certs }}"
   register: add_repo_keys
   until: add_repo_keys is success
   retries: 3
@@ -30,6 +31,7 @@
     state: "{{ maas_repos.main.state }}"
     filename: "{{ maas_repos.main.filename | default(omit) }}"
     update_cache: yes
+    validate_certs: "{{ maas_apt_validate_certs }}"
   register: add_repos
   until: add_repos is success
   retries: 5

--- a/playbooks/common-tasks/maas-poller-ubuntu-install.yml
+++ b/playbooks/common-tasks/maas-poller-ubuntu-install.yml
@@ -19,6 +19,7 @@
     keyserver: "{{ maas_keys.keyserver | default(omit) }}"
     url: "{{ maas_keys.url | default(omit) }}"
     state: "{{ maas_keys.state }}"
+    validate_certs: "{{ maas_apt_validate_certs }}"
   register: add_repo_keys
   until: add_repo_keys is success
   retries: 3
@@ -30,6 +31,7 @@
     state: "{{ maas_repos.poller.state }}"
     filename: "{{ maas_repos.main.filename | default(omit) }}"
     update_cache: yes
+    validate_certs: "{{ maas_apt_validate_certs }}"
   register: add_repos
   until: add_repos is success
   retries: 5

--- a/playbooks/files/rax-maas/tools/rpc-maas-tool.py
+++ b/playbooks/files/rax-maas/tools/rpc-maas-tool.py
@@ -223,11 +223,12 @@ class RpcMaasAgentConfig(object):
         """Read all config files in agentconfdpath"""
         self.checks = {}
         for path in os.listdir(self.agentconfdpath):
-            check = self._parse_config_file(
-                os.path.join(self.agentconfdpath, path)
-            )
-            if not str2bool(check.get('disabled')):
-                self.checks[check['label']] = check
+            if path.endswith('.yaml'):
+                check = self._parse_config_file(
+                    os.path.join(self.agentconfdpath, path)
+                )
+                if not str2bool(check.get('disabled')):
+                    self.checks[check['label']] = check
         else:
             return self.checks
 

--- a/playbooks/maas-ceph-raxmon.yml
+++ b/playbooks/maas-ceph-raxmon.yml
@@ -41,10 +41,14 @@
   hosts: maas_mon_hosts
   gather_facts: true
   become: true
+  vars:
+    maas_auth: "auth caps client.raxmon mon 'allow r'"
+    maas_mgr_auth: "auth caps client.raxmon mon 'allow r' mgr 'allow *'"
   pre_tasks:
-    - name: Add ceph command line alias string
+    - name: Add ceph variable facts
       set_fact:
-        ceph_command: "{{ (ansible_local['maas']['general']['deploy_osp'] | bool) | ternary('docker exec ceph-mon-' ~ inventory_hostname ~ ' ceph --cluster ceph', 'ceph') }}"
+        ceph_command: "{{ (ansible_local.maas.general.deploy_osp | bool) | ternary('docker exec ceph-mon-' ~ inventory_hostname ~ ' ceph --cluster ceph', 'ceph') }}"
+        ceph_auth_parameters: "{{ (ansible_local.maas.general.maas_product_ceph_version is version('12.0.0', '<') | bool) | ternary(maas_auth, maas_mgr_auth) }}"
 
     - name: Create ceph monitoring client
       command: "{{ ceph_command }} auth get-or-create client.raxmon"
@@ -52,8 +56,8 @@
       tags:
         - skip_ansible_lint
 
-    - name: Add mgr auth for client.raxmon
-      command: "{{ ceph_command }} auth caps client.raxmon mon 'allow r' mgr 'allow *'"
+    - name: Add auth for client.raxmon
+      command: "{{ ceph_command }} {{ ceph_auth_parameters }}"
       tags:
         - skip_ansible_lint
 
@@ -70,3 +74,4 @@
   tags:
     - maas-ceph
     - always
+

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -238,7 +238,6 @@
             filter: ansible_local
             gather_subset: "!all"
       when:
-        - not (deploy_osp | default(False) | bool)
         - groups['ceph_all'] | default([]) | length > 0
 
     - name: rhosp release block
@@ -452,6 +451,17 @@
         - ansible_local['maas']['general']['maas_product_osa_version'] is defined
         - ansible_local['maas']['general']['maas_product_rpco_version'] is defined
 
+    - name: Set RHOSP product metadata fact
+      ini_file:
+        path: "/etc/ansible/facts.d/maas.fact"
+        section: "general"
+        option: "maas_env_product"
+        value: "osp"
+      when:
+        - ansible_local['maas']['general']['maas_product_osa_version'] is undefined
+        - ansible_local['maas']['general']['maas_product_rpco_version'] is undefined
+        - deploy_osp | default(False) | bool
+
     - name: Set ceph product metadata fact
       ini_file:
         path: "/etc/ansible/facts.d/maas.fact"
@@ -463,18 +473,6 @@
         - ansible_local['maas']['general']['maas_product_osa_version'] is undefined
         - ansible_local['maas']['general']['maas_product_rpco_version'] is undefined
         - ansible_local['maas']['general']['maas_product_ceph_version'] is defined
-
-    - name: Set RHOSP product metadata fact
-      ini_file:
-        path: "/etc/ansible/facts.d/maas.fact"
-        section: "general"
-        option: "maas_env_product"
-        value: "osp"
-      when:
-        - ansible_local['maas']['general']['maas_product_osa_version'] is undefined
-        - ansible_local['maas']['general']['maas_product_rpco_version'] is undefined
-        - ansible_local['maas']['general']['maas_product_ceph_version'] is undefined
-        - deploy_osp | default(False) | bool
 
   vars_files:
     - vars/main.yml

--- a/playbooks/templates/common/macros.jinja
+++ b/playbooks/templates/common/macros.jinja
@@ -22,12 +22,21 @@ metadata:
 {% if ansible_local['maas']['general']['maas_env_product'] is defined and ansible_local['maas']['general']['maas_env_product'] == 'rpco' %}
   product_version: "{{ ansible_local['maas']['general']['maas_product_rpco_version'] | default('unknown') }}"
   osa_version: "{{ ansible_local['maas']['general']['maas_product_osa_version'] | default('unknown') }}"
+{% if ansible_local['maas']['general']['maas_product_ceph_version'] is defined %}
+  ceph_version: "{{ ansible_local['maas']['general']['maas_product_ceph_version'] | default('unknown') }}"
+{% endif %}
 {% elif ansible_local['maas']['general']['maas_env_product'] is defined and ansible_local['maas']['general']['maas_env_product'] == 'osa' %}
   osa_version: "{{ ansible_local['maas']['general']['maas_product_osa_version'] | default('unknown') }}"
-{% elif ansible_local['maas']['general']['maas_env_product'] is defined and ansible_local['maas']['general']['maas_env_product'] == 'ceph' %}
-  product_version: "{{ ansible_local['maas']['general']['maas_product_ceph_version'] | default('unknown') }}"
+{% if ansible_local['maas']['general']['maas_product_ceph_version'] is defined %}
+  ceph_version: "{{ ansible_local['maas']['general']['maas_product_ceph_version'] | default('unknown') }}"
+{% endif %}
 {% elif ansible_local['maas']['general']['maas_env_product'] is defined and ansible_local['maas']['general']['maas_env_product'] == 'osp' %}
   product_version: "{{ ansible_local['maas']['general']['maas_product_osp_version'] | default('unknown') }}"
+{% if ansible_local['maas']['general']['maas_product_ceph_version'] is defined %}
+  ceph_version: "{{ ansible_local['maas']['general']['maas_product_ceph_version'] | default('unknown') }}"
+{% endif %}
+{% elif ansible_local['maas']['general']['maas_env_product'] is defined and ansible_local['maas']['general']['maas_env_product'] == 'ceph' %}
+  product_version: "{{ ansible_local['maas']['general']['maas_product_ceph_version'] | default('unknown') }}"
 {% endif %}
   rpc_maas_version: "{{ lookup('pipe', 'cd ' + playbook_dir + ' && git describe --tags --abbrev=0') }}"
   rpc_maas_deploy_date: "{{ ansible_local.maas.general.deploy_date }}"

--- a/playbooks/vars/maas-ubuntu.yml
+++ b/playbooks/vars/maas-ubuntu.yml
@@ -41,11 +41,9 @@ maas_galera_distro_packages:
   - mariadb-client
 
 #
-# MaaS GPG keys
+# Apt module certificate verification
 #
-maas_keys:
-  url: "https://monitoring.api.rackspacecloud.com/pki/agent/linux.asc"
-  state: "present"
+maas_apt_validate_certs: True
 
 #
 # MaaS poller repos


### PR DESCRIPTION
Added version comparison for ceph authentication as a result of a
customer deployed with ceph Jewel. The mgr auth command is only
accessible in Luminous onward. Added the ability to override apt
certificate validation.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>