### PR TITLE
Fix invalid octavia_api groupname

### DIFF
--- a/playbooks/templates/rax-maas/lb_api_check_octavia.yaml.j2
+++ b/playbooks/templates/rax-maas/lb_api_check_octavia.yaml.j2
@@ -4,11 +4,12 @@
 {% set octavia_api_url = ansible_local.maas.api.octavia_public_url | default(ansible_local.maas.api.octavia_internal_url) %}
 {% set octavia_api_ip = ansible_local.maas.api.octavia_public_ip | default(ansible_local.maas.api.octavia_internal_ip) %}
 {% set octavia_fallback_url = (maas_octavia_scheme | default(maas_scheme)) + '://' + maas_external_hostname + ':9876/' %}
+{% set octavia_group = groups['octavia-api'][0] |default("") |join(groups['octavia_api'][0] |default("")) %}
 type              : remote.http
 label             : "{{ check_name }}"
 period            : "{{ maas_check_period_override[label] | default(maas_check_period) }}"
 timeout           : "{{ maas_check_timeout_override[label] | default(maas_check_timeout) }}"
-disabled          : "{{ (inventory_hostname != groups['octavia_api'][0] or check_name | regex_search(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
+disabled          : "{{ (inventory_hostname != octavia_group or check_name | regex_search(maas_excluded_checks_regex)) | ternary('true', 'false') }}"
 target_resolver   : "IPv4"
 target_hostname   : "{{ octavia_api_ip | default(maas_external_ip_address) }}"
 details           :


### PR DESCRIPTION
This issue was already fixed in the file octavia_group playbooks/templates/rax-maas/private_lb_api_check_octavia.yaml.j2 by checking and setting the correct group name in a variable:

`{% set octavia_group = groups['octavia-api'][0] |default("") |join(groups['octavia_api'][0] |default("")) %}`

I've updated this template to do the same.