### PR TITLE
JIRA RPCOS-33: Fixes for pep8 findings

### DIFF
--- a/playbooks/files/rax-maas/plugins/holland_local_check.py
+++ b/playbooks/files/rax-maas/plugins/holland_local_check.py
@@ -64,7 +64,7 @@ def holland_lb_check(hostname, binary, backupset):
     container_present = True
 
     try:
-        lxc_cgroup_stat = os.stat('/sys/fs/cgroup/pids/lxc/' + hostname)
+        os.stat('/sys/fs/cgroup/pids/lxc/' + hostname)
     except OSError:
         container_present = False
 

--- a/playbooks/files/rax-maas/plugins/nfs_check.py
+++ b/playbooks/files/rax-maas/plugins/nfs_check.py
@@ -18,7 +18,6 @@ import argparse
 import shlex
 import subprocess
 
-from maas_common import metric
 from maas_common import metric_bool
 from maas_common import print_output
 from maas_common import status_err

--- a/playbooks/library/ceph_osd_host_facts
+++ b/playbooks/library/ceph_osd_host_facts
@@ -64,7 +64,7 @@ class OSDHostFacts(object):
                      deploy_osp=False, osp_standalone=False):
         """Get information about OSDs."""
         ceph_command_string = "ceph"
-        if deploy_osp and osp_standalone == False:
+        if deploy_osp and not osp_standalone:
             ceph_command_string = (
                 "sudo docker exec {container_name} ceph "
                 "--cluster ceph").format(container_name=container_name)


### PR DESCRIPTION
The following findings are keeping the pep8 linter from passing:

* playbooks/files/rax-maas/plugins/nfs_check.py
    (:21:1: F401 'metric' imported but unused)
* playbooks/files/rax-maas/plugins/holland_local_check.py
    (:67:9: F841 local variable 'lxc_cgroup_stat' is assigned to but never used)
* playbooks/library/ceph_osd_host_facts
    (:67:42: E712 comparison to False should be 'if cond is False:' or
           'if not cond:')