### PR TITLE
Added openmanage 10.1.0.1 to supported versions

### DIFF
--- a/playbooks/files/rax-maas/plugins/openmanage.py
+++ b/playbooks/files/rax-maas/plugins/openmanage.py
@@ -24,7 +24,7 @@ from maas_common import status_err
 from maas_common import status_ok
 
 SUPPORTED_VERSIONS = set(["7.1.0", "7.4.0", "8.3.0", "8.4.0", "9.1.0",
-                          "9.2.0", "9.3.0", "9.4.0", "9.5.0"])
+                          "9.2.0", "9.3.0", "9.4.0", "9.5.0", "10.1.0.1"])
 OM_PATTERN = r'(?:%(field)s)\s+:\s+(%(group_pattern)s)'
 CHASSIS = re.compile(OM_PATTERN %
                      {'field': '^Health', 'group_pattern': r'\w+'},


### PR DESCRIPTION
The issue popped up on the Pipedrive Ubuntu 18 to 20 upgrade in FRA. The change has been tested there and related MaaS checks are working with this new version.