### PR TITLE
fixes for status output changes in octopus

### DIFF
--- a/playbooks/files/rax-maas/plugins/ceph_monitoring.py
+++ b/playbooks/files/rax-maas/plugins/ceph_monitoring.py
@@ -191,10 +191,7 @@ def get_mon_statistics(client=None, keyring=None, host=None,
                                   keyring=keyring,
                                   container_name=container_name,
                                   deploy_osp=deploy_osp)
-      mon = [m for m in ceph_mon_status['quorum']
-             if m['name'] == host]
-
-    mon_in = mon[0]['rank'] in ceph_status['quorum']
+    mon_in = host in ceph_status['quorum_names']
     metric_bool('mon_in_quorum', mon_in)
 
 
@@ -288,14 +285,24 @@ def get_cluster_statistics(client=None, keyring=None, container_name=None,
     metrics.append({'name': "monmap_epoch",
                     'type': 'uint32',
                     'value': ceph_status['monmap']['epoch']})
-    metrics.append({'name': "osdmap_epoch",
-                    'type': 'uint32',
-                    'value': ceph_status['osdmap']['osdmap']['epoch']})
+    if 'osdmap' in ceph_status['osdmap']:
+        metrics.append({'name': "osdmap_epoch",
+                        'type': 'uint32',
+                        'value': ceph_status['osdmap']['osdmap']['epoch']})
+    else:
+        metrics.append({'name': "osdmap_epoch",
+                        'type': 'uint32',
+                        'value': ceph_status['osdmap']['epoch']})
 
     # Collect OSDs per state
-    osds = {'total': ceph_status['osdmap']['osdmap']['num_osds'],
-            'up': ceph_status['osdmap']['osdmap']['num_up_osds'],
-            'in': ceph_status['osdmap']['osdmap']['num_in_osds']}
+    if 'osdmap' in ceph_status['osdmap']:
+        osds = {'total': ceph_status['osdmap']['osdmap']['num_osds'],
+                'up': ceph_status['osdmap']['osdmap']['num_up_osds'],
+                'in': ceph_status['osdmap']['osdmap']['num_in_osds']}
+    else:
+        osds = {'total': ceph_status['osdmap']['num_osds'],
+                'up': ceph_status['osdmap']['num_up_osds'],
+                'in': ceph_status['osdmap']['num_in_osds']}
     for k in osds:
         metrics.append({'name': 'osds_%s' % k,
                         'type': 'uint32',


### PR DESCRIPTION
In ceph octopus the mon quorum details have been removed from the status output, the mon check simply looks for the local name in the list of mon quorum hosts rather than extract it's rank and check for that rank in the mon quorum list.  The rank is no longer available.

The osdmap data has been flattened in the json output as seen below.  It was [osdmap][osdmap][attributes], but has been flattened in octopus to [osdmap][attributes].

Ticket https://core.rackspace.com/py/ticket/view.pt?ref_no=211222-05538 contains an example alert without this patch applied.

ceph octopus output:
root@1170870-ceph1:/usr/lib/rackspace-monitoring-agent/plugins# ceph status -f json-pretty

{
    "fsid": "2bc8eebb-5bad-4988-9319-98ff964d6dde",
    "health": {
        "status": "HEALTH_OK",
        "checks": {},
        "mutes": []
    },
    "election_epoch": 142,
    "quorum": [
        0,
        1,
        2
    ],
    "quorum_names": [
        "1170870-ceph1",
        "1170871-ceph2",
        "1170872-ceph3"
    ],
    "quorum_age": 19237,
    "monmap": {
        "epoch": 2,
        "min_mon_release_name": "octopus",
        "num_mons": 3
    },
    "osdmap": {
        "epoch": 20991,
        "num_osds": 100,
        "num_up_osds": 100,
        "osd_up_since": 1640193950,
        "num_in_osds": 100,
        "osd_in_since": 1638158073,
        "num_remapped_pgs": 0
    },
...




### ceph nautilus and previous
root@ceph-ads-1:~# ceph status -f json-pretty

{
    "fsid": "144c448e-db76-44fd-a5ee-8249f346e231",
    "health": {
        "checks": {},
        "status": "HEALTH_OK",
        "overall_status": "HEALTH_WARN"
    },
    "election_epoch": 350,
    "quorum": [
        0,
        1,
        2
    ],
    "quorum_names": [
        "ceph-ads-1",
        "ceph-ads-2",
        "ceph-ads-3"
    ],
    "monmap": {
        "epoch": 3,
        "fsid": "144c448e-db76-44fd-a5ee-8249f346e231",
        "modified": "2020-10-19 22:46:12.892533",
        "created": "2017-04-20 13:51:22.831365",
        "features": {
            "persistent": [
                "kraken",
                "luminous",
                "mimic",
                "osdmap-prune"
            ],
            "optional": []
        },
        "mons": [
            {
                "rank": 0,
                "name": "ceph-ads-1",
                "addr": "10.64.96.14:6789/0",
                "public_addr": "10.64.96.14:6789/0"
            },
            {
                "rank": 1,
                "name": "ceph-ads-2",
                "addr": "10.64.96.15:6789/0",
                "public_addr": "10.64.96.15:6789/0"
            },
            {
                "rank": 2,
                "name": "ceph-ads-3",
                "addr": "10.64.96.16:6789/0",
                "public_addr": "10.64.96.16:6789/0"
            }
        ]
    },
    "osdmap": {
        "osdmap": {
            "epoch": 346980,
            "num_osds": 244,
            "num_up_osds": 244,
            "num_in_osds": 244,
            "num_remapped_pgs": 0
        }
    },
....
