### PR TITLE
Update holland check to support new Ubuntu 20 cgroup path

### DIFF
--- a/playbooks/files/rax-maas/plugins/holland_local_check.py
+++ b/playbooks/files/rax-maas/plugins/holland_local_check.py
@@ -66,7 +66,10 @@ def holland_lb_check(hostname, binary, backupset):
     try:
         os.stat('/sys/fs/cgroup/pids/lxc/' + hostname)
     except OSError:
-        container_present = False
+        try:
+            os.stat('/sys/fs/cgroup/pids/lxc.payload.' + hostname)
+        except OSError:
+            container_present = False
 
     if container_present:
         retcode, output, err = run_command('lxc-attach -n %s -- %s lb' %

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -16,7 +16,7 @@ else
 fi
 
 # Create the virtual environment
-if [ ! -d /root/ansible_venv ]; then
+if [ ! -d /root/ansible_venv ] || [ ! -f /root/ansible_venv/bin/python3 ]; then
 
     # Set up the python virtual env
     virtualenv -p /usr/bin/python3 /root/ansible_venv --system-site-packages


### PR DESCRIPTION
The holland monitoring script checks to see if a container exists by checking if the cgroup path is present:

     /sys/fs/cgroup/pids/lxc/<container_name>

In Ubuntu 20.04, the cgroup path has changed to:

    /sys/fs/cgroup/pids/lxc.payload.<container_name>

I added a nested try/except so both paths are checked.