### PR TITLE
Add timeout to openssl proxy test

### DIFF
--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -308,7 +308,7 @@
     - name: maas_proxy_url block
       block:
         - name: Test direct http connectivity to agent endpoint
-          shell: "echo Q | openssl s_client -connect {{ maas_agent_endpoint }}"
+          shell: "timeout 60 bash -c 'echo Q | openssl s_client -connect {{ maas_agent_endpoint }}'"
 
       rescue:
         - name: (fallback) Set maas_proxy_url fact


### PR DESCRIPTION
This change removes the assumption that the openssl command will timeout
when attempting to reach an agent endpoint. The original command must be
encapsulated in bash to allow the timeout command to function properly.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>