### PR TITLE
Change requirements to opendev.org

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,10 +29,10 @@ setenv =
     PYTHONPATH={envsitepackagesdir}
     ### OSA specific call back files
     # Set the checkout to any supported tag, branch, or sha.
-    OSA_TESTS_CHECKOUT=b146d649e675d748a58af238c7b37138b8194f1f
+    OSA_TESTS_CHECKOUT=master
     OSA_REQUIREMENTS_CHECKOUT=master
-    UPPER_CONSTRAINTS_FILE=https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h={env:OSA_REQUIREMENTS_CHECKOUT:master}
-    OSA_TEST_DEPS=https://git.openstack.org/cgit/openstack/openstack-ansible-tests/plain/test-ansible-deps.txt?h={env:OSA_TESTS_CHECKOUT:master}
+    UPPER_CONSTRAINTS_FILE=https://opendev.org/openstack/requirements/raw/upper-constraints.txt?h={env:OSA_REQUIREMENTS_CHECKOUT:master}
+    OSA_TEST_DEPS=https://opendev.org/openstack/openstack-ansible-tests/raw/test-ansible-deps.txt?h={env:OSA_TESTS_CHECKOUT:master}
 
 
 [testenv:bindep]
@@ -94,7 +94,7 @@ commands =
 [testenv:tests_clone]
 commands =
     bash -c "if [ ! -d "{toxinidir}/tests/common" ]; then \
-               git clone https://git.openstack.org/openstack/openstack-ansible-tests {toxinidir}/tests/common; \
+               git clone https://opendev.org/openstack/openstack-ansible-tests {toxinidir}/tests/common; \
                pushd {toxinidir}/tests/common; \
                  git checkout {env:OSA_TESTS_CHECKOUT:master}; \
                popd; \
@@ -131,7 +131,7 @@ deps =
     {[testenv:ansible]deps}
 commands =
     {[testenv:tests_clone]commands}
-    bash -c "{toxinidir}/tests/common/test-ansible-syntax.sh"
+    bash -c "PIP_OPTS=' --isolated' {toxinidir}/tests/common/test-ansible-syntax.sh"
 
 
 [testenv:ansible-lint]
@@ -139,7 +139,7 @@ deps =
     {[testenv:ansible]deps}
 commands =
     {[testenv:tests_clone]commands}
-    bash -c "{toxinidir}/tests/common/test-ansible-lint.sh"
+    bash -c "PIP_OPTS=' --isolated' {toxinidir}/tests/common/test-ansible-lint.sh"
 
 
 [testenv:linters]


### PR DESCRIPTION
The transition from git.openstack.org to opendev.org has caused some
issues with TLS certificate verification. Since the resources are simply
redirecting, this change attempts to point them at the new location
instead. Also updates PIP_OPTS to include isolated and checkout latest
branch of openstack-ansible-tests.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>