### PR TITLE
Fixing health check for nautilus

### DIFF
--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -121,9 +121,11 @@ def get_cluster_statistics(client=None, keyring=None, container_name=None,
     # Get overall cluster health
     # For luminous+ this is the ceph_status.health.status
     # For < Luminous this is the ceph_status.health.overall_status
-    ceph_health_status = ceph_status['health']['overall_status']
-    if 'status' in ceph_status['health']:
-        ceph_health_status = ceph_status['health']['status']
+    try:
+      ceph_health_status = ceph_status['health']['overall_status']
+    except KeyError:
+      ceph_health_status = ceph_status['health']['status']
+
     metrics.append({
         'name': 'cluster_health',
         'type': 'uint32',


### PR DESCRIPTION
ceph_health_status = ceph_status['health']['overall_status']
is no longer available through ceph status.