### PR TITLE
Add link to softnet packet drop alarm

### DIFF
--- a/playbooks/templates/rax-maas/network_stats_check.yaml.j2
+++ b/playbooks/templates/rax-maas/network_stats_check.yaml.j2
@@ -40,6 +40,6 @@ alarms:
         criteria                : |
             :set consecutiveCount=1
             if (rate(metric['softnet_stats_packet_drop']) > {{ maas_softnet_stats_packet_drop_threshold }}) {
-              return new AlarmStatus(CRITICAL, "Softnet packet drop was detected over the last {{ maas_check_period_override[label] | default(maas_check_period) }}s. Contact OPCNetEng to investigate.");
+              return new AlarmStatus(CRITICAL, "Softnet packet drop was detected over the last {{ maas_check_period_override[label] | default(maas_check_period) }}s. More information around tuning can be found at https://rax.io/packet_drops.");
             }
             return new AlarmStatus(OK, "Softnet packet drop was detected over the last {{ maas_check_period_override[label] | default(maas_check_period) }}s.");


### PR DESCRIPTION
This change modifies the alarm status to point to an internal wiki around
tuning systems to eliminate softnet packet drops.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>