### PR TITLE
Moves to distro from platform due to deprecation

### DIFF
--- a/playbooks/files/rax-maas/plugins/maas_common.py
+++ b/playbooks/files/rax-maas/plugins/maas_common.py
@@ -15,11 +15,11 @@
 from __future__ import print_function
 
 import contextlib
+import distro
 import errno
 import logging
 import os
 import pickle
-import platform
 import re
 import sys
 import traceback
@@ -43,7 +43,7 @@ AUTH_DETAILS = {'OS_USERNAME': None,
                 'OS_IMAGE_API_VERSION': 1,
                 'OS_CLOUDNAME': 'overcloud'}
 
-if 'Ubuntu' in platform.linux_distribution()[0]:
+if 'Ubuntu' in distro.name():
     AUTH_DETAILS.update({
         'OS_USER_DOMAIN_NAME': None,
         'OS_PROJECT_DOMAIN_NAME': None,

--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -359,6 +359,7 @@ maas_pip_packages:
    - pyudev
    - dnspython
    - lxml
+   - distro
 
 #
 # pip extra packages for lxc containers


### PR DESCRIPTION
platform.linux_distribution has been deprecated completely. similar functionality is available via distro, and distro.name() specifically, for our use case. Appears backward compatible with (at least) py35 on 16.04.