### PR TITLE
JIRA-33: pip diskcache version issue

### DIFF
--- a/playbooks/files/pip-constraints.txt
+++ b/playbooks/files/pip-constraints.txt
@@ -11,6 +11,7 @@ lxc-python2
 psutil
 openstacksdk==0.37.0
 keystoneauth1
+diskcache==4.1.0
 
 ### General dependencies
 python-memcached

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -360,6 +360,7 @@ maas_pip_packages:
   - netaddr
   - ipaddress
   - contextlib2
+  - diskcache
 
 #
 # pip extra packages for lxc containers


### PR DESCRIPTION
It looks like on 23AUG20 diskcache started with versions 5.0.X.
This breaks the import on python 2 when checking for the 'Disk'
subclass.  Locking diskcache down to version 4.1.0 fixes the
issue.