### PR TITLE
Tweaks for RPCR OSP13 proxy and general swift

### DIFF
--- a/playbooks/files/rax-maas/plugins/swift-recon.py
+++ b/playbooks/files/rax-maas/plugins/swift-recon.py
@@ -67,7 +67,7 @@ def get_container_name(deploy_osp, for_ring):
         except (IndexError, subprocess.CalledProcessError):
             return False
     else:
-        get_containers = ("/usr/local/bin/docker ps -f status=running")
+        get_containers = ("docker ps -f status=running")
         containers_list = subprocess.check_output(get_containers.split())
 
         c = getcontainer('swift_proxy', containers_list)

--- a/playbooks/maas-openstack-swift.yml
+++ b/playbooks/maas-openstack-swift.yml
@@ -57,7 +57,7 @@
       set_fact:
         storage_address: "{{ storage_ip }}"
         openstack_release: ""
-        swift_recon_path: "/bin"
+        swift_recon_path: "/usr/bin"
       when:
         - ansible_local['maas']['general']['deploy_osp'] | bool
         - inventory_hostname in groups['swift_proxy']
@@ -66,7 +66,7 @@
       set_fact:
         storage_address: "{{ storage_mgmt_ip }}"
         openstack_release: ""
-        swift_recon_path: "/bin"
+        swift_recon_path: "/usr/bin"
       when:
         - ansible_local['maas']['general']['deploy_osp'] | bool
         - inventory_hostname in groups['swift_hosts']
@@ -203,9 +203,11 @@
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
-    - name: Set the swift release
+    - name: Set the swift release (OSA)
       set_fact:
         swift_release: "{{ ansible_local['maas']['general']['maas_product_osa_version'] }}"
+      when:
+        - ansible_local.maas.general.maas_product_osa_version is defined
 
     - name: Set recon nodes fact
       set_fact:

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -308,7 +308,7 @@
     - name: maas_proxy_url block
       block:
         - name: Test direct http connectivity to agent endpoint
-          shell: "echo Q | openssl s_client -connect {{ maas_agent_endpoint }}"
+          shell: "echo Q | timeout 60s openssl s_client -connect {{ maas_agent_endpoint }}"
 
       rescue:
         - name: (fallback) Set maas_proxy_url fact


### PR DESCRIPTION
These changes add the following functionality:

  * Add timeout to direct proxy connection attempts in
    maas-pre-flight.yml. This could previously take a considerable
    amount of time if the connection needed to be proxied.
  * Made some tweaks around the OSP aspects of swift to better account
    for what an environment will look like.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>