### PR TITLE
Only perform cinder backend discovery when cinder exists

### DIFF
--- a/playbooks/library/service_discovery.py
+++ b/playbooks/library/service_discovery.py
@@ -399,7 +399,8 @@ def main():
         argument_spec=dict(
             raxdc=dict(required=True, type='bool'),
             internal_vip=dict(required=True),
-            external_vip=dict(required=True)
+            external_vip=dict(required=True),
+            cinder_discovery=dict(required=True, type='bool')
         ),
         supports_check_mode=False
     )
@@ -407,7 +408,8 @@ def main():
     discovery = ServiceDiscovery(module)
     discovery.parse_service_catalog()
     discovery.generate_facts()
-    discovery.get_cinder_backends()
+    if module.params.get('cinder_discovery') is True:
+        discovery.get_cinder_backends()
 
     module.exit_json(
         changed=False,

--- a/playbooks/maas-sdk-integration.yml
+++ b/playbooks/maas-sdk-integration.yml
@@ -150,6 +150,7 @@
         raxdc: "{{ maas_raxdc | bool }}"
         internal_vip: "{{ internal_lb_vip_address }}"
         external_vip: "{{ external_lb_vip_address }}"
+        cinder_discovery: "{{ (groups['cinder_all'] | default([])) | length > 0 }}"
       register: discovery
       when:
         - ansible_local.maas.general.maas_env_product != 'ceph'


### PR DESCRIPTION
Only perform cinder aspect of service discovery when cinder is detected
in the inventory.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>