### PR TITLE
fixing ceph_monitoring.py for nautilus

### DIFF
--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -120,11 +120,16 @@ def get_cluster_statistics(client=None, keyring=None, container_name=None,
                                   deploy_osp=deploy_osp)
     # Get overall cluster health
     # For luminous+ this is the ceph_status.health.status
-    ceph_health_status = ceph_status['health']['status']
+
+    try:
+      ceph_health_status = ceph_status['health']['overall_status']
+    except KeyError:
+      ceph_health_status = ceph_status['health']['status']
+
     metrics.append({
-        'name': 'cluster_health',
-        'type': 'uint32',
-        'value': STATUSES[ceph_health_status]})
+    'name': 'cluster_health',
+    'type': 'uint32',
+    'value': STATUSES[ceph_health_status]})
 
     # Collect epochs for the mon and osd maps
     metrics.append({'name': "monmap_epoch",

--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -120,10 +120,7 @@ def get_cluster_statistics(client=None, keyring=None, container_name=None,
                                   deploy_osp=deploy_osp)
     # Get overall cluster health
     # For luminous+ this is the ceph_status.health.status
-    # For < Luminous this is the ceph_status.health.overall_status
-    ceph_health_status = ceph_status['health']['overall_status']
-    if 'status' in ceph_status['health']:
-        ceph_health_status = ceph_status['health']['status']
+    ceph_health_status = ceph_status['health']['status']
     metrics.append({
         'name': 'cluster_health',
         'type': 'uint32',

--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -126,10 +126,9 @@ def get_cluster_statistics(client=None, keyring=None, container_name=None,
     except KeyError:
       ceph_health_status = ceph_status['health']['status']
 
-    metrics.append({
-    'name': 'cluster_health',
-    'type': 'uint32',
-    'value': STATUSES[ceph_health_status]})
+    metrics.append({'name': 'cluster_health',
+                    'type': 'uint32',
+                    'value': STATUSES[ceph_health_status]})
 
     # Collect epochs for the mon and osd maps
     metrics.append({'name': "monmap_epoch",

--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -122,9 +122,9 @@ def get_cluster_statistics(client=None, keyring=None, container_name=None,
     # For luminous+ this is the ceph_status.health.status
 
     try:
-      ceph_health_status = ceph_status['health']['overall_status']
+        ceph_health_status = ceph_status['health']['overall_status']
     except KeyError:
-      ceph_health_status = ceph_status['health']['status']
+        ceph_health_status = ceph_status['health']['status']
 
     metrics.append({'name': 'cluster_health',
                     'type': 'uint32',


### PR DESCRIPTION
ceph_health_status = ceph_status['health']['overall_status'] is no longer available through ceph status. Since this value does not exist, the plug-in crashes when run. Since we no longer have to check for any hammer or jewel clusters, removing the if statement is the best option to fix this. 