### PR TITLE
Check if python3 is installed in the ansible venv

### DIFF
--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -16,7 +16,7 @@ else
 fi
 
 # Create the virtual environment
-if [ ! -d /root/ansible_venv ]; then
+if [ ! -d /root/ansible_venv ] || [ ! -f /root/ansible_venv/bin/python3 ]; then
 
     # Set up the python virtual env
     virtualenv -p /usr/bin/python3 /root/ansible_venv --system-site-packages


### PR DESCRIPTION
The script is checking if the ansible_venv directory exists. We have cases where the venv was present but was created with python2. With this change, the ansible_venv will be recreated if python3 isn't installed.