### PR TITLE
Adding package dependency for pyroute2

### DIFF
--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -352,6 +352,7 @@ maas_pip_packages:
    - rackspace-monitoring
    - monitorstack@git+https://opendev.org/x/monitorstack@master#egg=monitorstack
    - pyroute2
+   - mitogen
    - ipaddr
    - python-memcached
    - netaddr


### PR DESCRIPTION
Pyroute2 does now require mitogen in the latest version.
Without mitogen, import statements fail and the conntrack check
as well