### PR TITLE
Vastly speed up bond detection

### DIFF
--- a/playbooks/vars/maas.yml
+++ b/playbooks/vars/maas.yml
@@ -441,10 +441,10 @@ maas_disk_utilisation_critical_threshold: 99
 
 _maas_bonding_interfaces: |
   ---
-  {% for interface in ansible_interfaces %}
-  {% set interface_detail = (hostvars[inventory_hostname]['ansible_%s' | format(interface)] | default({})) %}
-  {%   if (interface_detail and interface_detail['type'] == 'bonding' ) %}
-  - "{{ interface }}"
+  {% for bond in ['bond0', 'bond1'] %}
+  {%   set bond_name = ('ansible_%s' | format(bond)) %}
+  {%   if bond_name in hostvars[inventory_hostname] %}
+  - "{{ bond }}"
   {%   endif %}
   {% endfor %}
 maas_bonding_interfaces: "{{ _maas_bonding_interfaces | from_yaml }}"


### PR DESCRIPTION
Previously, each interface in ansible_interfaces was being iterated to find interfaces of type 'bonding'. On controllers hosting a large number of neutron networks, the number of interfaces can be in the thousands.

This made the bond interface task take an very long time, especially coupled with a large number of hostvars, since hostvars were being loaded thousands of times.

This patch instead simply looks for the `ansible_bond0` and `ansible_bond1` facts and adds the bond if the fact exists. This means hostvars are loaded only twice per host instead number of interfaces times.