### PR TITLE
JIRA: RPCOS-51 Fix missing contextlibv2 suppress class

### DIFF
--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -359,6 +359,7 @@ maas_pip_packages:
   - requests
   - netaddr
   - ipaddress
+  - contextlib2
 
 #
 # pip extra packages for lxc containers


### PR DESCRIPTION
contextlibv2 0.4.0 is getting installed through dependancies into the
maas venv. Its missing the suppress class that is called later on
triggering a failure. Adding this to the maas_pip_packages installs
a later version fixing the issue.