### PR TITLE
Add introspection to account for local rabbitmq management address

### DIFF
--- a/playbooks/files/rax-maas/plugins/openmanage.py
+++ b/playbooks/files/rax-maas/plugins/openmanage.py
@@ -24,7 +24,7 @@ from maas_common import status_err
 from maas_common import status_ok
 
 SUPPORTED_VERSIONS = set(["7.1.0", "7.4.0", "8.3.0", "8.4.0", "9.1.0",
-                          "9.2.0"])
+                          "9.2.0", "9.3.0"])
 OM_PATTERN = '(?:%(field)s)\s+:\s+(%(group_pattern)s)'
 CHASSIS = re.compile(OM_PATTERN % {'field': '^Health', 'group_pattern': '\w+'},
                      re.MULTILINE)

--- a/playbooks/maas-infra-rabbitmq.yml
+++ b/playbooks/maas-infra-rabbitmq.yml
@@ -127,6 +127,7 @@
           shell: ss -lt | grep -c 127.0.0.1:15672
           register: rabbit_local
           delegate_to: "{{ groups['rabbitmq_all'][0] }}"
+          failed_when: rabbit_local.rc >= 2
 
         - name: Set rabbitmq management to local address
           set_fact:

--- a/playbooks/maas-infra-rabbitmq.yml
+++ b/playbooks/maas-infra-rabbitmq.yml
@@ -121,9 +121,21 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   tasks:
+    - name: introspect rabbitmq management ip
+      block:
+        - name: Identify rabbitmq management listening address
+          shell: ss -lt | grep -c 127.0.0.1:15672
+          register: rabbit_local
+          delegate_to: "{{ groups['rabbitmq_all'][0] }}"
+
+        - name: Set rabbitmq management to local address
+          set_fact:
+            rabbit_local_address: "127.0.0.1"
+          when: rabbit_local.rc == 0
+
     - name: Get list of vhosts
       uri:
-        url: "http://{{ container_address | default('localhost') }}:{{ rabbitmq_mgmt_port | default('15672') }}/api/vhosts"
+        url: "http://{{ rabbit_local_address | default(container_address | default('localhost')) }}:{{ rabbitmq_mgmt_port | default('15672') }}/api/vhosts"
         user: "{{ maas_rabbitmq_user }}"
         password: "{{ maas_rabbitmq_password }}"
         return_content: yes
@@ -134,7 +146,7 @@
 
     - name: Ensure MaaS rabbitmq user has access to all openstack vhosts
       uri:
-        url: "http://{{ container_address| default('localhost') }}:{{ rabbitmq_mgmt_port | default('15672') }}/api/permissions/{{ item.name | urlencode | regex_replace('/','%2F') }}/{{ maas_rabbitmq_user | urlencode }}"
+        url: "http://{{ rabbit_local_address | default(container_address| default('localhost')) }}:{{ rabbitmq_mgmt_port | default('15672') }}/api/permissions/{{ item.name | urlencode | regex_replace('/','%2F') }}/{{ maas_rabbitmq_user | urlencode }}"
         user: "{{ maas_rabbitmq_user }}"
         password: "{{ maas_rabbitmq_password }}"
         method: PUT

--- a/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
+++ b/playbooks/templates/rax-maas/rabbitmq_status.yaml.j2
@@ -8,7 +8,7 @@ timeout     : "{{ maas_check_timeout_override[label] | default(maas_check_timeou
 disabled    : "{{ (inventory_hostname != groups['rabbitmq_all'][0] or check_name | regex_search(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 details     :
     file    : run_plugin_in_venv.sh
-    args    : ["{{ maas_plugin_dir }}/rabbitmq_status.py", "-H", "{{ container_address | default(internal_api_ip | default(ansible_host)) }}", "-n", "{{ ansible_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}", "--{{ rabbitmq_http_protocol }}"]
+    args    : ["{{ maas_plugin_dir }}/rabbitmq_status.py", "-H", "{{ rabbit_local_address | default(container_address | default(internal_api_ip | default(ansible_host))) }}", "-n", "{{ ansible_hostname.split('.')[0] }}", "-U", "{{ maas_rabbitmq_user }}", "-p", "{{ maas_rabbitmq_password }}", "--{{ rabbitmq_http_protocol }}"]
     timeout : {{ (maas_check_timeout_override[label] | default(maas_check_timeout) * 1000) }}
 {{ get_metadata(label).strip() }}
 {# Add extra metadata options with two leading white spaces #}

--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -142,7 +142,7 @@ octavia_process_names:
     - octavia-health-manager
     - octavia-housekeeping
   osp:
-    - octavia-api
+    - octavia_wsgi
     - octavia-worker
     - octavia-health-manager
     - octavia-housekeeping


### PR DESCRIPTION
This change adds some basic introspection to the maas-infra-rabbitmq.yml
playbooks. The latest minor release of OSP13 modified the rabbitmq.config
management section to lock down access explicitly to localhost. Dynamic
inventory cannot be updated as it would break prior releases, and puppet
can't effectively be modified to prevent changes in later OSP releases from
breaking it again.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>