### PR TITLE
Include time_squeeze in network stats check

### DIFF
--- a/playbooks/files/rax-maas/plugins/network_stats_check.py
+++ b/playbooks/files/rax-maas/plugins/network_stats_check.py
@@ -40,10 +40,13 @@ def physical_interface_errors():
 
 
 def get_softnet_stats():
-    softnet_stats = 0
+    softnet_stats = dict()
+    softnet_stats['packet_drop'] = 0
+    softnet_stats['time_squeeze'] = 0
     with open('/proc/net/softnet_stat', 'r') as f:
         for line in f:
-            softnet_stats += int(line.split()[1], 16)
+            softnet_stats['packet_drop'] += int(line.split()[1], 16)
+            softnet_stats['time_squeeze'] += int(line.split()[2], 16)
     return softnet_stats
 
 
@@ -65,4 +68,5 @@ if __name__ == '__main__':
             status_ok(m_name='maas_network_stats')
             for k, v in totals.items():
                 metric('physical_interface_%s' % k, 'int64', v)
-            metric('softnet_stats', 'int64', softnet_stats)
+            for k, v in softnet_stats.items():
+                metric('softnet_stats_%s' % k, 'int64', v)

--- a/playbooks/templates/rax-maas/network_stats_check.yaml.j2
+++ b/playbooks/templates/rax-maas/network_stats_check.yaml.j2
@@ -33,13 +33,13 @@ alarms:
               return new AlarmStatus(CRITICAL, "There have been more than {{ maas_network_tx_error_threshold }} network TX errors in the last {{ maas_check_period_override[label] | default(maas_check_period) }}s.");
             }
             return new AlarmStatus(OK, "#{physical_interface_tx_errors} network TX errors have been detected in the last {{ maas_check_period_override[label] | default(maas_check_period) }}s.");
-    softnet_stats:
-        label                   : softnet_stats--{{ inventory_hostname }}
+    softnet_stats_packet_drop:
+        label                   : softnet_stats_packet_drop--{{ inventory_hostname }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('softnet_stats--'+inventory_hostname )| regex_search(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('softnet_stats_packet_drop--'+inventory_hostname )| regex_search(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount=1
-            if (rate(metric['softnet_stats']) > {{ maas_softnet_stats_threshold }}) {
-              return new AlarmStatus(CRITICAL, "#{softnet_stats} softnet drops were detected over the last {{ maas_check_period_override[label] | default(maas_check_period) }}s. Contact OPCNetEng to investigate.");
+            if (rate(metric['softnet_stats_packet_drop']) > {{ maas_softnet_stats_packet_drop_threshold }}) {
+              return new AlarmStatus(CRITICAL, "Softnet packet drop was detected over the last {{ maas_check_period_override[label] | default(maas_check_period) }}s. Contact OPCNetEng to investigate.");
             }
-            return new AlarmStatus(OK, "#{softnet_stats} softnet drops were detected over the last {{ maas_check_period_override[label] | default(maas_check_period) }}s.");
+            return new AlarmStatus(OK, "Softnet packet drop was detected over the last {{ maas_check_period_override[label] | default(maas_check_period) }}s.");

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -473,7 +473,7 @@ maas_network_checks_list:
 #
 maas_network_rx_error_threshold: 64
 maas_network_tx_error_threshold: 64
-maas_softnet_stats_threshold: 0
+maas_softnet_stats_packet_drop_threshold: 0
 
 #
 # pip installable packages for given services used within maas


### PR DESCRIPTION
This change adds an additional metric for column 3 of
/proc/net/softnet_stat, which indicates an increasing counter for
time_squeeze per CPU. Increasing values indicates that kernel level
network tuning may be needed.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>