### PR TITLE
Swift and undercloud private fixes.

### DIFF
--- a/playbooks/maas-openstack-swift.yml
+++ b/playbooks/maas-openstack-swift.yml
@@ -98,6 +98,23 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
+
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+
+    - name: Safety Check - Do not run on OSP
+      debug:
+        msg: "Swift playbooks are non-functional on OSP. Skipping..."
+      when:
+        - ansible_local['maas']['general']['deploy_osp'] | bool
+
+    - name: Exit
+      meta: end_play
+      when:
+        - ansible_local['maas']['general']['deploy_osp'] | bool
+
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -136,6 +153,23 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
+
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+
+    - name: Safety Check - Do not run on OSP
+      debug:
+        msg: "Swift playbooks are non-functional on OSP. Skipping..."
+      when:
+        - ansible_local['maas']['general']['deploy_osp'] | bool
+
+    - name: Exit
+      meta: end_play
+      when:
+        - ansible_local['maas']['general']['deploy_osp'] | bool
+
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -173,6 +207,23 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
+
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+
+    - name: Safety Check - Do not run on OSP
+      debug:
+        msg: "Swift playbooks are non-functional on OSP. Skipping..."
+      when:
+        - ansible_local['maas']['general']['deploy_osp'] | bool
+
+    - name: Exit
+      meta: end_play
+      when:
+        - ansible_local['maas']['general']['deploy_osp'] | bool
+
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -211,6 +262,23 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   pre_tasks:
+
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+
+    - name: Safety Check - Do not run on OSP
+      debug:
+        msg: "Swift playbooks are non-functional on OSP. Skipping..."
+      when:
+        - ansible_local['maas']['general']['deploy_osp'] | bool
+
+    - name: Exit
+      meta: end_play
+      when:
+        - ansible_local['maas']['general']['deploy_osp'] | bool
+
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:
@@ -304,8 +372,25 @@
   user: "{{ ansible_user | default('root') }}"
   become: true
   vars:
-    ansible_python_interpreter: "{{ target_venv | default(maas_venv) }}/bin/python"
+    ansible_python_interpreter: "{{ target_venv | default(maas_venv) }}/bin/python3"
   pre_tasks:
+
+    - name: Refresh local facts
+      setup:
+        filter: ansible_local
+        gather_subset: "!all"
+
+    - name: Safety Check - Do not run on OSP
+      debug:
+        msg: "Swift playbooks are non-functional on OSP. Skipping..."
+      when:
+        - ansible_local['maas']['general']['deploy_osp'] | bool
+
+    - name: Exit
+      meta: end_play
+      when:
+        - ansible_local['maas']['general']['deploy_osp'] | bool
+
     - include_tasks: "common-tasks/maas_excluded_regex.yml"
 
   tasks:

--- a/playbooks/templates/rax-maas/private_ping_check.yaml.j2
+++ b/playbooks/templates/rax-maas/private_ping_check.yaml.j2
@@ -7,7 +7,7 @@ period            : "{{ maas_check_period_override[label] | default(maas_check_p
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
 disabled          : "{{ (check_name | regex_search(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 {% if (ansible_local['maas']['general']['deploy_osp'] | bool) %}
-{% if inventory_hostname == 'director' %}
+{% if inventory_hostname == 'director' or ansible_host == 'localhost' %}
 target_hostname   : "{{ ansible_br_ctlplane.ipv4.address }}"
 {% else %}
 target_hostname   : "{{ ctlplane_ip }}"

--- a/playbooks/templates/rax-maas/private_ssh_check.yaml.j2
+++ b/playbooks/templates/rax-maas/private_ssh_check.yaml.j2
@@ -7,7 +7,7 @@ period            : "{{ maas_check_period_override[label] | default(maas_check_p
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
 disabled          : "{{ (check_name | regex_search(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 {% if (ansible_local['maas']['general']['deploy_osp'] | bool) %}
-{% if inventory_hostname == 'director' %}
+{% if inventory_hostname == 'director' or ansible_host == 'localhost' %}
 target_hostname   : "{{ ansible_br_ctlplane.ipv4.address }}"
 {% else %}
 target_hostname   : "{{ ctlplane_ip }}"


### PR DESCRIPTION
- Swift checks should not be deploying on OSP. The end_play call was
  only being done on one play in the playbook.

- The undercloud private checks were failing when the
  MAAS_DIRECTOR_NAME env var was set changing the inventory.