### PR TITLE
Add creation of .raxrc during verify to avoid expired token

### DIFF
--- a/playbooks/maas-verify.yml
+++ b/playbooks/maas-verify.yml
@@ -23,6 +23,14 @@
         filter: ansible_local
         gather_subset: "!all"
 
+    - name: Drop .raxrc file
+      template:
+        src: "templates/rax-maas/raxrc.j2"
+        dest: /root/.raxrc
+        mode: 0600
+        owner: root
+        group: root
+
   tasks:
     - name: Ensure log directories
       file:


### PR DESCRIPTION
@sdhardy ran into this during the Pipedrive upgrade this weekend.  maas-verify.yml doesn't do this currently, so an expired token means you end up need to push /root/.raxrc manually otherwise.  There doesn't seem to be much harm in preemptively doing anytime that it's run in case the token was updated in the YAML files.  He had done that since everyone came to the same conclusion about it being an expired token when everything was showing as failed during a subsequent maas-verify.yml run (after fixing some previously discovered issues).  But we didn't realize the .raxrc file was never updated until I looked directly at what the playbooks were doing (and ending up pushing it via an ad-hoc run to workaround it during the maintenance).

This fixes that.