### PR TITLE
Remove cinder quota check from octavia plugin

### DIFF
--- a/playbooks/vars/maas-openstack.yml
+++ b/playbooks/vars/maas-openstack.yml
@@ -152,8 +152,6 @@ octavia_quota_names:
   - octavia_instances_quota_usage
   - octavia_ram_quota_usage
   - octavia_server_group_quota_usage
-  - octavia_volume_gb_quota_usage
-  - octavia_num_volume_quota_usage
 
 octavia_observer_role_name: load-balancer_observer
 octavia_project: admin


### PR DESCRIPTION
Octavia does not consume cinder volumes and
the volume check can be removed.
Apart from the issue that the quota check is not scoped to the
actual service tenant, resulting into false alerts.