### PR TITLE
Fix syntax error: invalid operator '=+' in bonding_iface_check.py

### DIFF
--- a/playbooks/files/rax-maas/plugins/bonding_iface_check.py
+++ b/playbooks/files/rax-maas/plugins/bonding_iface_check.py
@@ -55,7 +55,7 @@ def bonding_ifaces_check(_):
                     has_slave_down = True
 
             if line.startswith("Link Failure Count"):
-                failure_count =+ int(line.split(':')[1])
+                failure_count += int(line.split(':')[1])
 
         if has_slave_down:
             metric_bool('host_bonding_iface_%s_slave_down' %


### PR DESCRIPTION
## Bug Description

The file `playbooks/files/rax-maas/plugins/bonding_iface_check.py` contains a syntax error on line 54:

```python
failure_count =+ int(line.split(':')[1])
```

The operator `=+` is not valid Python syntax for incrementing a variable. This will cause the code to fail at runtime.

## Fix

Changed `=+` to `+=` to properly increment the `failure_count` variable:

```python
failure_count += int(line.split(':')[1])
```

## Impact

This is a moderate severity bug that would cause the bonding interface check plugin to crash when processing the "Link Failure Count" line from `/proc/net/bonding/<interface>` output.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.