### PR TITLE
Python3 and Ussuri (ceph) fixes

### DIFF
--- a/playbooks/files/rax-maas/plugins/iptables_check.py
+++ b/playbooks/files/rax-maas/plugins/iptables_check.py
@@ -62,10 +62,11 @@ def main():
             try:
                 bridge_sysctl = True
                 for param in bridge_params:
-                    bridge_param_metrics[param] = str(
-                        subprocess.check_output(
-                            ['cat', '/proc/sys/net/bridge/' + param])
-                    ).rstrip('\n')
+                    bridge_param_metrics[param] = \
+                        subprocess.check_output(['cat',
+                                                '/proc/sys/net/bridge/' +
+                                                 param]
+                                                ).decode().rstrip('\n')
                     if bridge_param_metrics[param] != "1":
                         bridge_sysctl = False
             except Exception as e:
@@ -74,8 +75,8 @@ def main():
             # Check if iptables rules are in place
             iptables_rules = ''
             try:
-                iptables_rules = str(subprocess.check_output(
-                    ['iptables-save'])).split('\n')
+                iptables_rules = subprocess.check_output(
+                    ['iptables-save']).decode().split('\n')
             except Exception as e:
                 status('error', str(e), force_print=False)
 

--- a/playbooks/maas-agent-install.yml
+++ b/playbooks/maas-agent-install.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Gather facts
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   become: true
   tasks:
@@ -34,7 +34,7 @@
 
 
 - name: Install MaaS Agent
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   become: true
   pre_tasks:

--- a/playbooks/maas-agent-setup.yml
+++ b/playbooks/maas-agent-setup.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Gather facts
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   become: true
   tasks:
@@ -35,7 +35,7 @@
 
 
 - name: Setup MaaS Agent
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   become: true
   pre_tasks:

--- a/playbooks/maas-ceph-mon.yml
+++ b/playbooks/maas-ceph-mon.yml
@@ -48,14 +48,7 @@
       copy:
         content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"
         dest: "/etc/ceph/ceph.client.raxmon.keyring"
-      delegate_to: "{{ physical_host }}"
-      when: 'physical_host != ansible_host'
-
-    - name: Write Ceph monitoring client key to file
-      copy:
-        content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"
-        dest: "/etc/ceph/ceph.client.raxmon.keyring"
-      when: 'physical_host == ansible_host'
+      delegate_to: "{{ physical_host | default(ansible_hostname) }}"
 
     - name: Get the first mon container
       shell: podman ps --format '{{ '{{' }}.Names{{ '}}' }}' --filter name=ceph-mon
@@ -84,7 +77,7 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      delegate_to: "{{ physical_host | default(ansible_hostname) }}"
       with_items:
         - ceph_mon_stats
         - ceph_cluster_stats
@@ -94,25 +87,6 @@
         - ceph_health_checks_device_health
         - ceph_health_checks_data_health
         - ceph_health_checks_misc
-      when: 'physical_host != ansible_host'
-
-    - name: Install local mons checks
-      template:
-        src: "templates/rax-maas/{{ item }}.yaml.j2"
-        dest: "/etc/rackspace-monitoring-agent.conf.d/{{ item }}.yaml--{{ inventory_hostname }}.yaml"
-        owner: "root"
-        group: "root"
-        mode: "0644"
-      with_items:
-        - ceph_mon_stats
-        - ceph_cluster_stats
-        - ceph_health_checks_mon
-        - ceph_health_checks_mgr
-        - ceph_health_checks_osds
-        - ceph_health_checks_device_health
-        - ceph_health_checks_data_health
-        - ceph_health_checks_misc
-      when: 'physical_host == ansible_host'
 
   vars_files:
     - vars/main.yml

--- a/playbooks/maas-ceph-osd.yml
+++ b/playbooks/maas-ceph-osd.yml
@@ -46,14 +46,7 @@
       copy:
         content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"
         dest: "/etc/ceph/ceph.client.raxmon.keyring"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
-      when: 'physical_host != ansible_host'
-
-    - name: Write Ceph monitoring client key to file
-      copy:
-        content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"
-        dest: "/etc/ceph/ceph.client.raxmon.keyring"
-      when: 'physical_host == ansible_host'
+      delegate_to: "{{ physical_host | default(ansible_hostname) }}"
 
     - name: Write Ceph monitoring client key to file within legacy rpc hosts
       copy:
@@ -122,21 +115,9 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      delegate_to: "{{ physical_host | default(ansible_hostname) }}"
       with_items:
         - "{{ ceph_osd_list }}"
-      when: 'physical_host != ansible_host'
-
-    - name: Install local osd checks
-      template:
-        src: "templates/rax-maas/ceph_osd_stats.yaml.j2"
-        dest: "/etc/rackspace-monitoring-agent.conf.d/ceph_osd_{{ item }}_stats.yaml--{{ inventory_hostname }}.yaml"
-        owner: "root"
-        group: "root"
-        mode: "0644"
-      with_items:
-        - "{{ ceph_osd_list }}"
-      when: 'physical_host == ansible_host'
 
   vars_files:
     - vars/main.yml

--- a/playbooks/maas-ceph-rgw.yml
+++ b/playbooks/maas-ceph-rgw.yml
@@ -46,17 +46,8 @@
       copy:
         content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"
         dest: "/etc/ceph/ceph.client.raxmon.keyring"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      delegate_to: "{{ physical_host | default(ansible_hostname) }}"
       when:
-        - 'physical_host != ansible_host'
-        - ansible_local['maas']['general']['maas_product_ceph_version'] is defined
-
-    - name: Write Ceph monitoring client key to file
-      copy:
-        content: "{{ [hostvars[groups['mons'][0]]['ceph_raxmon_client']['stdout'], '\n'] | join('') }}"
-        dest: "/etc/ceph/ceph.client.raxmon.keyring"
-      when:
-        - 'physical_host == ansible_host'
         - ansible_local['maas']['general']['maas_product_ceph_version'] is defined
 
     - name: Write Ceph monitoring client key to file within legacy rpc hosts
@@ -75,24 +66,10 @@
         owner: "root"
         group: "root"
         mode: "0644"
-      delegate_to: "{{ physical_host | default(ansible_host) }}"
+      delegate_to: "{{ physical_host | default(ansible_hostname) }}"
       with_items:
         - ceph_rgw_stats
       when:
-        - 'physical_host != ansible_host'
-        - ansible_local['maas']['general']['maas_product_ceph_version'] is defined
-
-    - name: Install local rgws checks
-      template:
-        src: "templates/rax-maas/{{ item }}.yaml.j2"
-        dest: "/etc/rackspace-monitoring-agent.conf.d/{{ item }}.yaml--{{ inventory_hostname }}.yaml"
-        owner: "root"
-        group: "root"
-        mode: "0644"
-      with_items:
-        - ceph_rgw_stats
-      when:
-        - 'physical_host == ansible_host'
         - ansible_local['maas']['general']['maas_product_ceph_version'] is defined
 
   vars_files:

--- a/playbooks/maas-host-cdm.yml
+++ b/playbooks/maas-host-cdm.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Gather facts
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   become: true
   tasks:
@@ -34,7 +34,7 @@
 
 
 - name: Install checks for CDM
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   become: true
   pre_tasks:

--- a/playbooks/maas-host-kernel.yml
+++ b/playbooks/maas-host-kernel.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Gather facts
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   become: true
   tasks:
@@ -34,7 +34,7 @@
 
 
 - name: Install checks for hosts kernel
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   pre_tasks:
     - name: Check nf_conntrack status

--- a/playbooks/maas-host-network.yml
+++ b/playbooks/maas-host-network.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Gather facts
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   become: true
   tasks:
@@ -34,7 +34,7 @@
 
 
 - name: Install checks for host networking
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   become: true
   pre_tasks:

--- a/playbooks/maas-host-private-checks.yml
+++ b/playbooks/maas-host-private-checks.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Gather facts
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   become: true
   tasks:
@@ -34,7 +34,7 @@
 
 
 - name: Install private network monitoring checks
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   become: true
   tasks:

--- a/playbooks/maas-host-vendor.yml
+++ b/playbooks/maas-host-vendor.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Gather facts
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   become: true
   tasks:
@@ -34,7 +34,7 @@
 
 
 - name: Deploy vendor hardware monitoring
-  hosts: hosts
+  hosts: hosts:mons:mgrs:osds:rgws:grafana-server
   gather_facts: true
   become: true
   tasks:

--- a/playbooks/maas-pre-flight.yml
+++ b/playbooks/maas-pre-flight.yml
@@ -220,7 +220,15 @@
 
     - name: ceph release block
       block:
-        - name: Register ceph version
+        - name: Register ceph version (OSA)
+          command: ceph --version
+          register: maas_osa_ceph_version
+          delegate_to: "{{ groups['mons'][0] }}"
+          when:
+           - not (deploy_osp | default(False) | bool)
+           - ansible_local['maas']['general']['maas_product_osa_codename'] is defined
+
+        - name: Register ceph version (OSP)
           shell: |
               #!/bin/bash
               set -x
@@ -228,17 +236,25 @@
               export CONTAINER=$(podman ps --format '{{ '{{' }}.Names{{ '}}' }}' | grep ceph-mon-controller)
               echo "container:  $CONTAINER"
               podman exec $CONTAINER ceph --version
-          register: maas_product_ceph_version
+          register: maas_osp_ceph_version
           delegate_to: "{{ groups['ceph_mon'][0] }}"
+          when:
+            - deploy_osp | default(False) | bool
+
+        - name: Register maas_product_ceph_version
+          set_fact:
+            maas_product_ceph_version: "{{ maas_osa_ceph_version is defined |ternary(maas_osa_ceph_version.stdout,maas_osp_ceph_version.stdout) }}"
+          when:
+            - (maas_osa_ceph_version.changed |bool or maas_osp_ceph_version.changed |bool)
 
         - name: Set ceph release version fact
           ini_file:
             path: "/etc/ansible/facts.d/maas.fact"
             section: "general"
             option: "maas_product_ceph_version"
-            value: "{{ maas_product_ceph_version.stdout.split('(')[0].strip() | regex_search('[0-9]+.[0-9]+.[0-9]+') }}"
+            value: "{{ maas_product_ceph_version.split('(')[0].strip() | regex_search('[0-9]+.[0-9]+.[0-9]+') }}"
           when:
-            - maas_product_ceph_version.changed | bool
+            - maas_product_ceph_version is defined
 
         - name: Check for Podman command
           command: podman --version
@@ -272,8 +288,7 @@
             filter: ansible_local
             gather_subset: "!all"
       when:
-        - groups['ceph_all'] | default([]) | length > 0
-        - groups['ceph_mon'] | default([]) | length > 0
+        - (groups['ceph_mon'] | default([]) | length > 0 or groups['mons'] | default([]) | length > 0)
 
     - name: rhosp release block
       block:


### PR DESCRIPTION
- The iptables_check.py is now properly reporting the nf-table status
- The Ceph groups are now directly included in the tasks hosts as we
  currently do not create a maas/cached inventory, native inventories
  from OSA, ceph and OSP are utilized.