### PR TITLE
Add standlone ceph option for OSP

### DIFF
--- a/playbooks/library/ceph_osd_host_facts
+++ b/playbooks/library/ceph_osd_host_facts
@@ -61,10 +61,10 @@ class OSDHostFacts(object):
         self.module = module
 
     def gather_facts(self, hostname, container_name, deployed_osd_list,
-                     deploy_osp=False):
+                     deploy_osp=False, osp_standalone=False):
         """Get information about OSDs."""
         ceph_command_string = "ceph"
-        if deploy_osp:
+        if deploy_osp and osp_standalone == False:
             ceph_command_string = (
                 "sudo docker exec {container_name} ceph "
                 "--cluster ceph").format(container_name=container_name)
@@ -110,6 +110,11 @@ def main():
                 default=False,
                 type='bool'
             ),
+            osp_standalone=dict(
+                required=False,
+                default=False,
+                type='bool'
+            ),
             deployed_osd_list=dict(
                 required=True,
                 type='list'
@@ -122,6 +127,7 @@ def main():
         hostname=module.params.get('hostname'),
         container_name=module.params.get('container_name'),
         deploy_osp=module.params.get('deploy_osp', False),
+        osp_standalone=module.params.get('osp_standalone', False),
         deployed_osd_list=module.params.get('deployed_osd_list')
     )
 

--- a/playbooks/maas-ceph-osd.yml
+++ b/playbooks/maas-ceph-osd.yml
@@ -57,15 +57,17 @@
 
     - name: Get the first osd container
       raw: /bin/docker ps -a -f status=running | awk '/ceph-osd/ {print $NF}' | head -1
-      when:
-        - ansible_local['maas']['general']['deploy_osp'] | bool
       register: osd_container_name
+      when:
+        - ansible_local.maas.general.deploy_osp | bool
+        - not ansible_local.maas.general.maas_osp_ceph_standalone | bool
 
     - name: Set container name for osp template
       set_fact:
         container_name: "{{ osd_container_name.stdout | trim }}"
       when:
         - ansible_local['maas']['general']['deploy_osp'] | bool
+        - not ansible_local.maas.general.maas_osp_ceph_standalone | bool
 
   tasks:
     - name: Identify all deployed OSD check templates
@@ -85,6 +87,7 @@
         hostname: "{{ ansible_hostname }}"
         container_name: "{{ container_name | default(inventory_hostname) }}"
         deploy_osp: "{{ ansible_local['maas']['general']['deploy_osp'] | bool }}"
+        osp_standalone: "{{ ansible_local.maas.general.maas_osp_ceph_standalone | default(True) | bool }}"
         deployed_osd_list: "{{ deployed_osds_list | default([]) }}"
       tags:
         - always

--- a/playbooks/maas-ceph-raxmon.yml
+++ b/playbooks/maas-ceph-raxmon.yml
@@ -47,7 +47,7 @@
   pre_tasks:
     - name: Add ceph variable facts
       set_fact:
-        ceph_command: "{{ (ansible_local.maas.general.deploy_osp | bool) | ternary('docker exec ceph-mon-' ~ inventory_hostname ~ ' ceph --cluster ceph', 'ceph') }}"
+        ceph_command: "{{ ((ansible_local.maas.general.deploy_osp | bool) and not (ansible_local.maas.general.maas_osp_ceph_standalone | default(False) | bool)) | ternary('docker exec ceph-mon-' ~ inventory_hostname ~ ' ceph --cluster ceph', 'ceph') }}"
         ceph_auth_parameters: "{{ (ansible_local.maas.general.maas_product_ceph_version is version('12.0.0', '<') | bool) | ternary(maas_auth, maas_mgr_auth) }}"
 
     - name: Create ceph monitoring client
@@ -74,4 +74,3 @@
   tags:
     - maas-ceph
     - always
-

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -234,6 +234,33 @@
           when:
             - maas_product_ceph_version.changed | bool
 
+        - name: Check for Docker command
+          command: docker --version
+          ignore_errors: true
+          changed_when: false
+          register: docker_check
+          delegate_to: "{{ groups['ceph_all'][0] }}"
+          when:
+            - deploy_osp | default(False) | bool
+
+        - name: Check for OSP standalone ceph
+          command: docker container list -q --filter status=running --filter name=ceph-mon
+          register: maas_osp_ceph_container
+          delegate_to: "{{ groups['ceph_all'][0] }}"
+          changed_when: false
+          when:
+            - deploy_osp | default(False) | bool
+            - docker_check.rc == 0
+
+        - name: Set OSP standalone ceph fact
+          ini_file:
+            path: "/etc/ansible/facts.d/maas.fact"
+            section: "general"
+            option: "maas_osp_ceph_standalone"
+            value: "{{ maas_osp_ceph_container.stdout != '' | default(True) | ternary(True, False) | bool }}"
+          when:
+            - deploy_osp | default(False) | bool
+
         - name: Refresh local facts
           setup:
             filter: ansible_local


### PR DESCRIPTION
These changes allow playbooks to properly execute on OSP environments
with standalone ceph. It effectively prevents the use of Docker
commands when standalone ceph is deployed on baremetal.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>