### PR TITLE
JIRA: RPCOS-33 Disable vendor checks for director VM

### DIFF
--- a/playbooks/maas-host-vendor.yml
+++ b/playbooks/maas-host-vendor.yml
@@ -42,6 +42,7 @@
       include_tasks: "common-tasks/maas-host-vendor-{{ ansible_system_vendor.split()[0] | lower }}.yml"
       when:
         - maas_host_check | bool
+        - ansible_virtualization_role != "guest"
 
   vars_files:
     - vars/main.yml


### PR DESCRIPTION
When the director is on a VM, the playbooks look for
a dell or hp vendor check install playbook which doesn't
exist.  The ansible_virtualization_role var will be 'host'
for physical hardware and 'guest' for VMs. I'm using this
to filter out the install of the vendor checks.