### PR TITLE
Move container tasks into block

### DIFF
--- a/playbooks/maas-container-storage.yml
+++ b/playbooks/maas-container-storage.yml
@@ -62,20 +62,21 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   tasks:
-    - name: Remove the old mtab object
-      file:
-        path: /etc/mtab
-      ignore_errors: yes
-
-    - name: Create new mtab file
-      copy:
-        src: /proc/self/mounts
-        dest: /etc/mtab
-        remote_src: true
-        mode: 0644
-
     - name: add mtab service
       block:
+        - name: Remove the old mtab object
+          file:
+            path: /etc/mtab
+            state: absent
+          ignore_errors: yes
+
+        - name: Create new mtab file
+          copy:
+            src: /proc/self/mounts
+            dest: /etc/mtab
+            remote_src: true
+            mode: 0644
+
         - name: Create mtab oneshot service
           template:
             src: templates/rax-maas/mtab_systemd_oneshot.j2


### PR DESCRIPTION
This change scopes mtab removal for Ubuntu 16.04 and up. Older 14.04
systems should not be impacted.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>