### PR TITLE
Update hp_monitoring.py to catch predictive failures

### DIFF
--- a/playbooks/files/rax-maas/plugins/hp_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/hp_monitoring.py
@@ -36,8 +36,9 @@ def check_command(command, startswith, endswith):
         for line in lines:
             line = line.strip()
             if line.startswith(startswith):
-                matches = True
-                if not line.endswith(endswith):
+                if line.endswith(endswith):
+                    matches = True
+                else:
                     break
         else:
             if matches:
@@ -92,9 +93,14 @@ def get_powersupply_status(command, item):
                          'Condition', 'Ok')
 
 
-def get_drive_status(command):
+def get_logicaldrive_status(command):
     return check_command((command, 'ctrl', 'all', 'show', 'config'),
                          'logicaldrive', ('OK)', 'OK, Encrypted)'))
+
+
+def get_physicaldrive_status(command):
+    return check_command((command, 'ctrl', 'all', 'show', 'config'),
+                         'physicaldrive', ('OK)', 'OK, Encrypted)'))
 
 
 def get_controller_status(command):
@@ -156,7 +162,10 @@ def main():
         status['hardware_powersupply_status'] = \
             get_powersupply_status('hpasmcli', 'powersupply')
 
-    status['hardware_disk_status'] = get_drive_status(ssacli_bin)
+    status['hardware_logicaldrive_status'] = \
+        get_logicaldrive_status(ssacli_bin)
+    status['hardware_physicaldrive_status'] = \
+        get_physicaldrive_status(ssacli_bin)
     status['hardware_controller_status'] = get_controller_status(ssacli_bin)
     status['hardware_controller_cache_status'] = \
         get_controller_cache_status(ssacli_bin)

--- a/playbooks/templates/rax-maas/hp-check.yaml.j2
+++ b/playbooks/templates/rax-maas/hp-check.yaml.j2
@@ -40,14 +40,23 @@ alarms      :
             if (metric["hardware_controller_cache_status"] != 1) {
                 return new AlarmStatus(CRITICAL, "Hardware Controller Cache Error");
             }
-    hp-disk_status :
-        label                   : hp-disk--{{ inventory_hostname | quote }}
+    hp-logicaldrive_status :
+        label                   : hp-logicaldrive--{{ inventory_hostname | quote }}
         notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
-        disabled                : {{ (('hp-disk--'+inventory_hostname | quote) | regex_search(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        disabled                : {{ (('hp-logicaldrive--'+inventory_hostname | quote) | regex_search(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
         criteria                : |
             :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
-            if (metric["hardware_disk_status"] != 1) {
-                return new AlarmStatus(CRITICAL, "Physical Disk Error");
+            if (metric["hardware_logicaldrive_status"] != 1) {
+                return new AlarmStatus(CRITICAL, "A logical RAID volume is reporting a non-healthy value");
+            }
+    hp-physicaldrive_status :
+        label                   : hp-physicaldrive--{{ inventory_hostname | quote }}
+        notification_plan_id    : "{{ maas_notification_plan_override[label] | default(maas_notification_plan) }}"
+        disabled                : {{ (('hp-physicaldrive--'+inventory_hostname | quote) | regex_search(maas_excluded_alarms_regex)) | ternary('true', 'false') }}
+        criteria                : |
+            :set consecutiveCount={{ maas_alarm_local_consecutive_count }}
+            if (metric["hardware_physicaldrive_status"] != 1) {
+                return new AlarmStatus(CRITICAL, "A physical drive is reporting a non-healthy value");
             }
     hp-memory_status :
         label                   : hp-memory--{{ inventory_hostname | quote }}


### PR DESCRIPTION
This fixes a bug with the hp monitoring plugin which was only detecting
failures associated with logical volumes. When a physical drive is marked
as 'Predictive Failure' with the ssacli command line utility, the status
does not cause the logical volume to degrade. This change separates the
logicaldrive and physical drive metrics to ensure that predictive
failures are also accounted for.

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>