### PR TITLE
Allow keystone endpoint interface set with keystone_check_interface var.

### DIFF
--- a/playbooks/maas-openstack-octavia.yml
+++ b/playbooks/maas-openstack-octavia.yml
@@ -113,7 +113,7 @@
     - name: Ensure the observer role exists
       os_keystone_role:
         cloud: overcloud
-        interface: internal
+        interface: "{{ keystone_check_interface }}"
         name: "{{ octavia_observer_role_name }}"
         state: present
       delegate_to: localhost
@@ -122,7 +122,7 @@
     - name: Ensure Octavia observer member role assignment
       os_user_role:
         cloud: overcloud
-        interface: internal
+        interface: "{{ keystone_check_interface }}"
         role: "{{ octavia_observer_role_name }}"
         project: "{{ octavia_project }}"
         user: "{{ octavia_user }}"

--- a/playbooks/maas-openstack-swift.yml
+++ b/playbooks/maas-openstack-swift.yml
@@ -314,7 +314,7 @@
         - name: Create rax_maas_accesscheck project
           os_project:
             cloud: overcloud
-            interface: internal
+            interface: "{{ keystone_check_interface }}"
             state: present
             enabled: true
             domain_id: default
@@ -325,7 +325,7 @@
         - name: Create swift rax_maas_accesscheck user
           os_user:
             cloud: overcloud
-            interface: internal
+            interface: "{{ keystone_check_interface }}"
             state: present
             enabled: true
             domain: default
@@ -339,7 +339,7 @@
         - name: Create swift rax_maas_swiftoperator role
           os_keystone_role:
             cloud: overcloud
-            interface: internal
+            interface: "{{ keystone_check_interface }}"
             state: present
             name: "{{ maas_swift_operator_role }}"
             verify: false
@@ -347,7 +347,7 @@
         - name: Associate role to rax_maas_accesscheck user
           os_user_role:
             cloud: overcloud
-            interface: internal
+            interface: "{{ keystone_check_interface }}"
             state: present
             project: "{{ maas_swift_service_project_name }}"
             role: "{{ maas_swift_operator_role }}"

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -83,6 +83,11 @@ keystone_local_api_port: '5000'
 #
 keystone_local_api_protocol: 'http'
 
+#
+# interface to use when working with specific playbooks(swift, octavia)
+#
+keystone_check_interface: 'internal'
+
 # cinder_local_api_protocol: Protocol to use for cinder local API checks
 #
 cinder_local_api_protocol: 'http'


### PR DESCRIPTION
This applies to keystone calls in the swift and octavia playbooks.