### PR TITLE
JIRA: RPCOS-33 Fix ceph_health for luminous

### DIFF
--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -121,10 +121,15 @@ def get_cluster_statistics(client=None, keyring=None, container_name=None,
     # Get overall cluster health
     # For luminous+ this is the ceph_status.health.status
     # For < Luminous this is the ceph_status.health.overall_status
-    try:
-      ceph_health_status = ceph_status['health']['overall_status']
-    except KeyError:
-      ceph_health_status = ceph_status['health']['status']
+    # SLM: 'overall_status' exists along with 'status' for luminous.
+    #      It will be HEALTH_WARN while 'status' will be HEALTH_OK.
+    #      The following should work for all with the newer overriding
+    #      the older if both exist.
+    ceph_health_status = 'HEALTH_ERR'
+    if 'overall_status' in ceph_status['health']:
+        ceph_health_status = ceph_status['health']['overall_status']
+    if 'status' in ceph_status['health']:
+        ceph_health_status = ceph_status['health']['status']
 
     metrics.append({
         'name': 'cluster_health',


### PR DESCRIPTION
When installing rpc-maas onto OSP13 using ceph, the ceph_health
check was failing.  It looks like this was due to a breaking
change in PR 702 assuming that either 'overall_status' or
'status' checks exist exclusively. Luminous has both with
'status' being set to 'HEALTH_OK' and 'overall_status' set
to 'HEALTH_WARN' to let users know not to use it.