### PR TITLE
Update monitorstack for new URL

### DIFF
--- a/playbooks/files/pip-constraints.txt
+++ b/playbooks/files/pip-constraints.txt
@@ -1,5 +1,5 @@
 ### Monitorstack plugin framework
-git+https://github.com/openstack/monitorstack@master#egg=monitorstack
+git+https://opendev.org/x/monitorstack@master#egg=monitorstack
 
 ### Requirements for RAX-MaaS
 apache-libcloud<2.0.0

--- a/playbooks/templates/rax-maas/rally-constraint.txt.j2
+++ b/playbooks/templates/rax-maas/rally-constraint.txt.j2
@@ -1,3 +1,3 @@
-git+https://github.com/openstack/monitorstack@master#egg=monitorstack
+git+https://opendev.org/x/monitorstack@master#egg=monitorstack
 git+{{ maas_rally_git_repo }}@{{ maas_rally_git_version }}#egg=rally
 keystoneauth1>=3.0.0


### PR DESCRIPTION
The monitorstack on github is moved to opendev.org
and was no longer installable through the old URL