### PR TITLE
Add functionality for verifying CPU softnet stats

### DIFF
--- a/playbooks/templates/rax-maas/network_stats_check.yaml.j2
+++ b/playbooks/templates/rax-maas/network_stats_check.yaml.j2
@@ -33,3 +33,13 @@ alarms:
               return new AlarmStatus(CRITICAL, "There have been more than {{ maas_network_tx_error_threshold }} network TX errors in the last {{ maas_check_period_override[label] | default(maas_check_period) }}s.");
             }
             return new AlarmStatus(OK, "#{physical_interface_tx_errors} network TX errors have been detected in the last {{ maas_check_period_override[label] | default(maas_check_period) }}s.");
+    softnet_stats:
+        label                   : softnet_stats--{{ inventory_hostname }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (('softnet_stats--'+inventory_hostname )| regex_search(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount=1
+            if (rate(metric['softnet_stats']) > {{ maas_softnet_stats_threshold }}) {
+              return new AlarmStatus(CRITICAL, "#{softnet_stats} softnet drops were detected over the last {{ maas_check_period_override[label] | default(maas_check_period) }}s. Contact OPCNetEng to investigate.");
+            }
+            return new AlarmStatus(OK, "#{softnet_stats} softnet drops were detected over the last {{ maas_check_period_override[label] | default(maas_check_period) }}s.");

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -473,6 +473,7 @@ maas_network_checks_list:
 #
 maas_network_rx_error_threshold: 64
 maas_network_tx_error_threshold: 64
+maas_softnet_stats_threshold: 0
 
 #
 # pip installable packages for given services used within maas


### PR DESCRIPTION
If a softnet backlog is full, it will silently drop packets without any
logged indication of it happening. The second column of
`/proc/net/softnet_stats` will increment on a per-CPU basis. This
functionality simply sums these values while ignoring what CPU the drop
happened on. The threshold has been configured as 0 because any value
for this indicates that the kernel must be tuned accordingly.

Closes #677

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>