### PR TITLE
Re-enable octavia playbooks and ensure functionality

### DIFF
--- a/playbooks/maas-openstack-all.yml
+++ b/playbooks/maas-openstack-all.yml
@@ -53,9 +53,9 @@
   tags:
     - maas-openstack
 
-#- import_playbook: maas-openstack-octavia.yml
-#  tags:
-#    - maas-openstack
+- import_playbook: maas-openstack-octavia.yml
+  tags:
+    - maas-openstack
 
 - import_playbook: maas-openstack-swift.yml
   tags:

--- a/playbooks/maas-openstack-octavia.yml
+++ b/playbooks/maas-openstack-octavia.yml
@@ -27,6 +27,31 @@
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
+    - name: Set OSA rc file fact
+      set_fact:
+        rc_file_location: "{{ maas_openrc | default('/root/openrc') }}"
+      when:
+        - not (ansible_local.maas.general.deploy_osp | bool)
+
+    - name: Set OSP rc file fact
+      set_fact:
+        rc_file_location: "{{ maas_stackrc | default(maas_openrc) }}"
+      when:
+        - ansible_local.maas.general.deploy_osp | bool
+
+    - name: Get Octavia project ID
+      shell: |-
+        . {{ rc_file_location }}
+        openstack project show service -c id -f value
+      register: octavia_project_return
+      delegate_to: "{{ groups['utility_all'][0] }}"
+      tags:
+        - skip_ansible_lint
+
+    - name: Set Octavia project ID
+      set_fact:
+        octavia_project_id: "{{ octavia_project_return.stdout }}"
+
     - name: Install octavia process check
       template:
         src: "templates/rax-maas/octavia_process_check.yaml.j2"
@@ -35,37 +60,6 @@
         group: "root"
         mode: "0644"
       delegate_to: "{{ physical_host | default(ansible_host) }}"
-
-    - name: Get project id (RPC-O)
-      shell: ". {{ maas_openrc | default('/root/openrc') }} && openstack project list --user octavia -c ID -f value"
-      register: octavia_project_return_rpco
-      delegate_to: "{{ groups['utility_all'][0] }}"
-      when:
-        - not (ansible_local.maas.general.deploy_osp | bool)
-      tags:
-        - skip_ansible_lint
-
-    - name: Set project id when rpc-o
-      set_fact:
-        octavia_project_id: "{{ octavia_project_return_rpco.stdout }}"
-      when:
-        - not (ansible_local.maas.general.deploy_osp | bool)
-
-    - name: Get project id (RPC-R)
-      shell: ". {{ maas_stackrc | default(maas_openrc) }} && openstack project show service -c id -f value"
-      register: octavia_project_return_rpcr
-      run_once: true
-      delegate_to: "localhost"
-      when:
-        - ansible_local.maas.general.deploy_osp | bool
-      tags:
-        - skip_ansible_lint
-
-    - name: Set project id when rpc-r
-      set_fact:
-        octavia_project_id: "{{ octavia_project_return_rpcr.stdout }}"
-      when:
-        - ansible_local.maas.general.deploy_osp | bool
 
     - name: Install octavia quota check
       template:
@@ -86,34 +80,26 @@
 
 
 - name: Install checks for openstack octavia API
-  hosts: "octavia_api"
+  hosts: "octavia-api"
   user: "{{ ansible_user | default('root') }}"
   become: true
   gather_facts: true
+  vars:
+    ansible_python_interpreter: "{{ target_venv | default(maas_venv) }}/bin/python"
   pre_tasks:
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
-    - name: Add load-balancer member role (RPC-O)
-      shell: ". {{ maas_openrc | default('/root/openrc') }} && openstack role add --project $OS_PROJECT_NAME --user $OS_USERNAME load-balancer_observer"
-      delegate_to: "{{ groups['utility_all'][0] }}"
-      when:
-        - not (ansible_local.maas.general.deploy_osp | bool)
-      tags:
-        - skip_ansible_lint
-
-    - name: Add load-balancer member role (RPC-R)
-      shell: |
-        . {{ maas_stackrc | default(maas_openrc) }} && \
-        openstack role assignment list --project $OS_PROJECT_NAME --user $OS_USERNAME | \
-        grep $(openstack role show load-balancer_observer -c id -f value) || \
-        openstack role add --project $OS_PROJECT_NAME --user $OS_USERNAME load-balancer_observer
-      delegate_to: "localhost"
+    - name: Ensure Octavia observer member role assignment
+      os_user_role:
+        cloud: default
+        interface: internal
+        role: "{{ octavia_observer_role_name }}"
+        project: "{{ octavia_project }}"
+        user: "{{ octavia_user }}"
+        state: present
+      delegate_to: localhost
       run_once: true
-      when:
-        - ansible_local.maas.general.deploy_osp | bool
-      tags:
-        - skip_ansible_lint
 
     - name: Install octavia api checks
       template:

--- a/playbooks/maas-openstack-octavia.yml
+++ b/playbooks/maas-openstack-octavia.yml
@@ -85,7 +85,7 @@
     - maas-openstack-octavia
 
 
-- name: Install checks for openstack octavia_api
+- name: Install checks for openstack octavia API
   hosts: "octavia_api"
   user: "{{ ansible_user | default('root') }}"
   become: true

--- a/playbooks/templates/rax-maas/lb_api_check_octavia.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_octavia.yaml.j2
@@ -8,7 +8,7 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (inventory_hostname != groups['octavia_api'][0] or check_name | regex_search(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['octavia-api'][0] or check_name | regex_search(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ octavia_api_ip | default(maas_external_ip_address) }}"
 details           :

--- a/playbooks/templates/rax-maas/octavia_process_check.yaml.j2
+++ b/playbooks/templates/rax-maas/octavia_process_check.yaml.j2
@@ -17,7 +17,7 @@ details     :
 {{ get_metadata(label).strip() }}
 {# Add extra metadata options with two leading white spaces #}
 alarms      :
-{% for process in octavia_process_names_sanitized[arch] %}
+{% for process in octavia_process_names[arch] %}
     {{ process }}_process_status:
         label                   : {{ process }}_process_status--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"

--- a/playbooks/templates/rax-maas/private_lb_api_check_octavia.yaml.j2
+++ b/playbooks/templates/rax-maas/private_lb_api_check_octavia.yaml.j2
@@ -8,7 +8,7 @@ type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (inventory_hostname != groups['octavia_api'][0] or check_name | regex_search(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != groups['octavia-api'][0] or check_name | regex_search(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ octavia_api_ip | default(maas_external_ip_address) }}"
 details           :

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -147,18 +147,6 @@ octavia_process_names:
     - octavia-health-manager
     - octavia-housekeeping
 
-octavia_process_names_sanitized:
-  osa:
-    - uwsgi
-    - octavia-workerlog
-    - octavia-health-manager
-    - octavia-housekeeping
-  osp:
-    - octavia-api
-    - octavia-worker
-    - octavia-health-manager
-    - octavia-housekeeping
-
 octavia_quota_names:
   - octavia_cores_quota_usage
   - octavia_instances_quota_usage

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -155,6 +155,10 @@ octavia_quota_names:
   - octavia_volume_gb_quota_usage
   - octavia_num_volume_quota_usage
 
+octavia_observer_role_name: load-balancer_observer
+octavia_project: admin
+octavia_user: admin
+
 # Designate variables
 designate_process_names:
   - designate-sink


### PR DESCRIPTION
This change re-enables Octavia playbooks in maas-openstack-all.yml and
ensures the plugins are functionally working. Including commit from BjoernT
removing sanitized Octavia process names.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>